### PR TITLE
Closes #2: Implement pet CRUD API endpoints

### DIFF
--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -1,14 +1,17 @@
 """API routes for pet management."""
 
 import logging
+from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from sqlalchemy import text
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.core.database import get_session
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +23,9 @@ DbSession = Annotated[AsyncSession, Depends(get_session)]
 class PetCreate(BaseModel):
     """Request model for creating a pet."""
 
-    repo_owner: str
-    repo_name: str
-    name: str
+    repo_owner: str = Field(..., min_length=1, max_length=255)
+    repo_name: str = Field(..., min_length=1, max_length=255)
+    name: str = Field(..., min_length=1, max_length=100)
 
 
 class PetResponse(BaseModel):
@@ -36,6 +39,16 @@ class PetResponse(BaseModel):
     mood: str
     health: int
     experience: int
+
+
+class PetListResponse(BaseModel):
+    """Response model for paginated pet list."""
+
+    items: list[PetResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int
 
 
 class HealthResponse(BaseModel):
@@ -52,6 +65,20 @@ class ComfyUIHealthResponse(BaseModel):
     available: bool
     queue_remaining: int | None = None
     cuda_available: bool | None = None
+
+
+def _pet_to_response(pet: Pet) -> PetResponse:
+    """Convert a Pet model to PetResponse."""
+    return PetResponse(
+        id=pet.id,
+        repo_owner=pet.repo_owner,
+        repo_name=pet.repo_name,
+        name=pet.name,
+        stage=pet.stage,
+        mood=pet.mood,
+        health=pet.health,
+        experience=pet.experience,
+    )
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -83,22 +110,108 @@ async def comfyui_health_check() -> ComfyUIHealthResponse:
     )
 
 
-@router.post("/pets", response_model=PetResponse)
+@router.post("/pets", response_model=PetResponse, status_code=201)
 async def create_pet(pet_data: PetCreate, session: DbSession) -> PetResponse:
     """Create a new pet for a GitHub repository."""
-    # TODO: Implement database integration
-    raise HTTPException(status_code=501, detail="Not implemented yet")
+    pet = Pet(
+        repo_owner=pet_data.repo_owner,
+        repo_name=pet_data.repo_name,
+        name=pet_data.name,
+        stage=PetStage.EGG.value,
+        mood=PetMood.CONTENT.value,
+        health=100,
+        experience=0,
+    )
+    session.add(pet)
+    try:
+        await session.commit()
+        await session.refresh(pet)
+    except IntegrityError:
+        await session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"Pet for repository {pet_data.repo_owner}/{pet_data.repo_name} already exists",
+        ) from None
+    return _pet_to_response(pet)
+
+
+@router.get("/pets", response_model=PetListResponse)
+async def list_pets(
+    session: DbSession,
+    page: int = Query(default=1, ge=1, description="Page number"),
+    page_size: int = Query(default=10, ge=1, le=100, description="Items per page"),
+) -> PetListResponse:
+    """List all pets with pagination."""
+    # Count total pets
+    count_stmt = select(func.count(Pet.id))
+    total_result = await session.execute(count_stmt)
+    total = total_result.scalar_one()
+
+    # Calculate pagination
+    offset = (page - 1) * page_size
+    pages = (total + page_size - 1) // page_size if total > 0 else 1
+
+    # Get paginated pets
+    stmt = select(Pet).offset(offset).limit(page_size).order_by(Pet.id)
+    result = await session.execute(stmt)
+    pets = result.scalars().all()
+
+    return PetListResponse(
+        items=[_pet_to_response(pet) for pet in pets],
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=pages,
+    )
 
 
 @router.get("/pets/{repo_owner}/{repo_name}", response_model=PetResponse)
 async def get_pet(repo_owner: str, repo_name: str, session: DbSession) -> PetResponse:
     """Get pet status for a repository."""
-    # TODO: Implement database integration
-    raise HTTPException(status_code=501, detail="Not implemented yet")
+    stmt = select(Pet).where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
+    result = await session.execute(stmt)
+    pet = result.scalar_one_or_none()
+    if pet is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Pet for repository {repo_owner}/{repo_name} not found",
+        )
+    return _pet_to_response(pet)
 
 
-@router.post("/pets/{repo_owner}/{repo_name}/feed")
+@router.post("/pets/{repo_owner}/{repo_name}/feed", response_model=PetResponse)
 async def feed_pet(repo_owner: str, repo_name: str, session: DbSession) -> PetResponse:
     """Manually feed the pet (triggered by activity)."""
-    # TODO: Implement feeding logic
-    raise HTTPException(status_code=501, detail="Not implemented yet")
+    stmt = select(Pet).where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
+    result = await session.execute(stmt)
+    pet = result.scalar_one_or_none()
+    if pet is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Pet for repository {repo_owner}/{repo_name} not found",
+        )
+
+    # Feeding increases health and sets mood to happy
+    pet.health = min(100, pet.health + 10)
+    pet.mood = PetMood.HAPPY.value
+    pet.last_fed_at = datetime.now(UTC)
+
+    await session.commit()
+    await session.refresh(pet)
+    return _pet_to_response(pet)
+
+
+@router.delete("/pets/{repo_owner}/{repo_name}", status_code=204)
+async def delete_pet(repo_owner: str, repo_name: str, session: DbSession) -> None:
+    """Remove a pet from the system."""
+    stmt = select(Pet).where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
+    result = await session.execute(stmt)
+    pet = result.scalar_one_or_none()
+    if pet is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Pet for repository {repo_owner}/{repo_name} not found",
+        )
+
+    await session.delete(pet)
+    await session.commit()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,8 +38,11 @@ async def test_health_check_response_schema(async_client: AsyncClient) -> None:
     assert "database" in data
 
 
-async def test_create_pet_not_implemented(async_client: AsyncClient) -> None:
-    """Test create pet endpoint returns 501 (not yet implemented)."""
+# === Create Pet Tests ===
+
+
+async def test_create_pet_success(async_client: AsyncClient) -> None:
+    """Test creating a new pet returns 201 with pet data."""
     response = await async_client.post(
         "/api/v1/pets",
         json={
@@ -48,22 +51,42 @@ async def test_create_pet_not_implemented(async_client: AsyncClient) -> None:
             "name": "TestPet",
         },
     )
-    assert response.status_code == 501
-    assert response.json()["detail"] == "Not implemented yet"
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["repo_owner"] == "test-owner"
+    assert data["repo_name"] == "test-repo"
+    assert data["name"] == "TestPet"
+    assert data["stage"] == "egg"
+    assert data["mood"] == "content"
+    assert data["health"] == 100
+    assert data["experience"] == 0
+    assert "id" in data
 
 
-async def test_get_pet_not_implemented(async_client: AsyncClient) -> None:
-    """Test get pet endpoint returns 501 (not yet implemented)."""
-    response = await async_client.get("/api/v1/pets/test-owner/test-repo")
-    assert response.status_code == 501
-    assert response.json()["detail"] == "Not implemented yet"
+async def test_create_pet_duplicate_returns_409(async_client: AsyncClient) -> None:
+    """Test creating a duplicate pet returns 409 conflict."""
+    # Create first pet
+    await async_client.post(
+        "/api/v1/pets",
+        json={
+            "repo_owner": "dup-owner",
+            "repo_name": "dup-repo",
+            "name": "FirstPet",
+        },
+    )
 
-
-async def test_feed_pet_not_implemented(async_client: AsyncClient) -> None:
-    """Test feed pet endpoint returns 501 (not yet implemented)."""
-    response = await async_client.post("/api/v1/pets/test-owner/test-repo/feed")
-    assert response.status_code == 501
-    assert response.json()["detail"] == "Not implemented yet"
+    # Try to create duplicate
+    response = await async_client.post(
+        "/api/v1/pets",
+        json={
+            "repo_owner": "dup-owner",
+            "repo_name": "dup-repo",
+            "name": "SecondPet",
+        },
+    )
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"]
 
 
 async def test_create_pet_validates_request_body(async_client: AsyncClient) -> None:
@@ -73,3 +96,172 @@ async def test_create_pet_validates_request_body(async_client: AsyncClient) -> N
         json={"repo_owner": "test-owner"},  # Missing required fields
     )
     assert response.status_code == 422  # Validation error
+
+
+async def test_create_pet_validates_empty_name(async_client: AsyncClient) -> None:
+    """Test create pet rejects empty name."""
+    response = await async_client.post(
+        "/api/v1/pets",
+        json={
+            "repo_owner": "test-owner",
+            "repo_name": "test-repo",
+            "name": "",
+        },
+    )
+    assert response.status_code == 422
+
+
+# === Get Pet Tests ===
+
+
+async def test_get_pet_success(async_client: AsyncClient) -> None:
+    """Test getting an existing pet returns 200 with pet data."""
+    # Create a pet first
+    await async_client.post(
+        "/api/v1/pets",
+        json={
+            "repo_owner": "get-owner",
+            "repo_name": "get-repo",
+            "name": "GetPet",
+        },
+    )
+
+    # Get the pet
+    response = await async_client.get("/api/v1/pets/get-owner/get-repo")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["repo_owner"] == "get-owner"
+    assert data["repo_name"] == "get-repo"
+    assert data["name"] == "GetPet"
+
+
+async def test_get_pet_not_found(async_client: AsyncClient) -> None:
+    """Test getting a non-existent pet returns 404."""
+    response = await async_client.get("/api/v1/pets/nonexistent-owner/nonexistent-repo")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]
+
+
+# === List Pets Tests ===
+
+
+async def test_list_pets_empty(async_client: AsyncClient) -> None:
+    """Test listing pets when none exist returns empty list."""
+    response = await async_client.get("/api/v1/pets")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+    assert data["page"] == 1
+    assert data["pages"] == 1
+
+
+async def test_list_pets_with_pagination(async_client: AsyncClient) -> None:
+    """Test listing pets with pagination."""
+    # Create 3 pets
+    for i in range(3):
+        await async_client.post(
+            "/api/v1/pets",
+            json={
+                "repo_owner": f"owner-{i}",
+                "repo_name": f"repo-{i}",
+                "name": f"Pet{i}",
+            },
+        )
+
+    # Get first page with page_size=2
+    response = await async_client.get("/api/v1/pets?page=1&page_size=2")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["items"]) == 2
+    assert data["total"] == 3
+    assert data["page"] == 1
+    assert data["page_size"] == 2
+    assert data["pages"] == 2
+
+    # Get second page
+    response = await async_client.get("/api/v1/pets?page=2&page_size=2")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["items"]) == 1
+    assert data["page"] == 2
+
+
+async def test_list_pets_invalid_page(async_client: AsyncClient) -> None:
+    """Test listing pets with invalid page parameter returns 422."""
+    response = await async_client.get("/api/v1/pets?page=0")
+    assert response.status_code == 422
+
+
+async def test_list_pets_invalid_page_size(async_client: AsyncClient) -> None:
+    """Test listing pets with invalid page_size parameter returns 422."""
+    response = await async_client.get("/api/v1/pets?page_size=101")
+    assert response.status_code == 422
+
+
+# === Feed Pet Tests ===
+
+
+async def test_feed_pet_success(async_client: AsyncClient) -> None:
+    """Test feeding a pet increases health and sets mood to happy."""
+    # Create a pet first
+    create_response = await async_client.post(
+        "/api/v1/pets",
+        json={
+            "repo_owner": "feed-owner",
+            "repo_name": "feed-repo",
+            "name": "FeedPet",
+        },
+    )
+    initial_health = create_response.json()["health"]
+
+    # Feed the pet
+    response = await async_client.post("/api/v1/pets/feed-owner/feed-repo/feed")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["mood"] == "happy"
+    # Health should be at max since we started at 100
+    assert data["health"] == min(100, initial_health + 10)
+
+
+async def test_feed_pet_not_found(async_client: AsyncClient) -> None:
+    """Test feeding a non-existent pet returns 404."""
+    response = await async_client.post("/api/v1/pets/nonexistent-owner/nonexistent-repo/feed")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]
+
+
+# === Delete Pet Tests ===
+
+
+async def test_delete_pet_success(async_client: AsyncClient) -> None:
+    """Test deleting a pet returns 204 and removes the pet."""
+    # Create a pet first
+    await async_client.post(
+        "/api/v1/pets",
+        json={
+            "repo_owner": "del-owner",
+            "repo_name": "del-repo",
+            "name": "DelPet",
+        },
+    )
+
+    # Delete the pet
+    response = await async_client.delete("/api/v1/pets/del-owner/del-repo")
+    assert response.status_code == 204
+
+    # Verify pet is gone
+    get_response = await async_client.get("/api/v1/pets/del-owner/del-repo")
+    assert get_response.status_code == 404
+
+
+async def test_delete_pet_not_found(async_client: AsyncClient) -> None:
+    """Test deleting a non-existent pet returns 404."""
+    response = await async_client.delete("/api/v1/pets/nonexistent-owner/nonexistent-repo")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -29,27 +29,6 @@ class TestHealthEndpoint:
 class TestPetsEndpoints:
     """Tests for pet management endpoints."""
 
-    def test_create_pet_not_implemented(self, client: TestClient) -> None:
-        """Create pet endpoint should return 501 until implemented."""
-        response = client.post(
-            "/api/v1/pets",
-            json={"repo_owner": "owner", "repo_name": "repo", "name": "TestPet"},
-        )
-        assert response.status_code == 501
-        assert response.json()["detail"] == "Not implemented yet"
-
-    def test_get_pet_not_implemented(self, client: TestClient) -> None:
-        """Get pet endpoint should return 501 until implemented."""
-        response = client.get("/api/v1/pets/owner/repo")
-        assert response.status_code == 501
-        assert response.json()["detail"] == "Not implemented yet"
-
-    def test_feed_pet_not_implemented(self, client: TestClient) -> None:
-        """Feed pet endpoint should return 501 until implemented."""
-        response = client.post("/api/v1/pets/owner/repo/feed")
-        assert response.status_code == 501
-        assert response.json()["detail"] == "Not implemented yet"
-
     def test_create_pet_validates_input(self, client: TestClient) -> None:
         """Create pet endpoint should validate required fields."""
         response = client.post("/api/v1/pets", json={})
@@ -62,3 +41,29 @@ class TestPetsEndpoints:
             json={"repo_owner": "owner", "repo_name": "repo"},
         )
         assert response.status_code == 422
+
+    def test_get_pet_not_found_returns_404(self, client: TestClient) -> None:
+        """Get pet endpoint should return 404 for non-existent pet."""
+        response = client.get("/api/v1/pets/nonexistent/repo")
+        assert response.status_code == 404
+
+    def test_feed_pet_not_found_returns_404(self, client: TestClient) -> None:
+        """Feed pet endpoint should return 404 for non-existent pet."""
+        response = client.post("/api/v1/pets/nonexistent/repo/feed")
+        assert response.status_code == 404
+
+    def test_delete_pet_not_found_returns_404(self, client: TestClient) -> None:
+        """Delete pet endpoint should return 404 for non-existent pet."""
+        response = client.delete("/api/v1/pets/nonexistent/repo")
+        assert response.status_code == 404
+
+    def test_list_pets_returns_200(self, client: TestClient) -> None:
+        """List pets endpoint should return 200 OK."""
+        response = client.get("/api/v1/pets")
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "pages" in data


### PR DESCRIPTION
## Summary
- Implements all REST API endpoints for creating, reading, updating, and managing pets
- Adds comprehensive test coverage with 163 passing tests (83.19% coverage)

## Changes
- **POST `/api/v1/pets`** - Create new pet for a repo (returns 201, or 409 on duplicate)
- **GET `/api/v1/pets`** - List all pets with pagination (page/page_size params)
- **GET `/api/v1/pets/{owner}/{repo}`** - Get pet status (returns 404 if not found)
- **POST `/api/v1/pets/{owner}/{repo}/feed`** - Manual feed action (increases health, sets mood to happy)
- **DELETE `/api/v1/pets/{owner}/{repo}`** - Remove pet (returns 204)

## Technical Details
- Pydantic models with Field constraints for input validation
- Proper error handling (404 for missing pets, 409 for duplicates)
- Pagination with total count and page info in list response
- All endpoints documented in OpenAPI/Swagger at `/docs`

## Testing
- [x] All 163 tests pass locally
- [x] Ruff linting passes
- [x] mypy type checking passes (strict mode)
- [x] Coverage: 83.19% (above 70% threshold)

Closes #2