### PR TITLE
Show logged-in state on landing page after OAuth

### DIFF
--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -7,10 +7,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Annotated
 
 import structlog
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -19,12 +20,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi import __version__
 from github_tamagotchi.api.alerts import alert_router
-from github_tamagotchi.api.auth import auth_router
+from github_tamagotchi.api.auth import auth_router, get_optional_user
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.config import settings
 from github_tamagotchi.core.database import async_session_factory, close_database
 from github_tamagotchi.mcp.server import get_mcp_server
 from github_tamagotchi.models.pet import Pet, PetStage
+from github_tamagotchi.models.user import User
 from github_tamagotchi.services import image_queue
 from github_tamagotchi.services.alerting import AlertChecker
 from github_tamagotchi.services.github import GitHubService, RateLimitError
@@ -276,7 +278,10 @@ app.mount("/mcp", mcp_app)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 
 
+OptionalUser = Annotated[User | None, Depends(get_optional_user)]
+
+
 @app.get("/", response_class=HTMLResponse)
-async def root(request: Request) -> HTMLResponse:
+async def root(request: Request, user: OptionalUser) -> HTMLResponse:
     """Landing page."""
-    return templates.TemplateResponse(request, "landing.html")
+    return templates.TemplateResponse(request, "landing.html", {"user": user})

--- a/src/github_tamagotchi/static/css/style.css
+++ b/src/github_tamagotchi/static/css/style.css
@@ -34,6 +34,67 @@ body {
     padding: 0 1.5rem;
 }
 
+/* User Navigation */
+.user-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    background: var(--surface);
+    border-bottom: 1px solid var(--surface-light);
+    padding: 0.75rem 0;
+}
+
+.user-nav .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.user-nav .logo {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.user-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+.user-name {
+    color: var(--text);
+    font-weight: 500;
+}
+
+.logout-button {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--surface-light);
+    padding: 0.4rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: all 0.2s ease;
+}
+
+.logout-button:hover {
+    color: var(--text);
+    border-color: var(--text-muted);
+}
+
+.user-nav + .hero {
+    padding-top: 5rem;
+}
+
 /* Hero Section */
 .hero {
     min-height: 100vh;

--- a/src/github_tamagotchi/templates/landing.html
+++ b/src/github_tamagotchi/templates/landing.html
@@ -7,13 +7,33 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
+    {% if user %}
+    <!-- Logged-in Header -->
+    <nav class="user-nav">
+        <div class="container">
+            <span class="logo">GitHub Tamagotchi</span>
+            <div class="user-info">
+                {% if user.github_avatar_url %}
+                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar">
+                {% endif %}
+                <span class="user-name">{{ user.github_login }}</span>
+                <button class="logout-button" id="logout-btn">Log out</button>
+            </div>
+        </div>
+    </nav>
+    {% endif %}
+
     <!-- Hero Section -->
     <section class="hero">
         <div class="container">
             <div class="hero-content">
                 <h1>Your Repository Has a <span class="highlight">Pet</span></h1>
                 <p class="tagline">A virtual pet that reflects your GitHub repository's health. Keep coding, keep it happy.</p>
+                {% if user %}
+                <a href="/docs" class="cta-button">View Your Pets</a>
+                {% else %}
                 <a href="/auth/github" class="cta-button">Login with GitHub</a>
+                {% endif %}
             </div>
             <div class="hero-pet">
                 <div class="pet-container">
@@ -90,9 +110,15 @@
     <!-- CTA Section -->
     <section class="cta-section">
         <div class="container">
+            {% if user %}
+            <h2>Welcome Back, {{ user.github_login }}!</h2>
+            <p>Your pets are waiting for you.</p>
+            <a href="/docs" class="cta-button large">View Your Pets</a>
+            {% else %}
             <h2>Ready to Adopt Your Pet?</h2>
             <p>Connect your GitHub account and bring your repository to life.</p>
             <a href="/auth/github" class="cta-button large">Login with GitHub</a>
+            {% endif %}
         </div>
     </section>
 
@@ -144,6 +170,15 @@
         }
 
         blink();
+
+        // Logout handler
+        const logoutBtn = document.getElementById('logout-btn');
+        if (logoutBtn) {
+            logoutBtn.addEventListener('click', async () => {
+                await fetch('/auth/logout', { method: 'POST' });
+                window.location.reload();
+            });
+        }
     </script>
 </body>
 </html>

--- a/tests/api/test_landing.py
+++ b/tests/api/test_landing.py
@@ -1,10 +1,16 @@
 """Tests for landing page."""
 
+import asyncio
+
 from fastapi.testclient import TestClient
+
+from github_tamagotchi.api.auth import _create_jwt
+from github_tamagotchi.models.user import User
+from tests.conftest import test_session_factory
 
 
 class TestLandingPage:
-    """Tests for the landing page."""
+    """Tests for the landing page (unauthenticated)."""
 
     def test_returns_html(self, client: TestClient) -> None:
         """Landing page should return HTML content."""
@@ -18,7 +24,7 @@ class TestLandingPage:
         assert "GitHub Tamagotchi" in response.text
 
     def test_contains_login_cta(self, client: TestClient) -> None:
-        """Landing page should contain login with GitHub CTA."""
+        """Landing page should contain login with GitHub CTA when not logged in."""
         response = client.get("/")
         assert "Login with GitHub" in response.text
 
@@ -46,6 +52,67 @@ class TestLandingPage:
         """Landing page should mention MCP integration."""
         response = client.get("/")
         assert "MCP" in response.text
+
+    def test_no_logout_button_when_unauthenticated(self, client: TestClient) -> None:
+        """Landing page should not show logout button when not logged in."""
+        response = client.get("/")
+        assert "Log out" not in response.text
+
+    def test_no_user_nav_when_unauthenticated(self, client: TestClient) -> None:
+        """Landing page should not show user nav when not logged in."""
+        response = client.get("/")
+        assert "user-nav" not in response.text
+
+
+class TestLandingPageAuthenticated:
+    """Tests for the landing page when logged in."""
+
+    def _create_user_and_token(self) -> str:
+        """Create a test user in the DB and return a valid JWT."""
+
+        async def _setup() -> str:
+            async with test_session_factory() as session:
+                user = User(
+                    id=1,
+                    github_id=12345,
+                    github_login="testuser",
+                    github_avatar_url="https://avatars.example.com/testuser",
+                )
+                session.add(user)
+                await session.commit()
+            return _create_jwt(user_id=1)
+
+        return asyncio.run(_setup())
+
+    def test_shows_username_when_authenticated(self, client: TestClient) -> None:
+        """Landing page should show username when logged in."""
+        token = self._create_user_and_token()
+        response = client.get("/", cookies={"session_token": token})
+        assert "testuser" in response.text
+
+    def test_shows_avatar_when_authenticated(self, client: TestClient) -> None:
+        """Landing page should show avatar when logged in."""
+        token = self._create_user_and_token()
+        response = client.get("/", cookies={"session_token": token})
+        assert "https://avatars.example.com/testuser" in response.text
+
+    def test_shows_logout_button_when_authenticated(self, client: TestClient) -> None:
+        """Landing page should show logout button when logged in."""
+        token = self._create_user_and_token()
+        response = client.get("/", cookies={"session_token": token})
+        assert "Log out" in response.text
+
+    def test_hides_login_cta_when_authenticated(self, client: TestClient) -> None:
+        """Landing page should hide login buttons when logged in."""
+        token = self._create_user_and_token()
+        response = client.get("/", cookies={"session_token": token})
+        assert "Login with GitHub" not in response.text
+
+    def test_shows_user_nav_when_authenticated(self, client: TestClient) -> None:
+        """Landing page should show user nav when logged in."""
+        token = self._create_user_and_token()
+        response = client.get("/", cookies={"session_token": token})
+        assert "user-nav" in response.text
 
 
 class TestStaticFiles:


### PR DESCRIPTION
## Summary
- Landing page now detects authenticated users via `session_token` cookie and shows their GitHub avatar, username, and a logout button in a fixed top nav bar
- Login CTAs ("Login with GitHub") are hidden when already authenticated; replaced with "View Your Pets" links
- CTA section at the bottom personalizes with a welcome message for logged-in users
- Logout button calls `POST /auth/logout` and reloads the page

## Changes
- **`main.py`**: Root endpoint now accepts `get_optional_user` dependency, passes `user` to template context
- **`landing.html`**: Conditional Jinja2 blocks for authenticated vs unauthenticated state, logout JS handler
- **`style.css`**: Fixed top nav bar with avatar, username, and logout button styling
- **`test_landing.py`**: 5 new tests for authenticated state (username, avatar, logout button, hidden login CTA, user nav visibility) + 2 new unauthenticated assertion tests

## Testing
- [x] All 377 tests pass (84% coverage)
- [x] Linter passes (`ruff check .`)
- [x] Unauthenticated: shows login CTAs, no nav bar
- [x] Authenticated: shows avatar + username + logout, no login CTAs

Closes #79