### PR TITLE
feat: add pet resurrection with mourning period and generation tracking

### DIFF
--- a/alembic/versions/013_add_pet_generation.py
+++ b/alembic/versions/013_add_pet_generation.py
@@ -1,0 +1,35 @@
+"""Add pet generation field for resurrection tracking
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-04-09
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "013"
+down_revision: str | None = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "generation",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "generation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,8 @@ exclude_lines = [
 ]
 show_missing = true
 fail_under = 70
+
+[dependency-groups]
+dev = [
+    "mypy>=1.20.0",
+]

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -2,7 +2,7 @@
 
 import logging
 import math
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -16,7 +16,7 @@ from github_tamagotchi.api.auth import get_current_user, get_optional_user
 from github_tamagotchi.core.config import settings
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.crud import pet as pet_crud
-from github_tamagotchi.models.pet import Pet, PetStage
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
 from github_tamagotchi.models.user import User
 from github_tamagotchi.models.webhook_event import WebhookEvent
 from github_tamagotchi.services import image_queue
@@ -81,6 +81,10 @@ class PetResponse(BaseModel):
     style: str
     commit_streak: int
     longest_streak: int
+    generation: int
+    is_dead: bool
+    died_at: datetime | None
+    cause_of_death: str | None
     created_at: datetime
     updated_at: datetime
     last_fed_at: datetime | None
@@ -312,6 +316,69 @@ async def feed_pet(repo_owner: str, repo_name: str, session: DbSession) -> FeedR
         message=f"{updated_pet.name} has been fed!",
         pet=PetResponse.model_validate(updated_pet),
     )
+
+
+@router.post("/pets/{repo_owner}/{repo_name}/resurrect", response_model=PetResponse)
+async def resurrect_pet(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+) -> PetResponse:
+    """Resurrect a dead pet after the mandatory 7-day mourning period."""
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Pet not found for {repo_owner}/{repo_name}",
+        )
+    if not pet.is_dead:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Pet is not dead and cannot be resurrected",
+        )
+    if pet.user_id != user.id and not user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not own this pet",
+        )
+    if pet.died_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Pet death timestamp is missing",
+        )
+    now = datetime.now(UTC)
+    died_at = pet.died_at
+    if died_at.tzinfo is None:
+        died_at = died_at.replace(tzinfo=UTC)
+    days_elapsed = (now - died_at).total_seconds() / 86400
+    mourning_days = 7
+    if days_elapsed < mourning_days:
+        days_remaining = math.ceil(mourning_days - days_elapsed)
+        day_word = "day" if days_remaining == 1 else "days"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Your pet must rest for {days_remaining} more {day_word} before resurrection",
+        )
+    # Perform resurrection
+    pet.is_dead = False
+    pet.died_at = None
+    pet.cause_of_death = None
+    pet.grace_period_started = None
+    pet.stage = PetStage.EGG.value
+    pet.health = 60
+    pet.experience = 0
+    pet.mood = PetMood.CONTENT.value
+    pet.generation += 1
+    await session.commit()
+    await session.refresh(pet)
+    # Enqueue egg stage image generation for the new generation
+    try:
+        get_image_provider()
+        await image_queue.create_job(session, pet.id, PetStage.EGG.value)
+    except ValueError:
+        pass  # no valid provider configured, skip
+    return PetResponse.model_validate(pet)
 
 
 @router.get("/pets/{repo_owner}/{repo_name}/badge.svg", response_class=Response)

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -491,6 +491,7 @@ async def pet_profile(
             "repo_owner": repo_owner,
             "repo_name": repo_name,
             "base_url": settings.base_url,
+            "now_utc": now,
         },
         headers={"Cache-Control": "public, max-age=60"},
     )

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -93,6 +93,11 @@ class Pet(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Resurrection / generation tracking
+    generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -51,7 +51,12 @@
                             {% endif %}
                         </span>
                         <div>
-                            <div style="font-weight: 600; font-size: 1.05rem;">{{ pet.name }}</div>
+                            <div style="font-weight: 600; font-size: 1.05rem;">
+                                {{ pet.name }}
+                                {% if pet.generation > 1 %}
+                                <span style="display:inline-block; margin-left:0.4rem; font-size:0.65em; font-weight:600; background: linear-gradient(135deg, #b8860b, #ffd700); color:#1a1a1a; padding:0.15em 0.5em; border-radius:99px; vertical-align:middle; letter-spacing:0.03em;">Gen {{ pet.generation }}</span>
+                                {% endif %}
+                            </div>
                             <div style="color: var(--text-muted); font-size: 0.85rem;">{{ pet.repo_owner }}/{{ pet.repo_name }}</div>
                         </div>
                     </div>

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -88,7 +88,12 @@
                             {{ repo_owner }}/{{ repo_name }}
                         </a>
                     </div>
-                    <h1 class="profile-name">{{ pet.name }}</h1>
+                    <h1 class="profile-name">
+                        {{ pet.name }}
+                        {% if pet.generation > 1 %}
+                        <span style="display:inline-block; margin-left:0.5rem; font-size:0.55em; font-weight:600; background: linear-gradient(135deg, #b8860b, #ffd700); color:#1a1a1a; padding:0.2em 0.6em; border-radius:99px; vertical-align:middle; letter-spacing:0.03em;">Gen {{ pet.generation }}</span>
+                        {% endif %}
+                    </h1>
 
                     {% if pet.is_dead %}
                     <p class="profile-stage-label" style="color: #7f8c8d;">Deceased</p>
@@ -114,6 +119,33 @@
                         — {{ pet.created_at.year }}–{{ pet.died_at.year }}
                         {% endif %}
                     </p>
+
+                    {% if user and user.id == pet.user_id %}
+                    {# Resurrection section — only shown to the owner #}
+                    {% if pet.died_at %}
+                    {% set days_since_death = ((now_utc - pet.died_at).total_seconds() / 86400) | int %}
+                    {% set mourning_days = 7 %}
+                    {% set days_remaining = mourning_days - days_since_death %}
+                    <div id="resurrection-section" style="margin-top:1.5rem; padding:1.25rem; border-radius:12px; background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1);">
+                        {% if days_remaining > 0 %}
+                        <p style="color:#9e9e9e; font-size:0.95rem; margin-bottom:0.75rem;">Your pet must rest. Resurrection available in <strong style="color:#bdbdbd;">{{ days_remaining }} day{% if days_remaining != 1 %}s{% endif %}</strong>.</p>
+                        <div style="background:rgba(255,255,255,0.08); border-radius:4px; height:8px; overflow:hidden;">
+                            <div style="background: linear-gradient(90deg, #b8860b, #ffd700); height:100%; width:{{ [((days_since_death / mourning_days) * 100) | int, 100] | min }}%;"></div>
+                        </div>
+                        {% else %}
+                        <p style="color:rgba(255,255,255,0.75); font-size:0.95rem; margin-bottom:1rem;">The spirit stirs… Are you ready to bring <strong>{{ pet.name }}</strong> back?</p>
+                        <button
+                            id="resurrect-btn"
+                            style="background: linear-gradient(135deg, #b8860b, #ffd700); color:#1a1a1a; border:none; padding:0.6rem 1.5rem; border-radius:8px; font-size:1rem; font-weight:700; cursor:pointer; letter-spacing:0.02em;"
+                            onmouseover="this.style.opacity='0.85'"
+                            onmouseout="this.style.opacity='1'"
+                        >&#10024; Resurrect {{ pet.name }}</button>
+                        <p id="resurrect-error" style="color:#e53935; font-size:0.875rem; display:none; margin-top:0.5rem;"></p>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+                    {% endif %}
+
                     {% else %}
                     <p class="profile-stage-label">{{ pet.stage | capitalize }}</p>
 
@@ -440,6 +472,37 @@
                     feedFeedback.style.display = 'inline';
                     feedBtn.disabled = false;
                     setTimeout(() => { feedFeedback.style.display = 'none'; }, 4000);
+                }
+            });
+        }
+
+        // Resurrect button
+        const resurrectBtn = document.getElementById('resurrect-btn');
+        const resurrectError = document.getElementById('resurrect-error');
+        if (resurrectBtn) {
+            resurrectBtn.addEventListener('click', async () => {
+                resurrectBtn.disabled = true;
+                resurrectBtn.textContent = 'Resurrecting\u2026';
+                resurrectError.style.display = 'none';
+                try {
+                    const resp = await fetch(
+                        '/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/resurrect',
+                        { method: 'POST' }
+                    );
+                    if (!resp.ok) {
+                        const err = await resp.json().catch(() => ({}));
+                        resurrectError.textContent = err.detail || 'Resurrection failed.';
+                        resurrectError.style.display = 'block';
+                        resurrectBtn.disabled = false;
+                        resurrectBtn.innerHTML = '&#10024; Resurrect {{ pet.name }}';
+                        return;
+                    }
+                    window.location.reload();
+                } catch (e) {
+                    resurrectError.textContent = 'Network error, please try again.';
+                    resurrectError.style.display = 'block';
+                    resurrectBtn.disabled = false;
+                    resurrectBtn.innerHTML = '&#10024; Resurrect {{ pet.name }}';
                 }
             });
         }

--- a/tests/api/test_resurrect.py
+++ b/tests/api/test_resurrect.py
@@ -1,0 +1,319 @@
+"""Tests for the pet resurrection endpoint."""
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from github_tamagotchi.api.auth import _create_jwt, auth_router
+from github_tamagotchi.api.routes import router
+from github_tamagotchi.core.database import get_session
+from github_tamagotchi.models.pet import Base, PetMood, PetStage
+from github_tamagotchi.models.user import User
+from tests.conftest import get_test_session, test_engine, test_session_factory
+
+
+def create_resurrect_test_app() -> FastAPI:
+    """Create a test app with API and auth routes."""
+    app = FastAPI(title="Resurrect Test")
+    app.include_router(router)
+    app.include_router(auth_router)
+    app.dependency_overrides[get_session] = get_test_session
+    return app
+
+
+@pytest.fixture
+async def resurrect_client() -> AsyncIterator[AsyncClient]:
+    """AsyncClient with a fresh in-memory database (no auth)."""
+    app = create_resurrect_test_app()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        yield client
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture
+async def owner_client() -> AsyncIterator[tuple[AsyncClient, User]]:
+    """AsyncClient authenticated as the pet owner."""
+    app = create_resurrect_test_app()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with test_session_factory() as session:
+        user = User(
+            github_id=77001,
+            github_login="petowner",
+            github_avatar_url=None,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+    token = _create_jwt(user.id)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"session_token": token},
+    ) as client:
+        yield client, user
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture
+async def other_client() -> AsyncIterator[tuple[AsyncClient, User]]:
+    """AsyncClient authenticated as a different user (non-owner)."""
+    app = create_resurrect_test_app()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with test_session_factory() as session:
+        user = User(
+            github_id=77002,
+            github_login="nottheowner",
+            github_avatar_url=None,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+    token = _create_jwt(user.id)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"session_token": token},
+    ) as client:
+        yield client, user
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+async def _create_pet_for_user(
+    client: AsyncClient, owner: str = "owner", repo: str = "repo"
+) -> None:
+    """Helper: create a pet via API (no image provider)."""
+    with patch(
+        "github_tamagotchi.api.routes.get_image_provider",
+        side_effect=ValueError("no provider"),
+    ):
+        resp = await client.post(
+            "/api/v1/pets",
+            json={"repo_owner": owner, "repo_name": repo, "name": "GhostPet"},
+        )
+    assert resp.status_code == 201
+
+
+async def _mark_pet_dead(
+    died_at: datetime,
+    owner: str = "owner",
+    repo: str = "repo",
+) -> None:
+    """Helper: directly update a pet in the DB to be dead with given died_at."""
+    from sqlalchemy import update as sa_update
+
+    from github_tamagotchi.models.pet import Pet
+
+    async with test_session_factory() as session:
+        await session.execute(
+            sa_update(Pet)
+            .where(Pet.repo_owner == owner, Pet.repo_name == repo)
+            .values(
+                is_dead=True,
+                died_at=died_at,
+                cause_of_death="neglect",
+                health=0,
+            )
+        )
+        await session.commit()
+
+
+async def _assign_pet_owner(user_id: int, owner: str = "owner", repo: str = "repo") -> None:
+    """Helper: assign a pet to a specific user in the DB."""
+    from sqlalchemy import update as sa_update
+
+    from github_tamagotchi.models.pet import Pet
+
+    async with test_session_factory() as session:
+        await session.execute(
+            sa_update(Pet)
+            .where(Pet.repo_owner == owner, Pet.repo_name == repo)
+            .values(user_id=user_id)
+        )
+        await session.commit()
+
+
+class TestResurrectEndpoint:
+    """Tests for POST /api/v1/pets/{owner}/{repo}/resurrect."""
+
+    async def test_resurrect_requires_auth(self, resurrect_client: AsyncClient) -> None:
+        """Calling resurrect without auth should return 401."""
+        resp = await resurrect_client.post("/api/v1/pets/owner/repo/resurrect")
+        assert resp.status_code == 401
+
+    async def test_resurrect_living_pet_returns_400(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """Trying to resurrect a living pet should return 400."""
+        client, user = owner_client
+        await _create_pet_for_user(client)
+        await _assign_pet_owner(user.id)
+
+        resp = await client.post("/api/v1/pets/owner/repo/resurrect")
+        assert resp.status_code == 400
+        assert "not dead" in resp.json()["detail"]
+
+    async def test_resurrect_within_mourning_period_returns_400(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """Resurrecting within 7 days of death should return 400 with days remaining."""
+        client, user = owner_client
+        await _create_pet_for_user(client)
+        await _assign_pet_owner(user.id)
+
+        # Pet died 3 days ago — 4 days still remaining
+        died_at = datetime.now(UTC) - timedelta(days=3)
+        await _mark_pet_dead(died_at)
+
+        resp = await client.post("/api/v1/pets/owner/repo/resurrect")
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "must rest" in detail
+        assert "4" in detail  # 4 days remaining
+
+    async def test_resurrect_days_remaining_singular(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """When exactly 1 day remains the message should say 'day' not 'days'."""
+        client, user = owner_client
+        await _create_pet_for_user(client)
+        await _assign_pet_owner(user.id)
+
+        # Pet died 6 days ago — 1 day still remaining
+        died_at = datetime.now(UTC) - timedelta(days=6)
+        await _mark_pet_dead(died_at)
+
+        resp = await client.post("/api/v1/pets/owner/repo/resurrect")
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "1 more day before" in detail
+
+    async def test_resurrect_after_mourning_period_succeeds(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """Resurrecting after 7 days should succeed and reset pet state."""
+        client, user = owner_client
+        await _create_pet_for_user(client)
+        await _assign_pet_owner(user.id)
+
+        # Pet died 8 days ago — mourning period over
+        died_at = datetime.now(UTC) - timedelta(days=8)
+        await _mark_pet_dead(died_at)
+
+        with patch(
+            "github_tamagotchi.api.routes.get_image_provider",
+            side_effect=ValueError("no provider"),
+        ):
+            resp = await client.post("/api/v1/pets/owner/repo/resurrect")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_dead"] is False
+        assert data["died_at"] is None
+        assert data["cause_of_death"] is None
+        assert data["stage"] == PetStage.EGG.value
+        assert data["health"] == 60
+        assert data["experience"] == 0
+        assert data["mood"] == PetMood.CONTENT.value
+        assert data["generation"] == 2
+
+    async def test_resurrect_increments_generation(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """Each resurrection should increment the generation counter."""
+        client, user = owner_client
+        await _create_pet_for_user(client)
+        await _assign_pet_owner(user.id)
+
+        # Start from gen 1, die and resurrect
+        died_at = datetime.now(UTC) - timedelta(days=8)
+        await _mark_pet_dead(died_at)
+
+        with patch(
+            "github_tamagotchi.api.routes.get_image_provider",
+            side_effect=ValueError("no provider"),
+        ):
+            resp = await client.post("/api/v1/pets/owner/repo/resurrect")
+        assert resp.status_code == 200
+        assert resp.json()["generation"] == 2
+
+    async def test_resurrect_enqueues_image_job_when_provider_configured(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """On successful resurrection, an EGG-stage image job should be enqueued."""
+        client, user = owner_client
+        await _create_pet_for_user(client)
+        await _assign_pet_owner(user.id)
+
+        died_at = datetime.now(UTC) - timedelta(days=8)
+        await _mark_pet_dead(died_at)
+
+        mock_job = object()
+        with (
+            patch(
+                "github_tamagotchi.api.routes.get_image_provider",
+                return_value=object(),
+            ),
+            patch(
+                "github_tamagotchi.api.routes.image_queue.create_job",
+                new_callable=AsyncMock,
+                return_value=mock_job,
+            ) as mock_create_job,
+        ):
+            resp = await client.post("/api/v1/pets/owner/repo/resurrect")
+
+        assert resp.status_code == 200
+        mock_create_job.assert_called_once()
+        call_args = mock_create_job.call_args
+        # Third positional arg or kwarg should be the EGG stage
+        stage_arg = (
+            call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("stage")
+        )
+        assert stage_arg == PetStage.EGG.value
+
+    async def test_non_owner_cannot_resurrect(
+        self,
+        owner_client: tuple[AsyncClient, User],
+        other_client: tuple[AsyncClient, User],
+    ) -> None:
+        """A user who does not own the pet should receive 403."""
+        owner, owner_user = owner_client
+        stranger, _stranger_user = other_client
+
+        await _create_pet_for_user(owner)
+        await _assign_pet_owner(owner_user.id)
+
+        died_at = datetime.now(UTC) - timedelta(days=8)
+        await _mark_pet_dead(died_at)
+
+        resp = await stranger.post("/api/v1/pets/owner/repo/resurrect")
+        assert resp.status_code == 403
+        assert "do not own" in resp.json()["detail"]
+
+    async def test_resurrect_pet_not_found(
+        self, owner_client: tuple[AsyncClient, User]
+    ) -> None:
+        """Resurrecting a non-existent pet should return 404."""
+        client, _user = owner_client
+        resp = await client.post("/api/v1/pets/nobody/nopet/resurrect")
+        assert resp.status_code == 404

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -20,6 +20,11 @@ def make_pet(
     commit_streak: int = 0,
     longest_streak: int = 0,
     last_streak_date: datetime | None = None,
+    is_dead: bool = False,
+    died_at: datetime | None = None,
+    cause_of_death: str | None = None,
+    grace_period_started: datetime | None = None,
+    generation: int = 1,
 ) -> Pet:
     """Create a Pet instance with sensible defaults."""
     return Pet(
@@ -35,6 +40,11 @@ def make_pet(
         commit_streak=commit_streak,
         longest_streak=longest_streak,
         last_streak_date=last_streak_date,
+        is_dead=is_dead,
+        died_at=died_at,
+        cause_of_death=cause_of_death,
+        grace_period_started=grace_period_started,
+        generation=generation,
     )
 
 


### PR DESCRIPTION
## Summary

- Adds **mandatory 7-day mourning period** before resurrection is available after death
- `POST /api/v1/pets/{owner}/{repo}/resurrect` — auth-gated, owner-only endpoint with full validation
- **Grave page** shows countdown progress bar during mourning, then a golden "Resurrect" button when ready
- **Generation badge** (Gen 2, Gen 3…) shown on profile header and dashboard card
- On resurrection: stage resets to EGG, health to 60, XP to 0, generation increments, new EGG image enqueued
- Migration 013 adds `generation` column (default 1)

Note: built on top of the pet death mechanics branch (cd71081). Will need that merged first or rebased onto main.

Closes #36

## Test plan

- [ ] `test_resurrect_requires_auth` — 401 without session cookie
- [ ] `test_resurrect_living_pet_returns_400` — 400 if pet is alive
- [ ] `test_resurrect_within_mourning_period_returns_400` — 400 with days remaining in message
- [ ] `test_resurrect_days_remaining_singular` — "1 more day" (not "days")
- [ ] `test_resurrect_after_mourning_period_succeeds` — all fields reset, generation = 2
- [ ] `test_resurrect_increments_generation` — confirms Gen N increments
- [ ] `test_resurrect_enqueues_image_job_when_provider_configured` — EGG job created
- [ ] `test_non_owner_cannot_resurrect` — 403
- [ ] `test_resurrect_pet_not_found` — 404