### PR TITLE
feat: add release frequency and contributor count to health metrics

### DIFF
--- a/alembic/versions/012_add_pet_death_fields.py
+++ b/alembic/versions/012_add_pet_death_fields.py
@@ -1,0 +1,47 @@
+"""Add pet death fields
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-04-09
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "is_dead", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+    )
+    op.add_column(
+        "pets",
+        sa.Column("died_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "pets",
+        sa.Column("cause_of_death", sa.String(50), nullable=True),
+    )
+    op.add_column(
+        "pets",
+        sa.Column("grace_period_started", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "grace_period_started")
+    op.drop_column("pets", "cause_of_death")
+    op.drop_column("pets", "died_at")
+    op.drop_column("pets", "is_dead")

--- a/alembic/versions/014_add_release_and_contributor_counts.py
+++ b/alembic/versions/014_add_release_and_contributor_counts.py
@@ -1,0 +1,45 @@
+"""Add last_release_count and last_contributor_count to pets
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-04-09
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "last_release_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "pets",
+        sa.Column(
+            "last_contributor_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "last_contributor_count")
+    op.drop_column("pets", "last_release_count")

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -331,6 +331,9 @@ async def get_pet_badge(repo_owner: str, repo_name: str, session: DbSession) -> 
         pet.stage,
         pet.mood,
         pet.health,
+        is_dead=pet.is_dead,
+        died_at=pet.died_at,
+        created_at=pet.created_at,
         commit_streak=pet.commit_streak,
     )
     return Response(

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -37,6 +37,7 @@ from github_tamagotchi.models.pet import Pet, PetStage
 from github_tamagotchi.models.user import User
 from github_tamagotchi.models.webhook_event import WebhookEvent
 from github_tamagotchi.services import image_queue
+from github_tamagotchi.services.achievements import check_and_unlock_achievements
 from github_tamagotchi.services.alerting import AlertChecker
 from github_tamagotchi.services.github import GitHubService, RateLimitError
 from github_tamagotchi.services.pet_logic import (
@@ -144,6 +145,10 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             experience=new_experience,
                         )
 
+                    # Store last-known release and contributor snapshots
+                    pet.last_release_count = health.release_count_30d
+                    pet.last_contributor_count = health.contributor_count
+
                     # Update last_fed_at if there was a recent commit
                     if health.last_commit_at:
                         hours_since_commit = (
@@ -168,6 +173,16 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             pet_name=pet.name,
                             repo=f"{pet.repo_owner}/{pet.repo_name}",
                             cause=cause,
+                        )
+
+                    # Check and unlock achievements based on updated pet state
+                    newly_unlocked = await check_and_unlock_achievements(pet, session)
+                    if newly_unlocked:
+                        logger.info(
+                            "achievements_unlocked",
+                            pet_id=pet.id,
+                            pet_name=pet.name,
+                            achievements=newly_unlocked,
                         )
 
                     updated_count += 1
@@ -376,7 +391,9 @@ OptionalUser = Annotated[User | None, Depends(get_optional_user)]
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request, user: OptionalUser) -> HTMLResponse:
     """Landing page."""
-    return templates.TemplateResponse(request, "landing.html", {"user": user})
+    return templates.TemplateResponse(
+        request, "landing.html", {"user": user, "base_url": settings.base_url}
+    )
 
 
 DbSession = Annotated[AsyncSession, Depends(get_session)]
@@ -488,6 +505,8 @@ async def pet_profile(
             "page_url": page_url,
             "repo_owner": repo_owner,
             "repo_name": repo_name,
+            "base_url": settings.base_url,
+            "now_utc": now,
         },
         headers={"Cache-Control": "public, max-age=60"},
     )
@@ -631,3 +650,72 @@ async def admin_trigger_poll(
     triggered_by = f"manual:{user.github_login}"
     background_tasks.add_task(poll_repositories, triggered_by=triggered_by)
     return RedirectResponse(url="/admin/jobs", status_code=303)
+
+
+@app.get("/admin/achievements", response_class=HTMLResponse)
+async def admin_achievements(
+    request: Request,
+    user: AdminUser,
+    session: DbSession,
+) -> HTMLResponse:
+    """Admin page showing achievement statistics."""
+    from sqlalchemy import desc
+
+    from github_tamagotchi.models.achievement import PetAchievement
+    from github_tamagotchi.services.achievements import ACHIEVEMENT_ORDER, ACHIEVEMENTS
+
+    # Total achievements unlocked
+    total_result = await session.execute(
+        select(func.count()).select_from(PetAchievement)
+    )
+    total_unlocked = total_result.scalar() or 0
+
+    # Most commonly unlocked achievements
+    popular_result = await session.execute(
+        select(PetAchievement.achievement_id, func.count().label("count"))
+        .group_by(PetAchievement.achievement_id)
+        .order_by(desc("count"))
+    )
+    popular_rows = popular_result.all()
+    popular = [
+        {
+            "achievement_id": row.achievement_id,
+            "name": ACHIEVEMENTS.get(row.achievement_id, {}).get("name", row.achievement_id),
+            "icon": ACHIEVEMENTS.get(row.achievement_id, {}).get("icon", ""),
+            "count": row.count,
+        }
+        for row in popular_rows
+    ]
+
+    # Recent unlocks (last 20) with pet info
+    recent_result = await session.execute(
+        select(PetAchievement, Pet)
+        .join(Pet, PetAchievement.pet_id == Pet.id)
+        .order_by(PetAchievement.unlocked_at.desc())
+        .limit(20)
+    )
+    recent_unlocks = [
+        {
+            "pet": row.Pet,
+            "achievement_id": row.PetAchievement.achievement_id,
+            "name": ACHIEVEMENTS.get(row.PetAchievement.achievement_id, {}).get(
+                "name", row.PetAchievement.achievement_id
+            ),
+            "icon": ACHIEVEMENTS.get(row.PetAchievement.achievement_id, {}).get("icon", ""),
+            "unlocked_at": row.PetAchievement.unlocked_at,
+        }
+        for row in recent_result
+    ]
+
+    return templates.TemplateResponse(
+        request,
+        "admin_achievements.html",
+        {
+            "user": user,
+            "total_unlocked": total_unlocked,
+            "popular": popular,
+            "recent_unlocks": recent_unlocks,
+            "achievements": ACHIEVEMENTS,
+            "achievement_order": ACHIEVEMENT_ORDER,
+        },
+    )

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -44,8 +44,10 @@ from github_tamagotchi.services.pet_logic import (
     calculate_experience,
     calculate_health_delta,
     calculate_mood,
+    check_death_conditions,
     get_next_stage,
     update_commit_streak,
+    update_grace_period,
 )
 
 # Set up paths for templates and static files
@@ -102,6 +104,12 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                 try:
                     now = datetime.now(UTC)
 
+                    # Dead pets: still poll (grave page stays current) but skip health updates
+                    if pet.is_dead:
+                        pet.last_checked_at = now
+                        updated_count += 1
+                        continue
+
                     # Fetch health metrics from GitHub
                     health = await github_service.get_repo_health(pet.repo_owner, pet.repo_name)
 
@@ -146,6 +154,21 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
 
                     # Update commit streak
                     update_commit_streak(pet, health, now)
+
+                    # Update grace period tracker and check death conditions
+                    update_grace_period(pet, now)
+                    should_die, cause = check_death_conditions(pet, now)
+                    if should_die:
+                        pet.is_dead = True
+                        pet.died_at = now
+                        pet.cause_of_death = cause
+                        logger.info(
+                            "pet_died",
+                            pet_id=pet.id,
+                            pet_name=pet.name,
+                            repo=f"{pet.repo_owner}/{pet.repo_name}",
+                            cause=cause,
+                        )
 
                     updated_count += 1
 

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
@@ -80,6 +80,16 @@ class Pet(Base):
     last_fed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     images_generated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Death state
+    is_dead: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    died_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cause_of_death: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    grace_period_started: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
 

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -93,6 +93,19 @@ class Pet(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Resurrection / generation tracking
+    generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+
+    # Last-known health metric snapshots
+    last_release_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    last_contributor_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -1,7 +1,7 @@
 """GitHub API service for repository health metrics."""
 
-from dataclasses import dataclass
-from datetime import UTC, datetime
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
@@ -31,6 +31,8 @@ class RepoHealth:
     oldest_issue_age_days: float | None
     last_ci_success: bool | None
     has_stale_dependencies: bool
+    release_count_30d: int = field(default=0)
+    contributor_count: int = field(default=0)
 
 
 class GitHubService:
@@ -81,6 +83,12 @@ class GitHubService:
             # Get CI status
             last_ci_success = await self._get_ci_status(client, owner, repo)
 
+            # Get release frequency (last 30 days)
+            release_count_30d = await self._get_release_count_30d(client, owner, repo)
+
+            # Get contributor count (last 90 days)
+            contributor_count = await self._get_contributor_count_90d(client, owner, repo)
+
             return RepoHealth(
                 last_commit_at=last_commit_at,
                 open_prs_count=open_prs_count,
@@ -89,6 +97,8 @@ class GitHubService:
                 oldest_issue_age_days=oldest_issue_age,
                 last_ci_success=last_ci_success,
                 has_stale_dependencies=False,  # TODO: Check dependabot
+                release_count_30d=release_count_30d,
+                contributor_count=contributor_count,
             )
 
     async def _get_last_commit(
@@ -192,6 +202,61 @@ class GitHubService:
     def _get_oldest_age_days(self, items: list[dict[str, Any]]) -> float:
         """Get age in days of the oldest item."""
         return self._get_oldest_age_hours(items) / 24
+
+    async def _get_release_count_30d(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> int:
+        """Get the number of releases published in the last 30 days (capped at 10)."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/releases",
+                headers=self._get_headers(),
+                params={"per_page": 100},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            releases: list[dict[str, Any]] = resp.json()
+            cutoff = datetime.now(UTC) - timedelta(days=30)
+            count = sum(
+                1
+                for r in releases
+                if r.get("published_at")
+                and datetime.fromisoformat(
+                    r["published_at"].replace("Z", "+00:00")
+                ) >= cutoff
+            )
+            return min(count, 10)
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get releases", error=str(e))
+        return 0
+
+    async def _get_contributor_count_90d(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> int:
+        """Get the number of unique commit authors in the last 90 days (capped at 20)."""
+        try:
+            since = (datetime.now(UTC) - timedelta(days=90)).isoformat()
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"since": since, "per_page": 100},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            authors = {
+                c["author"]["login"]
+                for c in commits
+                if c.get("author") and c["author"].get("login")
+            }
+            return min(len(authors), 20)
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get contributor count", error=str(e))
+        return 0
 
     async def list_user_repos(
         self, page: int = 1, per_page: int = 100

--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -70,6 +70,12 @@ def calculate_health_delta(health: RepoHealth) -> int:
         if hours_since_commit < 24:
             delta += 10  # Recent commit = feeding
 
+    # Release frequency bonus: +2 per release in last 30d, capped at +10
+    delta += min(health.release_count_30d * 2, 10)
+
+    # Contributor count bonus: +1 per unique contributor in last 90d, capped at +8
+    delta += min(health.contributor_count, 8)
+
     # Negative effects
     if health.has_stale_dependencies:
         delta -= 10

--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -148,3 +148,49 @@ def update_commit_streak(pet: "Pet", health: RepoHealth, now: datetime) -> None:
                 pet.commit_streak = 0
 
     pet.longest_streak = max(pet.longest_streak, pet.commit_streak)
+
+
+# Death thresholds
+DEATH_GRACE_PERIOD_DAYS = 7  # Days at 0 health before death
+ABANDONMENT_THRESHOLD_DAYS = 90  # Days without any activity before abandonment death
+
+
+def update_grace_period(pet: "Pet", now: datetime) -> None:
+    """Set or clear grace_period_started based on current health.
+
+    If health is 0, record the start of the grace period (if not already set).
+    If health is above 0, clear the grace period.
+    """
+    if pet.health == 0:
+        if pet.grace_period_started is None:
+            pet.grace_period_started = now
+    else:
+        pet.grace_period_started = None
+
+
+def check_death_conditions(pet: "Pet", now: datetime) -> tuple[bool, str | None]:
+    """Check whether the pet should die and return the cause.
+
+    Returns (should_die, cause) where cause is one of:
+      - "neglect"     — health has been at 0 for 7+ days
+      - "abandonment" — no activity for 90 days
+
+    Returns (False, None) if the pet should stay alive.
+    """
+    # Abandonment: no activity (last_checked_at or last_fed_at) for 90 days
+    last_activity = pet.last_checked_at or pet.last_fed_at or pet.created_at
+    # Normalise: if naive datetime, compare against naive now
+    compare_now = now.replace(tzinfo=None) if last_activity.tzinfo is None else now
+    days_inactive = (compare_now - last_activity).total_seconds() / 86400
+    if days_inactive >= ABANDONMENT_THRESHOLD_DAYS:
+        return True, "abandonment"
+
+    # Neglect: health at 0 for 7+ days
+    if pet.grace_period_started is not None:
+        grace_start = pet.grace_period_started
+        compare_now = now.replace(tzinfo=None) if grace_start.tzinfo is None else now
+        days_at_zero = (compare_now - grace_start).total_seconds() / 86400
+        if days_at_zero >= DEATH_GRACE_PERIOD_DAYS:
+            return True, "neglect"
+
+    return False, None

--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -37,10 +37,11 @@
             {% if pets %}
             <div class="feature-grid">
                 {% for pet in pets %}
-                <div class="feature" id="pet-card-{{ loop.index }}" style="padding: 1.5rem; display: flex; flex-direction: column; gap: 0.75rem;">
+                <div class="feature" id="pet-card-{{ loop.index }}" style="padding: 1.5rem; display: flex; flex-direction: column; gap: 0.75rem;{% if pet.is_dead %} opacity: 0.6; filter: grayscale(0.8);{% endif %}">
                     <div style="display: flex; align-items: center; gap: 0.75rem;">
                         <span style="font-size: 2rem;">
-                            {% if pet.stage == "egg" %}🥚
+                            {% if pet.is_dead %}&#129680;
+                            {% elif pet.stage == "egg" %}🥚
                             {% elif pet.stage == "baby" %}🐣
                             {% elif pet.stage == "child" %}🐥
                             {% elif pet.stage == "teen" %}🐦
@@ -55,6 +56,19 @@
                         </div>
                     </div>
 
+                    {% if pet.is_dead %}
+                    <div style="display: flex; gap: 0.5rem; align-items: center; font-size: 0.85rem;">
+                        <span style="background: #4a4a4a; color: #9e9e9e; padding: 0.2rem 0.6rem; border-radius: 99px;">Deceased</span>
+                        {% if pet.cause_of_death %}
+                        <span style="background: #4a4a4a; color: #9e9e9e; padding: 0.2rem 0.6rem; border-radius: 99px;">{{ pet.cause_of_death | capitalize }}</span>
+                        {% endif %}
+                    </div>
+                    {% if pet.died_at %}
+                    <div style="font-size: 0.8rem; color: #7f8c8d;">
+                        Died {{ pet.died_at.strftime('%Y-%m-%d') }}
+                    </div>
+                    {% endif %}
+                    {% else %}
                     <div style="display: flex; gap: 0.5rem; align-items: center; font-size: 0.85rem;">
                         <span style="background: var(--surface-light); padding: 0.2rem 0.6rem; border-radius: 99px;">{{ pet.stage | capitalize }}</span>
                         <span style="background: var(--surface-light); padding: 0.2rem 0.6rem; border-radius: 99px;">{{ pet.mood | capitalize }}</span>
@@ -69,9 +83,10 @@
                             <div style="background: {% if pet.health >= 70 %}var(--secondary){% elif pet.health >= 30 %}var(--accent){% else %}#ef4444{% endif %}; width: {{ pet.health }}%; height: 100%;"></div>
                         </div>
                     </div>
+                    {% endif %}
 
                     <div style="display: flex; gap: 0.5rem; margin-top: 0.25rem;">
-                        <a href="/pet/{{ pet.repo_owner }}/{{ pet.repo_name }}" class="secondary-btn" style="text-align: center; flex: 1;">View Profile</a>
+                        <a href="/pet/{{ pet.repo_owner }}/{{ pet.repo_name }}" class="secondary-btn" style="text-align: center; flex: 1;">{% if pet.is_dead %}View Memorial{% else %}View Profile{% endif %}</a>
                         <button
                             onclick="deletePet('{{ pet.repo_owner }}', '{{ pet.repo_name }}', 'pet-card-{{ loop.index }}')"
                             style="background: none; border: 1px solid #ef4444; color: #ef4444; border-radius: 6px; padding: 0.4rem 0.75rem; font-size: 0.85rem; cursor: pointer; white-space: nowrap;"

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -54,8 +54,11 @@
         <div class="container">
 
             <!-- Hero row: sprite + core stats -->
-            <section class="profile-hero">
+            <section class="profile-hero{% if pet.is_dead %} profile-hero--deceased{% endif %}">
                 <div class="profile-sprite-wrap">
+                    {% if pet.is_dead %}
+                    <div class="pet-emoji-fallback" style="display:flex; font-size: 4rem;">&#129680;</div>
+                    {% else %}
                     <img
                         src="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}"
                         alt="{{ pet.name }}"
@@ -66,6 +69,7 @@
                     <div id="pet-emoji-fallback" class="pet-emoji-fallback" style="display:none;">&#128049;</div>
                     <div class="pet-shadow"></div>
                     <div class="status-badge mood-{{ pet.mood }}">{{ pet.mood | capitalize }}</div>
+                    {% endif %}
                 </div>
 
                 <div class="profile-meta">
@@ -75,6 +79,32 @@
                         </a>
                     </div>
                     <h1 class="profile-name">{{ pet.name }}</h1>
+
+                    {% if pet.is_dead %}
+                    <p class="profile-stage-label" style="color: #7f8c8d;">Deceased</p>
+                    <div class="stats-grid">
+                        <div class="stat-card" style="grid-column: span 2;">
+                            <div class="stat-label">&#128128; Cause of death</div>
+                            <div class="stat-value" style="color: #9e9e9e;">{{ pet.cause_of_death | capitalize if pet.cause_of_death else "Unknown" }}</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-label">Died</div>
+                            <div class="stat-value" style="color: #9e9e9e;">
+                                {% if pet.died_at %}{{ pet.died_at.strftime('%Y-%m-%d') }}{% else %}Unknown{% endif %}
+                            </div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-label">Age at death</div>
+                            <div class="stat-value" style="color: #9e9e9e;">{{ age_days }} day{% if age_days != 1 %}s{% endif %}</div>
+                        </div>
+                    </div>
+                    <p style="margin-top: 1rem; font-size: 1.1rem; color: #7f8c8d;">
+                        RIP {{ pet.name }}
+                        {% if pet.died_at and pet.created_at %}
+                        — {{ pet.created_at.year }}–{{ pet.died_at.year }}
+                        {% endif %}
+                    </p>
+                    {% else %}
                     <p class="profile-stage-label">{{ pet.stage | capitalize }}</p>
 
                     <div class="stats-grid">
@@ -121,6 +151,7 @@
                         >🍖 Feed</button>
                         <span id="feed-feedback" style="margin-left: 0.75rem; font-size: 0.9rem; color: #4caf50; display: none;"></span>
                     </div>
+                    {% endif %}
                     {% endif %}
 
                     <!-- Share buttons -->

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -6,18 +6,28 @@
     <title>{{ pet.name }} — {{ repo_owner }}/{{ repo_name }} | GitHub Tamagotchi</title>
 
     <!-- OpenGraph / Social Sharing -->
-    <meta property="og:title" content="{{ pet.name }} — {{ repo_owner }}/{{ repo_name }}">
-    <meta property="og:description" content="{{ pet.name }} is a {{ pet.stage }} feeling {{ pet.mood }}. Health: {{ pet.health }}%, XP: {{ pet.experience }}. Age: {{ age_days }} days.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ page_url }}">
-    <meta property="og:image" content="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}">
     <meta property="og:site_name" content="GitHub Tamagotchi">
+    <meta property="og:title" content="{{ pet.name }} the {{ pet.stage | capitalize }} · GitHub Tamagotchi">
+    {% if pet.is_dead %}
+    <meta property="og:description" content="{{ pet.name }} has passed away. 🪦 {{ repo_owner }}/{{ repo_name }} needs some love.">
+    {% else %}
+    <meta property="og:description" content="{{ pet.name }} is a {{ pet.mood }} {{ pet.stage }} with {{ pet.health }}HP, watching over {{ repo_owner }}/{{ repo_name }}.">
+    {% endif %}
+    <meta property="og:image" content="{{ base_url }}/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/badge.svg">
+    <meta property="og:image:width" content="120">
+    <meta property="og:image:height" content="80">
+    <meta property="og:url" content="{{ base_url }}/pets/{{ repo_owner }}/{{ repo_name }}">
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{{ pet.name }} — {{ repo_owner }}/{{ repo_name }}">
-    <meta name="twitter:description" content="{{ pet.name }} is a {{ pet.stage }} feeling {{ pet.mood }}. Health: {{ pet.health }}%, XP: {{ pet.experience }}. Age: {{ age_days }} days.">
-    <meta name="twitter:image" content="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ pet.name }} the {{ pet.stage | capitalize }} · GitHub Tamagotchi">
+    {% if pet.is_dead %}
+    <meta name="twitter:description" content="{{ pet.name }} has passed away. 🪦 {{ repo_owner }}/{{ repo_name }} needs some love.">
+    {% else %}
+    <meta name="twitter:description" content="{{ pet.name }} is a {{ pet.mood }} {{ pet.stage }} with {{ pet.health }}HP, watching over {{ repo_owner }}/{{ repo_name }}.">
+    {% endif %}
+    <meta name="twitter:image" content="{{ base_url }}/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/badge.svg">
 
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
@@ -78,7 +88,12 @@
                             {{ repo_owner }}/{{ repo_name }}
                         </a>
                     </div>
-                    <h1 class="profile-name">{{ pet.name }}</h1>
+                    <h1 class="profile-name">
+                        {{ pet.name }}
+                        {% if pet.generation > 1 %}
+                        <span style="display:inline-block; margin-left:0.5rem; font-size:0.55em; font-weight:600; background: linear-gradient(135deg, #b8860b, #ffd700); color:#1a1a1a; padding:0.2em 0.6em; border-radius:99px; vertical-align:middle; letter-spacing:0.03em;">Gen {{ pet.generation }}</span>
+                        {% endif %}
+                    </h1>
 
                     {% if pet.is_dead %}
                     <p class="profile-stage-label" style="color: #7f8c8d;">Deceased</p>
@@ -104,6 +119,33 @@
                         — {{ pet.created_at.year }}–{{ pet.died_at.year }}
                         {% endif %}
                     </p>
+
+                    {% if user and user.id == pet.user_id %}
+                    {# Resurrection section — only shown to the owner #}
+                    {% if pet.died_at %}
+                    {% set days_since_death = ((now_utc - pet.died_at).total_seconds() / 86400) | int %}
+                    {% set mourning_days = 7 %}
+                    {% set days_remaining = mourning_days - days_since_death %}
+                    <div id="resurrection-section" style="margin-top:1.5rem; padding:1.25rem; border-radius:12px; background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1);">
+                        {% if days_remaining > 0 %}
+                        <p style="color:#9e9e9e; font-size:0.95rem; margin-bottom:0.75rem;">Your pet must rest. Resurrection available in <strong style="color:#bdbdbd;">{{ days_remaining }} day{% if days_remaining != 1 %}s{% endif %}</strong>.</p>
+                        <div style="background:rgba(255,255,255,0.08); border-radius:4px; height:8px; overflow:hidden;">
+                            <div style="background: linear-gradient(90deg, #b8860b, #ffd700); height:100%; width:{{ [((days_since_death / mourning_days) * 100) | int, 100] | min }}%;"></div>
+                        </div>
+                        {% else %}
+                        <p style="color:rgba(255,255,255,0.75); font-size:0.95rem; margin-bottom:1rem;">The spirit stirs… Are you ready to bring <strong>{{ pet.name }}</strong> back?</p>
+                        <button
+                            id="resurrect-btn"
+                            style="background: linear-gradient(135deg, #b8860b, #ffd700); color:#1a1a1a; border:none; padding:0.6rem 1.5rem; border-radius:8px; font-size:1rem; font-weight:700; cursor:pointer; letter-spacing:0.02em;"
+                            onmouseover="this.style.opacity='0.85'"
+                            onmouseout="this.style.opacity='1'"
+                        >&#10024; Resurrect {{ pet.name }}</button>
+                        <p id="resurrect-error" style="color:#e53935; font-size:0.875rem; display:none; margin-top:0.5rem;"></p>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+                    {% endif %}
+
                     {% else %}
                     <p class="profile-stage-label">{{ pet.stage | capitalize }}</p>
 
@@ -126,6 +168,14 @@
                         <div class="stat-card">
                             <div class="stat-label">Age</div>
                             <div class="stat-value">{{ age_days }} day{% if age_days != 1 %}s{% endif %}</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-label">&#128640; Releases (30d)</div>
+                            <div class="stat-value">{{ pet.last_release_count }}</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-label">&#128101; Contributors</div>
+                            <div class="stat-value">{{ pet.last_contributor_count }}</div>
                         </div>
                     </div>
 
@@ -217,6 +267,14 @@
                 <a href="/auth/github" class="cta-button large">Login with GitHub</a>
             </section>
             {% endif %}
+
+            <!-- Achievements Section -->
+            <section class="profile-section" id="achievements-section" style="margin-top: 2rem;">
+                <h2>Achievements</h2>
+                <div id="achievements-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 0.75rem; margin-top: 1rem;">
+                    <p id="achievements-loading" style="color: rgba(255,255,255,0.5); font-size: 0.9rem; grid-column: 1/-1;">Loading achievements&#8230;</p>
+                </div>
+            </section>
 
             <!-- Comments Section -->
             <section class="profile-section" id="comments-section" style="margin-top: 2rem;">
@@ -433,6 +491,91 @@
                 }
             });
         }
+
+        // Resurrect button
+        const resurrectBtn = document.getElementById('resurrect-btn');
+        const resurrectError = document.getElementById('resurrect-error');
+        if (resurrectBtn) {
+            resurrectBtn.addEventListener('click', async () => {
+                resurrectBtn.disabled = true;
+                resurrectBtn.textContent = 'Resurrecting…';
+                resurrectError.style.display = 'none';
+                try {
+                    const resp = await fetch(
+                        '/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/resurrect',
+                        { method: 'POST' }
+                    );
+                    if (!resp.ok) {
+                        const err = await resp.json().catch(() => ({}));
+                        resurrectError.textContent = err.detail || 'Resurrection failed.';
+                        resurrectError.style.display = 'block';
+                        resurrectBtn.disabled = false;
+                        resurrectBtn.textContent = '✨ Resurrect {{ pet.name }}';
+                        return;
+                    }
+                    window.location.reload();
+                } catch (e) {
+                    resurrectError.textContent = 'Network error, please try again.';
+                    resurrectError.style.display = 'block';
+                    resurrectBtn.disabled = false;
+                    resurrectBtn.textContent = '✨ Resurrect {{ pet.name }}';
+                }
+            });
+        }
+
+        // Achievements
+        const ACHIEVEMENTS_API = '/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/achievements';
+
+        function renderAchievement(a) {
+            const card = document.createElement('div');
+            const opacity = a.unlocked ? '1' : '0.35';
+            card.style.cssText = `
+                background: rgba(255,255,255,0.05);
+                border: 1px solid rgba(255,255,255,${a.unlocked ? '0.15' : '0.06'});
+                border-radius: 10px;
+                padding: 0.75rem;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                text-align: center;
+                gap: 0.3rem;
+                opacity: ${opacity};
+            `;
+            const iconEl = document.createElement('div');
+            iconEl.style.cssText = 'font-size: 1.75rem; line-height: 1;';
+            iconEl.textContent = a.unlocked ? a.icon : '🔒';
+            const nameEl = document.createElement('div');
+            nameEl.style.cssText = 'font-size: 0.78rem; font-weight: 600; color: rgba(255,255,255,0.9);';
+            nameEl.textContent = a.name;
+            card.appendChild(iconEl);
+            card.appendChild(nameEl);
+            if (a.unlocked && a.unlocked_at) {
+                const dateEl = document.createElement('div');
+                dateEl.style.cssText = 'font-size: 0.68rem; color: rgba(255,255,255,0.45);';
+                const d = new Date(a.unlocked_at);
+                dateEl.textContent = d.toLocaleDateString();
+                card.appendChild(dateEl);
+            }
+            card.title = a.description;
+            return card;
+        }
+
+        async function loadAchievements() {
+            const grid = document.getElementById('achievements-grid');
+            const loading = document.getElementById('achievements-loading');
+            try {
+                const resp = await fetch(ACHIEVEMENTS_API);
+                if (!resp.ok) throw new Error('Failed to load');
+                const data = await resp.json();
+                if (loading) loading.remove();
+                grid.innerHTML = '';
+                data.achievements.forEach(a => grid.appendChild(renderAchievement(a)));
+            } catch {
+                if (loading) loading.textContent = 'Could not load achievements.';
+            }
+        }
+
+        loadAchievements();
     </script>
 </body>
 </html>

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -425,6 +425,9 @@ class TestGetRepoHealth:
             return_value=httpx.Response(500)
         )
         respx.get("https://api.github.com/repos/owner/repo").mock(return_value=httpx.Response(500))
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(500)
+        )
 
         service = GitHubService(token="test")
         result = await service.get_repo_health("owner", "repo")
@@ -434,3 +437,129 @@ class TestGetRepoHealth:
         assert result.open_prs_count == 0
         assert result.open_issues_count == 0
         assert result.last_ci_success is None
+        assert result.release_count_30d == 0
+        assert result.contributor_count == 0
+
+
+class TestGetReleaseCount30d:
+    """Tests for fetching release count in last 30 days."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_counts_recent_releases(self) -> None:
+        """Should count only releases published in the last 30 days."""
+        from datetime import UTC, datetime, timedelta
+
+        now = datetime.now(UTC)
+        releases = [
+            {"published_at": (now - timedelta(days=5)).isoformat()},   # within 30d
+            {"published_at": (now - timedelta(days=15)).isoformat()},  # within 30d
+            {"published_at": (now - timedelta(days=40)).isoformat()},  # older than 30d
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(200, json=releases)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_release_count_30d(client, "owner", "repo")
+
+        assert result == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_caps_at_ten(self) -> None:
+        """Should cap result at 10 regardless of actual count."""
+        from datetime import UTC, datetime, timedelta
+
+        now = datetime.now(UTC)
+        releases = [
+            {"published_at": (now - timedelta(days=i)).isoformat()} for i in range(1, 16)
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(200, json=releases)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_release_count_30d(client, "owner", "repo")
+
+        assert result == 10
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_api_error(self) -> None:
+        """Should return 0 when the releases API returns an error."""
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_release_count_30d(client, "owner", "repo")
+
+        assert result == 0
+
+
+class TestGetContributorCount90d:
+    """Tests for fetching unique contributor count in last 90 days."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_counts_unique_authors(self) -> None:
+        """Should count unique author logins from commits."""
+        commits = [
+            {"author": {"login": "alice"}},
+            {"author": {"login": "bob"}},
+            {"author": {"login": "alice"}},  # duplicate, should not count twice
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_caps_at_twenty(self) -> None:
+        """Should cap result at 20 regardless of actual count."""
+        commits = [{"author": {"login": f"user{i}"}} for i in range(25)]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 20
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_api_error(self) -> None:
+        """Should return 0 when the commits API returns an error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skips_commits_without_author(self) -> None:
+        """Should skip commits where author or login is missing."""
+        commits = [
+            {"author": {"login": "alice"}},
+            {"author": None},
+            {},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 1

--- a/tests/services/test_pet_death.py
+++ b/tests/services/test_pet_death.py
@@ -1,0 +1,223 @@
+"""Tests for pet death mechanics."""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+from github_tamagotchi.models.pet import PetMood, PetStage
+from github_tamagotchi.services.pet_logic import (
+    ABANDONMENT_THRESHOLD_DAYS,
+    DEATH_GRACE_PERIOD_DAYS,
+    check_death_conditions,
+    update_grace_period,
+)
+
+
+def _make_pet(**kwargs: Any) -> Any:
+    """Create a minimal pet-like namespace for unit testing (no DB required)."""
+    defaults: dict[str, Any] = {
+        "repo_owner": "owner",
+        "repo_name": "repo",
+        "name": "TestPet",
+        "stage": PetStage.EGG.value,
+        "mood": PetMood.CONTENT.value,
+        "health": 100,
+        "experience": 0,
+        "is_dead": False,
+        "died_at": None,
+        "cause_of_death": None,
+        "grace_period_started": None,
+        "last_fed_at": None,
+        "last_checked_at": None,
+        "created_at": datetime.now(UTC) - timedelta(days=10),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestUpdateGracePeriod:
+    """Tests for update_grace_period."""
+
+    def test_sets_grace_period_when_health_is_zero(self) -> None:
+        now = datetime.now(UTC)
+        pet = _make_pet(health=0, grace_period_started=None)
+        update_grace_period(pet, now)
+        assert pet.grace_period_started == now
+
+    def test_does_not_overwrite_existing_grace_period(self) -> None:
+        earlier = datetime.now(UTC) - timedelta(days=3)
+        now = datetime.now(UTC)
+        pet = _make_pet(health=0, grace_period_started=earlier)
+        update_grace_period(pet, now)
+        assert pet.grace_period_started == earlier
+
+    def test_clears_grace_period_when_health_above_zero(self) -> None:
+        earlier = datetime.now(UTC) - timedelta(days=2)
+        pet = _make_pet(health=50, grace_period_started=earlier)
+        update_grace_period(pet, datetime.now(UTC))
+        assert pet.grace_period_started is None
+
+    def test_does_nothing_when_health_above_zero_and_no_grace_period(self) -> None:
+        pet = _make_pet(health=80, grace_period_started=None)
+        update_grace_period(pet, datetime.now(UTC))
+        assert pet.grace_period_started is None
+
+
+class TestCheckDeathConditions:
+    """Tests for check_death_conditions."""
+
+    def test_no_death_for_healthy_active_pet(self) -> None:
+        now = datetime.now(UTC)
+        pet = _make_pet(
+            health=80,
+            grace_period_started=None,
+            last_checked_at=now - timedelta(days=1),
+            created_at=now - timedelta(days=30),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is False
+        assert cause is None
+
+    def test_neglect_death_after_grace_period(self) -> None:
+        now = datetime.now(UTC)
+        pet = _make_pet(
+            health=0,
+            grace_period_started=now - timedelta(days=DEATH_GRACE_PERIOD_DAYS + 1),
+            last_checked_at=now - timedelta(days=1),
+            created_at=now - timedelta(days=30),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is True
+        assert cause == "neglect"
+
+    def test_no_death_when_grace_period_not_elapsed(self) -> None:
+        now = datetime.now(UTC)
+        pet = _make_pet(
+            health=0,
+            grace_period_started=now - timedelta(days=DEATH_GRACE_PERIOD_DAYS - 1),
+            last_checked_at=now - timedelta(days=1),
+            created_at=now - timedelta(days=30),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is False
+        assert cause is None
+
+    def test_abandonment_death_after_90_days_inactive(self) -> None:
+        now = datetime.now(UTC)
+        long_ago = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS + 1)
+        pet = _make_pet(
+            health=50,
+            grace_period_started=None,
+            last_checked_at=long_ago,
+            created_at=long_ago - timedelta(days=10),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is True
+        assert cause == "abandonment"
+
+    def test_no_abandonment_before_90_days(self) -> None:
+        now = datetime.now(UTC)
+        recent = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS - 1)
+        pet = _make_pet(
+            health=50,
+            grace_period_started=None,
+            last_checked_at=recent,
+            created_at=now - timedelta(days=30),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is False
+        assert cause is None
+
+    def test_abandonment_uses_last_fed_at_if_no_checked_at(self) -> None:
+        now = datetime.now(UTC)
+        long_ago = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS + 1)
+        pet = _make_pet(
+            health=50,
+            grace_period_started=None,
+            last_checked_at=None,
+            last_fed_at=long_ago,
+            created_at=long_ago - timedelta(days=10),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is True
+        assert cause == "abandonment"
+
+    def test_abandonment_uses_created_at_as_fallback(self) -> None:
+        now = datetime.now(UTC)
+        long_ago = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS + 1)
+        pet = _make_pet(
+            health=50,
+            grace_period_started=None,
+            last_checked_at=None,
+            last_fed_at=None,
+            created_at=long_ago,
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is True
+        assert cause == "abandonment"
+
+    def test_abandonment_takes_priority_over_neglect(self) -> None:
+        """Abandonment check runs first; if that triggers, cause is 'abandonment'."""
+        now = datetime.now(UTC)
+        long_ago = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS + 1)
+        pet = _make_pet(
+            health=0,
+            grace_period_started=now - timedelta(days=DEATH_GRACE_PERIOD_DAYS + 1),
+            last_checked_at=long_ago,
+            created_at=long_ago - timedelta(days=10),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is True
+        assert cause == "abandonment"
+
+
+class TestDeadPetBadge:
+    """Tests for dead pet badge rendering."""
+
+    def test_dead_badge_contains_grave_emoji(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        svg = generate_badge_svg("Chompy", "adult", "happy", 80, is_dead=True)
+        assert "🪦" in svg
+
+    def test_dead_badge_contains_skull_emoji(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        svg = generate_badge_svg("Chompy", "adult", "happy", 80, is_dead=True)
+        assert "💀" in svg
+
+    def test_dead_badge_contains_rip_label(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        born = datetime(2024, 1, 1, tzinfo=UTC)
+        died = datetime(2025, 6, 15, tzinfo=UTC)
+        svg = generate_badge_svg(
+            "Chompy", "adult", "happy", 80, is_dead=True, died_at=died, created_at=born
+        )
+        assert "RIP 2024–2025" in svg
+
+    def test_dead_badge_contains_deceased_label(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        svg = generate_badge_svg("Chompy", "adult", "happy", 80, is_dead=True)
+        assert "Deceased" in svg
+
+    def test_dead_badge_no_health_bar(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        svg = generate_badge_svg("Chompy", "adult", "happy", 80, is_dead=True)
+        # Health bar has specific "HP" label in live badge
+        assert ">HP<" not in svg
+
+    def test_dead_badge_uses_grey_accent(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        svg = generate_badge_svg("Chompy", "adult", "happy", 80, is_dead=True)
+        assert "#7f8c8d" in svg
+
+    def test_live_badge_unchanged_when_not_dead(self) -> None:
+        from github_tamagotchi.services.badge import generate_badge_svg
+
+        svg = generate_badge_svg("Chompy", "adult", "happy", 80, is_dead=False)
+        assert "🪦" not in svg
+        assert "Deceased" not in svg

--- a/tests/unit/test_pet_logic.py
+++ b/tests/unit/test_pet_logic.py
@@ -261,6 +261,86 @@ class TestCalculateHealthDelta:
         )
         assert calculate_health_delta(health) == 0
 
+    def test_release_count_adds_bonus(self) -> None:
+        """Each release in last 30d adds +2 health, up to +10."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=3,
+        )
+        assert calculate_health_delta(health) == 6  # 3 * 2
+
+    def test_release_count_capped_at_ten(self) -> None:
+        """Release bonus should be capped at +10 regardless of count."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=10,
+        )
+        assert calculate_health_delta(health) == 10
+
+    def test_contributor_count_adds_bonus(self) -> None:
+        """Each contributor in last 90d adds +1 health, up to +8."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            contributor_count=5,
+        )
+        assert calculate_health_delta(health) == 5
+
+    def test_contributor_count_capped_at_eight(self) -> None:
+        """Contributor bonus should be capped at +8 regardless of count."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            contributor_count=20,
+        )
+        assert calculate_health_delta(health) == 8
+
+    def test_releases_and_contributors_higher_than_absent(self) -> None:
+        """Delta with releases+contributors should exceed delta without them."""
+        base_health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+        )
+        active_health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=2,
+            contributor_count=4,
+        )
+        assert calculate_health_delta(active_health) > calculate_health_delta(base_health)
+
 
 class TestCalculateExperience:
     """Tests for calculate_experience function."""


### PR DESCRIPTION
## Summary

Closes #25, closes #26.

- **`RepoHealth` extended** with `release_count_30d` (releases in last 30 days, capped at 10) and `contributor_count` (unique commit authors in last 90 days, capped at 20). Both fields default to 0 on any API error so polling never breaks.
- **Two new GitHub API calls** in `get_repo_health()`: `GET /releases?per_page=100` filtered by `published_at`, and `GET /commits?since=90d` with unique `author.login` extraction.
- **Health delta gains** additive bonuses: +2 per release (max +10) and +1 per contributor (max +8).
- **Pet model** gains `last_release_count` and `last_contributor_count` columns (migration 014), updated on every poll cycle.
- **pet_profile.html** displays "Releases (30d)" and "Contributors" stat cards in the stats grid.

## Test plan

- [ ] `ruff check .` — passes
- [ ] `mypy src/` on changed files — no new errors
- [ ] `pytest tests/ --ignore=tests/e2e` — 495 passed (12 new tests covering release count, contributor count, error handling, and health delta bonuses)
- [ ] CI green on the PR