### PR TITLE
feat: add Open Graph and Twitter Card meta tags to pet profiles

### DIFF
--- a/src/github_tamagotchi/core/config.py
+++ b/src/github_tamagotchi/core/config.py
@@ -57,6 +57,9 @@ class Settings(BaseSettings):
     minio_bucket: str = "tamagotchi"
     minio_secure: bool = False
 
+    # Public base URL (used for absolute URLs in meta tags, embeds, etc.)
+    base_url: str = "https://tamagotchi.nijmegen.wiebe.xyz"
+
     # Server
     host: str = "0.0.0.0"
     port: int = 8000

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -353,7 +353,9 @@ OptionalUser = Annotated[User | None, Depends(get_optional_user)]
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request, user: OptionalUser) -> HTMLResponse:
     """Landing page."""
-    return templates.TemplateResponse(request, "landing.html", {"user": user})
+    return templates.TemplateResponse(
+        request, "landing.html", {"user": user, "base_url": settings.base_url}
+    )
 
 
 DbSession = Annotated[AsyncSession, Depends(get_session)]
@@ -465,6 +467,7 @@ async def pet_profile(
             "page_url": page_url,
             "repo_owner": repo_owner,
             "repo_name": repo_name,
+            "base_url": settings.base_url,
         },
         headers={"Cache-Control": "public, max-age=60"},
     )

--- a/src/github_tamagotchi/templates/landing.html
+++ b/src/github_tamagotchi/templates/landing.html
@@ -3,7 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GitHub Tamagotchi - Your Repo's Virtual Pet</title>
+    <title>GitHub Tamagotchi — Virtual pets for your repos</title>
+
+    <!-- OpenGraph / Social Sharing -->
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="GitHub Tamagotchi">
+    <meta property="og:title" content="GitHub Tamagotchi — Virtual pets for your repos">
+    <meta property="og:description" content="Give your GitHub repository a virtual pet that lives and dies by your commit activity.">
+    <meta property="og:url" content="{{ base_url }}">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="GitHub Tamagotchi — Virtual pets for your repos">
+    <meta name="twitter:description" content="Give your GitHub repository a virtual pet that lives and dies by your commit activity.">
+
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -6,18 +6,28 @@
     <title>{{ pet.name }} — {{ repo_owner }}/{{ repo_name }} | GitHub Tamagotchi</title>
 
     <!-- OpenGraph / Social Sharing -->
-    <meta property="og:title" content="{{ pet.name }} — {{ repo_owner }}/{{ repo_name }}">
-    <meta property="og:description" content="{{ pet.name }} is a {{ pet.stage }} feeling {{ pet.mood }}. Health: {{ pet.health }}%, XP: {{ pet.experience }}. Age: {{ age_days }} days.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ page_url }}">
-    <meta property="og:image" content="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}">
     <meta property="og:site_name" content="GitHub Tamagotchi">
+    <meta property="og:title" content="{{ pet.name }} the {{ pet.stage | capitalize }} · GitHub Tamagotchi">
+    {% if pet.is_dead %}
+    <meta property="og:description" content="{{ pet.name }} has passed away. 🪦 {{ repo_owner }}/{{ repo_name }} needs some love.">
+    {% else %}
+    <meta property="og:description" content="{{ pet.name }} is a {{ pet.mood }} {{ pet.stage }} with {{ pet.health }}HP, watching over {{ repo_owner }}/{{ repo_name }}.">
+    {% endif %}
+    <meta property="og:image" content="{{ base_url }}/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/badge.svg">
+    <meta property="og:image:width" content="120">
+    <meta property="og:image:height" content="80">
+    <meta property="og:url" content="{{ base_url }}/pets/{{ repo_owner }}/{{ repo_name }}">
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{{ pet.name }} — {{ repo_owner }}/{{ repo_name }}">
-    <meta name="twitter:description" content="{{ pet.name }} is a {{ pet.stage }} feeling {{ pet.mood }}. Health: {{ pet.health }}%, XP: {{ pet.experience }}. Age: {{ age_days }} days.">
-    <meta name="twitter:image" content="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ pet.name }} the {{ pet.stage | capitalize }} · GitHub Tamagotchi">
+    {% if pet.is_dead %}
+    <meta name="twitter:description" content="{{ pet.name }} has passed away. 🪦 {{ repo_owner }}/{{ repo_name }} needs some love.">
+    {% else %}
+    <meta name="twitter:description" content="{{ pet.name }} is a {{ pet.mood }} {{ pet.stage }} with {{ pet.health }}HP, watching over {{ repo_owner }}/{{ repo_name }}.">
+    {% endif %}
+    <meta name="twitter:image" content="{{ base_url }}/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/badge.svg">
 
     <link rel="stylesheet" href="/static/css/style.css">
 </head>

--- a/tests/api/test_pet_profile.py
+++ b/tests/api/test_pet_profile.py
@@ -125,6 +125,20 @@ class TestPetProfilePage:
         assert 'name="twitter:card"' in response.text
         assert 'name="twitter:title"' in response.text
 
+    def test_meta_tags_use_absolute_urls_with_badge_svg(self, client: TestClient) -> None:
+        """Profile page meta image tags should use absolute URLs pointing to the badge SVG."""
+        _create_pet(repo_owner="testowner", repo_name="testrepo")
+        response = client.get("/pet/testowner/testrepo")
+        assert response.status_code == 200
+        # og:image must point to badge.svg (not image endpoint), with an absolute URL
+        assert "/api/v1/pets/testowner/testrepo/badge.svg" in response.text
+        # og:url must be an absolute URL (starts with http)
+        og_url_line = next(
+            (line for line in response.text.splitlines() if 'property="og:url"' in line),
+            "",
+        )
+        assert "http" in og_url_line
+
     def test_not_found_returns_404(self, client: TestClient) -> None:
         """Non-existent pet should return 404."""
         response = client.get("/pet/nobody/nonexistent")


### PR DESCRIPTION
Closes #14

## Summary

- Add `base_url` config setting (default: `https://tamagotchi.nijmegen.wiebe.xyz`) so the domain is not hardcoded in templates
- Rewrite pet profile OG/Twitter meta tags to use absolute URLs and the always-available `badge.svg` endpoint instead of the image endpoint (which has MinIO dependency)
- Dynamic descriptions: alive pets show mood/health/HP copy, dead pets show a memorial message
- Add basic OG + Twitter Card meta tags to the landing page
- Pass `base_url` from config into both template contexts (landing + profile)
- Add test verifying meta image URLs are absolute and point to `badge.svg`

## Test plan

- [ ] All existing tests pass (455 tests, ruff clean, mypy clean)
- [ ] `test_meta_tags_use_absolute_urls_with_badge_svg` verifies the badge endpoint and absolute URLs
- [ ] Share a pet profile URL in a link previewer (e.g. opengraph.xyz) to confirm the card renders correctly