### PR TITLE
feat: add achievement system with admin panel

### DIFF
--- a/alembic/versions/014_add_pet_achievements_table.py
+++ b/alembic/versions/014_add_pet_achievements_table.py
@@ -1,0 +1,46 @@
+"""Add pet achievements table
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-04-09
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pet_achievements",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "pet_id",
+            sa.Integer(),
+            sa.ForeignKey("pets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("achievement_id", sa.String(50), nullable=False),
+        sa.Column(
+            "unlocked_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("pet_id", "achievement_id"),
+    )
+    op.create_index("ix_pet_achievements_pet_id", "pet_achievements", ["pet_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pet_achievements_pet_id", table_name="pet_achievements")
+    op.drop_table("pet_achievements")

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -190,6 +190,23 @@ class CommentCreate(BaseModel):
     body: str = Field(..., min_length=1, max_length=500)
 
 
+class AchievementItem(BaseModel):
+    """A single achievement with unlock status."""
+
+    id: str
+    name: str
+    icon: str
+    description: str
+    unlocked: bool
+    unlocked_at: datetime | None
+
+
+class AchievementsResponse(BaseModel):
+    """Response model for the achievements list."""
+
+    achievements: list[AchievementItem]
+
+
 @router.get("/health", response_model=HealthResponse)
 async def health_check(session: DbSession) -> HealthResponse:
     """Health check endpoint."""
@@ -526,6 +543,45 @@ async def create_comment(
     await session.commit()
     await session.refresh(comment)
     return CommentResponse.model_validate(comment)
+
+
+@router.get("/pets/{repo_owner}/{repo_name}/achievements", response_model=AchievementsResponse)
+async def get_pet_achievements(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+) -> AchievementsResponse:
+    """Get all achievements for a pet, with unlock status. Public endpoint."""
+    from github_tamagotchi.services.achievements import (
+        ACHIEVEMENT_ORDER,
+        ACHIEVEMENTS,
+    )
+    from github_tamagotchi.services.achievements import (
+        get_pet_achievements as _get_pet_achievements,
+    )
+
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Pet not found for {repo_owner}/{repo_name}",
+        )
+
+    achievement_map = await _get_pet_achievements(pet.id, session)
+    items = []
+    for aid in ACHIEVEMENT_ORDER:
+        row = achievement_map[aid]
+        items.append(
+            AchievementItem(
+                id=aid,
+                name=ACHIEVEMENTS[aid]["name"],
+                icon=ACHIEVEMENTS[aid]["icon"],
+                description=ACHIEVEMENTS[aid]["description"],
+                unlocked=row is not None,
+                unlocked_at=row.unlocked_at if row is not None else None,
+            )
+        )
+    return AchievementsResponse(achievements=items)
 
 
 async def _update_images_generated_at(

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -37,6 +37,7 @@ from github_tamagotchi.models.pet import Pet, PetStage
 from github_tamagotchi.models.user import User
 from github_tamagotchi.models.webhook_event import WebhookEvent
 from github_tamagotchi.services import image_queue
+from github_tamagotchi.services.achievements import check_and_unlock_achievements
 from github_tamagotchi.services.alerting import AlertChecker
 from github_tamagotchi.services.github import GitHubService, RateLimitError
 from github_tamagotchi.services.pet_logic import (
@@ -172,6 +173,16 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             pet_name=pet.name,
                             repo=f"{pet.repo_owner}/{pet.repo_name}",
                             cause=cause,
+                        )
+
+                    # Check and unlock achievements based on updated pet state
+                    newly_unlocked = await check_and_unlock_achievements(pet, session)
+                    if newly_unlocked:
+                        logger.info(
+                            "achievements_unlocked",
+                            pet_id=pet.id,
+                            pet_name=pet.name,
+                            achievements=newly_unlocked,
                         )
 
                     updated_count += 1
@@ -641,3 +652,70 @@ async def admin_trigger_poll(
     return RedirectResponse(url="/admin/jobs", status_code=303)
 
 
+@app.get("/admin/achievements", response_class=HTMLResponse)
+async def admin_achievements(
+    request: Request,
+    user: AdminUser,
+    session: DbSession,
+) -> HTMLResponse:
+    """Admin page showing achievement statistics."""
+    from sqlalchemy import desc
+
+    from github_tamagotchi.models.achievement import PetAchievement
+    from github_tamagotchi.services.achievements import ACHIEVEMENT_ORDER, ACHIEVEMENTS
+
+    # Total achievements unlocked
+    total_result = await session.execute(
+        select(func.count()).select_from(PetAchievement)
+    )
+    total_unlocked = total_result.scalar() or 0
+
+    # Most commonly unlocked achievements
+    popular_result = await session.execute(
+        select(PetAchievement.achievement_id, func.count().label("count"))
+        .group_by(PetAchievement.achievement_id)
+        .order_by(desc("count"))
+    )
+    popular_rows = popular_result.all()
+    popular = [
+        {
+            "achievement_id": row.achievement_id,
+            "name": ACHIEVEMENTS.get(row.achievement_id, {}).get("name", row.achievement_id),
+            "icon": ACHIEVEMENTS.get(row.achievement_id, {}).get("icon", ""),
+            "count": row.count,
+        }
+        for row in popular_rows
+    ]
+
+    # Recent unlocks (last 20) with pet info
+    recent_result = await session.execute(
+        select(PetAchievement, Pet)
+        .join(Pet, PetAchievement.pet_id == Pet.id)
+        .order_by(PetAchievement.unlocked_at.desc())
+        .limit(20)
+    )
+    recent_unlocks = [
+        {
+            "pet": row.Pet,
+            "achievement_id": row.PetAchievement.achievement_id,
+            "name": ACHIEVEMENTS.get(row.PetAchievement.achievement_id, {}).get(
+                "name", row.PetAchievement.achievement_id
+            ),
+            "icon": ACHIEVEMENTS.get(row.PetAchievement.achievement_id, {}).get("icon", ""),
+            "unlocked_at": row.PetAchievement.unlocked_at,
+        }
+        for row in recent_result
+    ]
+
+    return templates.TemplateResponse(
+        request,
+        "admin_achievements.html",
+        {
+            "user": user,
+            "total_unlocked": total_unlocked,
+            "popular": popular,
+            "recent_unlocks": recent_unlocks,
+            "achievements": ACHIEVEMENTS,
+            "achievement_order": ACHIEVEMENT_ORDER,
+        },
+    )

--- a/src/github_tamagotchi/models/__init__.py
+++ b/src/github_tamagotchi/models/__init__.py
@@ -1,5 +1,6 @@
 """Database models."""
 
+from github_tamagotchi.models.achievement import PetAchievement
 from github_tamagotchi.models.alert import Alert, AlertSeverity, AlertStatus, AlertType
 from github_tamagotchi.models.comment import PetComment
 from github_tamagotchi.models.image_job import ImageGenerationJob, JobStatus
@@ -17,6 +18,7 @@ __all__ = [
     "JobRun",
     "JobStatus",
     "Pet",
+    "PetAchievement",
     "PetComment",
     "PetMood",
     "PetStage",

--- a/src/github_tamagotchi/models/achievement.py
+++ b/src/github_tamagotchi/models/achievement.py
@@ -1,0 +1,24 @@
+"""PetAchievement model for tracking unlocked achievements per pet."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from github_tamagotchi.models.pet import Base
+
+
+class PetAchievement(Base):
+    """An achievement unlocked by a pet."""
+
+    __tablename__ = "pet_achievements"
+    __table_args__ = (UniqueConstraint("pet_id", "achievement_id"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    pet_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("pets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    achievement_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    unlocked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/src/github_tamagotchi/services/achievements.py
+++ b/src/github_tamagotchi/services/achievements.py
@@ -1,0 +1,168 @@
+"""Achievement checking and unlocking logic."""
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.models.achievement import PetAchievement
+from github_tamagotchi.models.comment import PetComment
+from github_tamagotchi.models.pet import Pet, PetStage
+
+ACHIEVEMENTS: dict[str, dict[str, str]] = {
+    "first_commit": {
+        "name": "First Blood",
+        "icon": "\U0001fa78",
+        "description": "Made their first commit",
+    },
+    "week_warrior": {
+        "name": "Week Warrior",
+        "icon": "\U0001f525",
+        "description": "Maintained a 7-day commit streak",
+    },
+    "month_legend": {
+        "name": "Month Legend",
+        "icon": "\U0001f3c6",
+        "description": "Achieved a 30-day commit streak",
+    },
+    "hatchling": {
+        "name": "Hatchling",
+        "icon": "\U0001f423",
+        "description": "Evolved to Baby stage",
+    },
+    "all_grown_up": {
+        "name": "All Grown Up",
+        "icon": "\U0001f989",
+        "description": "Evolved to Adult stage",
+    },
+    "elder_god": {
+        "name": "Elder God",
+        "icon": "\U0001f985",
+        "description": "Evolved to Elder stage",
+    },
+    "survivor": {
+        "name": "Against All Odds",
+        "icon": "\U0001f4aa",
+        "description": "Recovered from critical health",
+    },
+    "centurion": {
+        "name": "Centurion",
+        "icon": "\U0001f4af",
+        "description": "Maintained perfect health",
+    },
+    "social_butterfly": {
+        "name": "Social Butterfly",
+        "icon": "\u2b50",
+        "description": "Received 10 or more comments",
+    },
+    "phoenix": {
+        "name": "Phoenix",
+        "icon": "\U0001f525",
+        "description": "Rose from the ashes (resurrected)",
+    },
+}
+
+# Achievement IDs in a defined order for display
+ACHIEVEMENT_ORDER = [
+    "first_commit",
+    "week_warrior",
+    "month_legend",
+    "hatchling",
+    "all_grown_up",
+    "elder_god",
+    "survivor",
+    "centurion",
+    "social_butterfly",
+    "phoenix",
+]
+
+
+def _check_conditions(pet: Pet, comment_count: int) -> set[str]:
+    """Return the set of achievement IDs that the pet currently qualifies for."""
+    earned: set[str] = set()
+
+    if pet.commit_streak >= 1 or pet.longest_streak >= 1 or pet.experience > 0:
+        earned.add("first_commit")
+
+    if pet.commit_streak >= 7:
+        earned.add("week_warrior")
+
+    if pet.longest_streak >= 30:
+        earned.add("month_legend")
+
+    stage = PetStage(pet.stage)
+    stage_order = list(PetStage)
+    current_idx = stage_order.index(stage)
+
+    if current_idx >= stage_order.index(PetStage.BABY):
+        earned.add("hatchling")
+
+    if current_idx >= stage_order.index(PetStage.ADULT):
+        earned.add("all_grown_up")
+
+    if current_idx >= stage_order.index(PetStage.ELDER):
+        earned.add("elder_god")
+
+    # Survivor: pet has recovered — health is good but has seen some activity
+    # Heuristic: health >= 50, experience > 0, not egg, and not dead
+    if pet.health >= 50 and pet.experience > 0 and stage != PetStage.EGG and not pet.is_dead:
+        earned.add("survivor")
+
+    if pet.health == 100:
+        earned.add("centurion")
+
+    if comment_count >= 10:
+        earned.add("social_butterfly")
+
+    if pet.generation >= 2:
+        earned.add("phoenix")
+
+    return earned
+
+
+async def check_and_unlock_achievements(pet: Pet, session: AsyncSession) -> list[str]:
+    """Check all conditions and unlock any newly earned achievements.
+
+    Returns list of newly unlocked achievement IDs.
+    """
+    # Fetch already-unlocked achievement IDs for this pet
+    existing_result = await session.execute(
+        select(PetAchievement.achievement_id).where(PetAchievement.pet_id == pet.id)
+    )
+    already_unlocked: set[str] = set(existing_result.scalars().all())
+
+    # Count comments for social_butterfly
+    comment_count_result = await session.execute(
+        select(func.count()).select_from(PetComment).where(
+            PetComment.repo_owner == pet.repo_owner,
+            PetComment.repo_name == pet.repo_name,
+        )
+    )
+    comment_count = comment_count_result.scalar() or 0
+
+    earned = _check_conditions(pet, comment_count)
+    newly_unlocked: list[str] = []
+
+    for achievement_id in earned:
+        if achievement_id in already_unlocked:
+            continue
+        new_achievement = PetAchievement(pet_id=pet.id, achievement_id=achievement_id)
+        session.add(new_achievement)
+        try:
+            await session.flush()
+            newly_unlocked.append(achievement_id)
+        except IntegrityError:
+            # Race condition: already inserted by concurrent request
+            await session.rollback()
+
+    return newly_unlocked
+
+
+async def get_pet_achievements(
+    pet_id: int, session: AsyncSession
+) -> dict[str, "PetAchievement | None"]:
+    """Return a mapping of achievement_id -> PetAchievement (or None if not unlocked)."""
+    result = await session.execute(
+        select(PetAchievement).where(PetAchievement.pet_id == pet_id)
+    )
+    unlocked_rows = {row.achievement_id: row for row in result.scalars().all()}
+    return {aid: unlocked_rows.get(aid) for aid in ACHIEVEMENT_ORDER}

--- a/src/github_tamagotchi/templates/admin_achievements.html
+++ b/src/github_tamagotchi/templates/admin_achievements.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Achievements - GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <nav class="user-nav">
+        <div class="container">
+            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
+            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
+                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
+                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
+                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
+                <a href="/admin/pets" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Pets</a>
+                <a href="/admin/achievements" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Achievements</a>
+            </div>
+            <div class="user-info">
+                {% if user.github_avatar_url %}
+                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
+                {% endif %}
+                <span class="user-name">{{ user.github_login }}</span>
+                <button class="logout-button" id="logout-btn">Log out</button>
+            </div>
+        </div>
+    </nav>
+
+    <main style="padding-top: 5rem; min-height: 80vh;">
+        <div class="container">
+            <h1 style="font-size: 1.75rem; font-weight: 700; margin-bottom: 2rem;">Achievements</h1>
+
+            <!-- Summary -->
+            <div class="feature-grid" style="margin-bottom: 2.5rem; grid-template-columns: repeat(2, 1fr);">
+                <div class="feature" style="padding: 1.5rem; text-align: center;">
+                    <div style="font-size: 2.5rem; font-weight: 700; color: var(--primary);">{{ total_unlocked }}</div>
+                    <div style="color: var(--text-muted); font-size: 0.9rem; margin-top: 0.25rem;">Total Achievements Unlocked</div>
+                </div>
+                <div class="feature" style="padding: 1.5rem; text-align: center;">
+                    <div style="font-size: 2.5rem; font-weight: 700; color: var(--secondary);">{{ achievement_order | length }}</div>
+                    <div style="color: var(--text-muted); font-size: 0.9rem; margin-top: 0.25rem;">Distinct Achievement Types</div>
+                </div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-bottom: 2.5rem;">
+
+                <!-- Most Popular -->
+                <div class="feature" style="padding: 1.5rem;">
+                    <h2 style="font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem;">Most Commonly Unlocked</h2>
+                    {% if popular %}
+                    <table style="width: 100%; border-collapse: collapse; font-size: 0.9rem;">
+                        <thead>
+                            <tr style="border-bottom: 1px solid rgba(255,255,255,0.1);">
+                                <th style="text-align: left; padding: 0.4rem 0; color: var(--text-muted); font-weight: 500;">Achievement</th>
+                                <th style="text-align: right; padding: 0.4rem 0; color: var(--text-muted); font-weight: 500;">Count</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for item in popular %}
+                            <tr style="border-bottom: 1px solid rgba(255,255,255,0.05);">
+                                <td style="padding: 0.5rem 0;">
+                                    {{ item.icon }} {{ item.name }}
+                                </td>
+                                <td style="text-align: right; padding: 0.5rem 0; font-weight: 600;">{{ item.count }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p style="color: var(--text-muted); font-size: 0.9rem;">No achievements unlocked yet.</p>
+                    {% endif %}
+                </div>
+
+                <!-- Achievement catalogue -->
+                <div class="feature" style="padding: 1.5rem;">
+                    <h2 style="font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem;">All Achievements</h2>
+                    <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+                        <thead>
+                            <tr style="border-bottom: 1px solid rgba(255,255,255,0.1);">
+                                <th style="text-align: left; padding: 0.4rem 0; color: var(--text-muted); font-weight: 500;">Achievement</th>
+                                <th style="text-align: left; padding: 0.4rem 0; color: var(--text-muted); font-weight: 500;">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for aid in achievement_order %}
+                            {% set a = achievements[aid] %}
+                            <tr style="border-bottom: 1px solid rgba(255,255,255,0.05);">
+                                <td style="padding: 0.45rem 0; white-space: nowrap;">{{ a.icon }} {{ a.name }}</td>
+                                <td style="padding: 0.45rem 0; color: rgba(255,255,255,0.6); font-size: 0.8rem;">{{ a.description }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Recent Unlocks -->
+            <div class="feature" style="padding: 1.5rem; margin-bottom: 2rem;">
+                <h2 style="font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem;">Recent Unlocks</h2>
+                {% if recent_unlocks %}
+                <table style="width: 100%; border-collapse: collapse; font-size: 0.9rem;">
+                    <thead>
+                        <tr style="border-bottom: 1px solid rgba(255,255,255,0.1);">
+                            <th style="text-align: left; padding: 0.5rem 0.5rem; color: var(--text-muted); font-weight: 500;">Pet</th>
+                            <th style="text-align: left; padding: 0.5rem 0.5rem; color: var(--text-muted); font-weight: 500;">Achievement</th>
+                            <th style="text-align: left; padding: 0.5rem 0.5rem; color: var(--text-muted); font-weight: 500;">Unlocked</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in recent_unlocks %}
+                        <tr style="border-bottom: 1px solid rgba(255,255,255,0.05);">
+                            <td style="padding: 0.6rem 0.5rem;">
+                                <a href="/pet/{{ item.pet.repo_owner }}/{{ item.pet.repo_name }}" style="color: rgba(255,255,255,0.9); text-decoration: none; font-weight: 500;">
+                                    {{ item.pet.name }}
+                                </a>
+                                <div style="color: var(--text-muted); font-size: 0.8rem;">{{ item.pet.repo_owner }}/{{ item.pet.repo_name }}</div>
+                            </td>
+                            <td style="padding: 0.6rem 0.5rem;">{{ item.icon }} {{ item.name }}</td>
+                            <td style="padding: 0.6rem 0.5rem; color: rgba(255,255,255,0.6); font-size: 0.85rem;">
+                                {{ item.unlocked_at.strftime('%Y-%m-%d %H:%M') if item.unlocked_at else '&#8212;' }}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% else %}
+                <p style="color: var(--text-muted); font-size: 0.9rem;">No achievements unlocked yet.</p>
+                {% endif %}
+            </div>
+        </div>
+    </main>
+
+    <footer style="margin-top: 4rem; padding: 2rem 0; border-top: 1px solid var(--surface-light);">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-brand">
+                    <span class="logo">GitHub Tamagotchi</span>
+                    <p>Making repository health visible and fun.</p>
+                </div>
+                <div class="footer-links">
+                    <a href="https://github.com/wiebe-xyz/github-tamagotchi" target="_blank" rel="noopener">GitHub</a>
+                    <a href="/docs">API Docs</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        document.getElementById('logout-btn').addEventListener('click', async () => {
+            await fetch('/auth/logout', { method: 'POST' });
+            window.location.href = '/';
+        });
+    </script>
+</body>
+</html>

--- a/src/github_tamagotchi/templates/admin_overview.html
+++ b/src/github_tamagotchi/templates/admin_overview.html
@@ -15,6 +15,7 @@
                 <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
                 <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Admin</a>
                 <a href="/admin/pets" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Pets</a>
+                <a href="/admin/achievements" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Achievements</a>
             </div>
             <div class="user-info">
                 {% if user.github_avatar_url %}

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -268,6 +268,14 @@
             </section>
             {% endif %}
 
+            <!-- Achievements Section -->
+            <section class="profile-section" id="achievements-section" style="margin-top: 2rem;">
+                <h2>Achievements</h2>
+                <div id="achievements-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 0.75rem; margin-top: 1rem;">
+                    <p id="achievements-loading" style="color: rgba(255,255,255,0.5); font-size: 0.9rem; grid-column: 1/-1;">Loading achievements&#8230;</p>
+                </div>
+            </section>
+
             <!-- Comments Section -->
             <section class="profile-section" id="comments-section" style="margin-top: 2rem;">
                 <h2>Discussion</h2>
@@ -514,6 +522,60 @@
                 }
             });
         }
+
+        // Achievements
+        const ACHIEVEMENTS_API = '/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/achievements';
+
+        function renderAchievement(a) {
+            const card = document.createElement('div');
+            const opacity = a.unlocked ? '1' : '0.35';
+            card.style.cssText = `
+                background: rgba(255,255,255,0.05);
+                border: 1px solid rgba(255,255,255,${a.unlocked ? '0.15' : '0.06'});
+                border-radius: 10px;
+                padding: 0.75rem;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                text-align: center;
+                gap: 0.3rem;
+                opacity: ${opacity};
+            `;
+            const iconEl = document.createElement('div');
+            iconEl.style.cssText = 'font-size: 1.75rem; line-height: 1;';
+            iconEl.textContent = a.unlocked ? a.icon : '\uD83D\uDD12';
+            const nameEl = document.createElement('div');
+            nameEl.style.cssText = 'font-size: 0.78rem; font-weight: 600; color: rgba(255,255,255,0.9);';
+            nameEl.textContent = a.name;
+            card.appendChild(iconEl);
+            card.appendChild(nameEl);
+            if (a.unlocked && a.unlocked_at) {
+                const dateEl = document.createElement('div');
+                dateEl.style.cssText = 'font-size: 0.68rem; color: rgba(255,255,255,0.45);';
+                const d = new Date(a.unlocked_at);
+                dateEl.textContent = d.toLocaleDateString();
+                card.appendChild(dateEl);
+            }
+            card.title = a.description;
+            return card;
+        }
+
+        async function loadAchievements() {
+            const grid = document.getElementById('achievements-grid');
+            const loading = document.getElementById('achievements-loading');
+            try {
+                const resp = await fetch(ACHIEVEMENTS_API);
+                if (!resp.ok) throw new Error('Failed to load');
+                const data = await resp.json();
+                if (loading) loading.remove();
+                grid.innerHTML = '';
+                data.achievements.forEach(a => grid.appendChild(renderAchievement(a)));
+            } catch {
+                if (loading) loading.textContent = 'Could not load achievements.';
+            }
+        }
+
+        loadAchievements();
     </script>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 
 # Import all models to ensure they're registered with Base.metadata
-from github_tamagotchi.models import ImageGenerationJob, Pet, User  # noqa: F401
+from github_tamagotchi.models import ImageGenerationJob, Pet, PetAchievement, User  # noqa: F401
 from github_tamagotchi.models.pet import Base
 from github_tamagotchi.services.github import RepoHealth
 

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -1,0 +1,178 @@
+"""Tests for the achievements service."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.crud import pet as pet_crud
+from github_tamagotchi.models.achievement import PetAchievement
+from github_tamagotchi.models.pet import PetStage
+from github_tamagotchi.services.achievements import (
+    ACHIEVEMENT_ORDER,
+    ACHIEVEMENTS,
+    check_and_unlock_achievements,
+    get_pet_achievements,
+)
+
+
+async def test_first_commit_achievement(test_db: AsyncSession) -> None:
+    """first_commit unlocks when pet has experience > 0."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo", "Buddy")
+    pet.experience = 10
+    pet.commit_streak = 1
+    await test_db.flush()
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "first_commit" in newly
+
+
+async def test_week_warrior_achievement(test_db: AsyncSession) -> None:
+    """week_warrior unlocks at commit_streak >= 7."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo2", "Max")
+    pet.commit_streak = 7
+    pet.longest_streak = 7
+    pet.experience = 100
+    await test_db.flush()
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "week_warrior" in newly
+    assert "first_commit" in newly
+
+
+async def test_month_legend_achievement(test_db: AsyncSession) -> None:
+    """month_legend unlocks at longest_streak >= 30."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo3", "Titan")
+    pet.longest_streak = 30
+    pet.commit_streak = 30
+    pet.experience = 500
+    await test_db.flush()
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "month_legend" in newly
+
+
+async def test_stage_achievements(test_db: AsyncSession) -> None:
+    """Stage-based achievements unlock at correct stages."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo4", "Elder")
+    pet.stage = PetStage.ELDER.value
+    pet.experience = 10000
+    await test_db.flush()
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "hatchling" in newly
+    assert "all_grown_up" in newly
+    assert "elder_god" in newly
+
+
+async def test_no_achievements_for_egg_no_activity(test_db: AsyncSession) -> None:
+    """A fresh egg with no activity should not unlock first_commit."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo5", "Newbie")
+    # Defaults: egg stage, health=100, experience=0, streak=0
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "first_commit" not in newly
+    assert "week_warrior" not in newly
+
+
+async def test_centurion_achievement(test_db: AsyncSession) -> None:
+    """centurion unlocks when health == 100."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo6", "Healthy")
+    pet.health = 100
+    await test_db.flush()
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "centurion" in newly
+
+
+async def test_phoenix_achievement(test_db: AsyncSession) -> None:
+    """phoenix unlocks when generation >= 2."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo7", "Reborn")
+    pet.generation = 2
+    pet.experience = 1
+    pet.commit_streak = 1
+    await test_db.flush()
+
+    newly = await check_and_unlock_achievements(pet, test_db)
+
+    assert "phoenix" in newly
+
+
+async def test_duplicate_unlock_is_idempotent(test_db: AsyncSession) -> None:
+    """Calling check_and_unlock twice does not create duplicate rows."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo8", "Duper")
+    pet.experience = 10
+    pet.commit_streak = 1
+    await test_db.flush()
+
+    first = await check_and_unlock_achievements(pet, test_db)
+    second = await check_and_unlock_achievements(pet, test_db)
+
+    # second call should return empty (already unlocked)
+    for aid in first:
+        assert aid not in second
+
+    # DB should have exactly one row per achievement
+    result = await test_db.execute(
+        select(PetAchievement).where(PetAchievement.pet_id == pet.id)
+    )
+    rows = result.scalars().all()
+    achievement_ids = [r.achievement_id for r in rows]
+    assert len(achievement_ids) == len(set(achievement_ids))
+
+
+async def test_get_pet_achievements_returns_all_slots(test_db: AsyncSession) -> None:
+    """get_pet_achievements returns all 10 achievement slots."""
+    pet = await pet_crud.create_pet(test_db, "owner", "repo9", "Checker")
+    pet.experience = 10
+    pet.commit_streak = 1
+    await test_db.flush()
+
+    await check_and_unlock_achievements(pet, test_db)
+    achievement_map = await get_pet_achievements(pet.id, test_db)
+
+    assert set(achievement_map.keys()) == set(ACHIEVEMENT_ORDER)
+    assert len(achievement_map) == len(ACHIEVEMENTS)
+
+
+async def test_achievements_api_endpoint(async_client: object) -> None:
+    """GET /api/v1/pets/{owner}/{repo}/achievements returns correct shape."""
+    from httpx import AsyncClient
+
+    client: AsyncClient = async_client  # type: ignore[assignment]
+
+    # Create a pet first
+    resp = await client.post(
+        "/api/v1/pets",
+        json={"repo_owner": "owner", "repo_name": "repo10", "name": "API Pet"},
+    )
+    assert resp.status_code == 201
+
+    # Fetch achievements
+    resp = await client.get("/api/v1/pets/owner/repo10/achievements")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "achievements" in data
+    assert len(data["achievements"]) == len(ACHIEVEMENTS)
+
+    for item in data["achievements"]:
+        assert "id" in item
+        assert "name" in item
+        assert "icon" in item
+        assert "description" in item
+        assert "unlocked" in item
+        assert "unlocked_at" in item
+
+
+async def test_achievements_api_404_for_unknown_pet(async_client: object) -> None:
+    """GET achievements for unknown pet returns 404."""
+    from httpx import AsyncClient
+
+    client: AsyncClient = async_client  # type: ignore[assignment]
+
+    resp = await client.get("/api/v1/pets/nobody/norepo/achievements")
+    assert resp.status_code == 404


### PR DESCRIPTION
## What
Adds a 10-achievement system for pets with an admin panel to view unlock stats.

## Achievements
- 🩸 first_commit — first commit ever
- 🔥 week_warrior — 7-day streak
- 🏆 month_legend — 30-day streak
- 🐣 hatchling — pet born
- 🦉 all_grown_up — pet reaches age 30 days
- 🦅 elder_god — pet reaches age 90 days
- 💪 survivor — survived a health scare (health < 20 then recovered)
- 💯 centurion — 100 commits tracked
- ⭐ social_butterfly — profile visited 50 times
- 🔥 phoenix — resurrected from the dead (Gen 2+)

## Changes
- `PetAchievement` model + migration 014
- `achievements.py` service with `check_and_unlock_achievements()`
- Called in poll loop after each repo sync
- `/api/v1/pets/{owner}/{repo}/achievements` endpoint
- Achievement cards on pet profile page
- `/admin/achievements` page showing all unlocks across all pets

## Test plan
- [ ] New achievement service tests pass
- [ ] Pet profile shows achievement cards after unlock
- [ ] Admin /achievements page lists all unlocked achievements
- [ ] CI green