### PR TITLE
feat: add release frequency and contributor count to health metrics

### DIFF
--- a/alembic/versions/015_add_release_and_contributor_counts.py
+++ b/alembic/versions/015_add_release_and_contributor_counts.py
@@ -1,0 +1,45 @@
+"""Add last_release_count and last_contributor_count to pets
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-04-09
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "015"
+down_revision: str | None = "014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "last_release_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "pets",
+        sa.Column(
+            "last_contributor_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "last_contributor_count")
+    op.drop_column("pets", "last_release_count")

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -144,6 +144,10 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             experience=new_experience,
                         )
 
+                    # Store last-known release and contributor snapshots
+                    pet.last_release_count = health.release_count_30d
+                    pet.last_contributor_count = health.contributor_count
+
                     # Update last_fed_at if there was a recent commit
                     if health.last_commit_at:
                         hours_since_commit = (
@@ -635,3 +639,5 @@ async def admin_trigger_poll(
     triggered_by = f"manual:{user.github_login}"
     background_tasks.add_task(poll_repositories, triggered_by=triggered_by)
     return RedirectResponse(url="/admin/jobs", status_code=303)
+
+

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -98,6 +98,14 @@ class Pet(Base):
         Integer, nullable=False, default=1, server_default="1"
     )
 
+    # Last-known health metric snapshots
+    last_release_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    last_contributor_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -1,7 +1,7 @@
 """GitHub API service for repository health metrics."""
 
-from dataclasses import dataclass
-from datetime import UTC, datetime
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
@@ -31,6 +31,8 @@ class RepoHealth:
     oldest_issue_age_days: float | None
     last_ci_success: bool | None
     has_stale_dependencies: bool
+    release_count_30d: int = field(default=0)
+    contributor_count: int = field(default=0)
 
 
 class GitHubService:
@@ -81,6 +83,12 @@ class GitHubService:
             # Get CI status
             last_ci_success = await self._get_ci_status(client, owner, repo)
 
+            # Get release frequency (last 30 days)
+            release_count_30d = await self._get_release_count_30d(client, owner, repo)
+
+            # Get contributor count (last 90 days)
+            contributor_count = await self._get_contributor_count_90d(client, owner, repo)
+
             return RepoHealth(
                 last_commit_at=last_commit_at,
                 open_prs_count=open_prs_count,
@@ -89,6 +97,8 @@ class GitHubService:
                 oldest_issue_age_days=oldest_issue_age,
                 last_ci_success=last_ci_success,
                 has_stale_dependencies=False,  # TODO: Check dependabot
+                release_count_30d=release_count_30d,
+                contributor_count=contributor_count,
             )
 
     async def _get_last_commit(
@@ -192,6 +202,61 @@ class GitHubService:
     def _get_oldest_age_days(self, items: list[dict[str, Any]]) -> float:
         """Get age in days of the oldest item."""
         return self._get_oldest_age_hours(items) / 24
+
+    async def _get_release_count_30d(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> int:
+        """Get the number of releases published in the last 30 days (capped at 10)."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/releases",
+                headers=self._get_headers(),
+                params={"per_page": 100},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            releases: list[dict[str, Any]] = resp.json()
+            cutoff = datetime.now(UTC) - timedelta(days=30)
+            count = sum(
+                1
+                for r in releases
+                if r.get("published_at")
+                and datetime.fromisoformat(
+                    r["published_at"].replace("Z", "+00:00")
+                ) >= cutoff
+            )
+            return min(count, 10)
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get releases", error=str(e))
+        return 0
+
+    async def _get_contributor_count_90d(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> int:
+        """Get the number of unique commit authors in the last 90 days (capped at 20)."""
+        try:
+            since = (datetime.now(UTC) - timedelta(days=90)).isoformat()
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"since": since, "per_page": 100},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            authors = {
+                c["author"]["login"]
+                for c in commits
+                if c.get("author") and c["author"].get("login")
+            }
+            return min(len(authors), 20)
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get contributor count", error=str(e))
+        return 0
 
     async def list_user_repos(
         self, page: int = 1, per_page: int = 100

--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -70,6 +70,12 @@ def calculate_health_delta(health: RepoHealth) -> int:
         if hours_since_commit < 24:
             delta += 10  # Recent commit = feeding
 
+    # Release frequency bonus: +2 per release in last 30d, capped at +10
+    delta += min(health.release_count_30d * 2, 10)
+
+    # Contributor count bonus: +1 per unique contributor in last 90d, capped at +8
+    delta += min(health.contributor_count, 8)
+
     # Negative effects
     if health.has_stale_dependencies:
         delta -= 10

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -169,6 +169,14 @@
                             <div class="stat-label">Age</div>
                             <div class="stat-value">{{ age_days }} day{% if age_days != 1 %}s{% endif %}</div>
                         </div>
+                        <div class="stat-card">
+                            <div class="stat-label">&#128640; Releases (30d)</div>
+                            <div class="stat-value">{{ pet.last_release_count }}</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-label">&#128101; Contributors</div>
+                            <div class="stat-value">{{ pet.last_contributor_count }}</div>
+                        </div>
                     </div>
 
                     <!-- Commit Streak -->

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -425,6 +425,9 @@ class TestGetRepoHealth:
             return_value=httpx.Response(500)
         )
         respx.get("https://api.github.com/repos/owner/repo").mock(return_value=httpx.Response(500))
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(500)
+        )
 
         service = GitHubService(token="test")
         result = await service.get_repo_health("owner", "repo")
@@ -434,3 +437,129 @@ class TestGetRepoHealth:
         assert result.open_prs_count == 0
         assert result.open_issues_count == 0
         assert result.last_ci_success is None
+        assert result.release_count_30d == 0
+        assert result.contributor_count == 0
+
+
+class TestGetReleaseCount30d:
+    """Tests for fetching release count in last 30 days."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_counts_recent_releases(self) -> None:
+        """Should count only releases published in the last 30 days."""
+        from datetime import UTC, datetime, timedelta
+
+        now = datetime.now(UTC)
+        releases = [
+            {"published_at": (now - timedelta(days=5)).isoformat()},   # within 30d
+            {"published_at": (now - timedelta(days=15)).isoformat()},  # within 30d
+            {"published_at": (now - timedelta(days=40)).isoformat()},  # older than 30d
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(200, json=releases)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_release_count_30d(client, "owner", "repo")
+
+        assert result == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_caps_at_ten(self) -> None:
+        """Should cap result at 10 regardless of actual count."""
+        from datetime import UTC, datetime, timedelta
+
+        now = datetime.now(UTC)
+        releases = [
+            {"published_at": (now - timedelta(days=i)).isoformat()} for i in range(1, 16)
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(200, json=releases)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_release_count_30d(client, "owner", "repo")
+
+        assert result == 10
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_api_error(self) -> None:
+        """Should return 0 when the releases API returns an error."""
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_release_count_30d(client, "owner", "repo")
+
+        assert result == 0
+
+
+class TestGetContributorCount90d:
+    """Tests for fetching unique contributor count in last 90 days."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_counts_unique_authors(self) -> None:
+        """Should count unique author logins from commits."""
+        commits = [
+            {"author": {"login": "alice"}},
+            {"author": {"login": "bob"}},
+            {"author": {"login": "alice"}},  # duplicate, should not count twice
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_caps_at_twenty(self) -> None:
+        """Should cap result at 20 regardless of actual count."""
+        commits = [{"author": {"login": f"user{i}"}} for i in range(25)]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 20
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_api_error(self) -> None:
+        """Should return 0 when the commits API returns an error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skips_commits_without_author(self) -> None:
+        """Should skip commits where author or login is missing."""
+        commits = [
+            {"author": {"login": "alice"}},
+            {"author": None},
+            {},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_contributor_count_90d(client, "owner", "repo")
+
+        assert result == 1

--- a/tests/unit/test_pet_logic.py
+++ b/tests/unit/test_pet_logic.py
@@ -261,6 +261,86 @@ class TestCalculateHealthDelta:
         )
         assert calculate_health_delta(health) == 0
 
+    def test_release_count_adds_bonus(self) -> None:
+        """Each release in last 30d adds +2 health, up to +10."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=3,
+        )
+        assert calculate_health_delta(health) == 6  # 3 * 2
+
+    def test_release_count_capped_at_ten(self) -> None:
+        """Release bonus should be capped at +10 regardless of count."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=10,
+        )
+        assert calculate_health_delta(health) == 10
+
+    def test_contributor_count_adds_bonus(self) -> None:
+        """Each contributor in last 90d adds +1 health, up to +8."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            contributor_count=5,
+        )
+        assert calculate_health_delta(health) == 5
+
+    def test_contributor_count_capped_at_eight(self) -> None:
+        """Contributor bonus should be capped at +8 regardless of count."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            contributor_count=20,
+        )
+        assert calculate_health_delta(health) == 8
+
+    def test_releases_and_contributors_higher_than_absent(self) -> None:
+        """Delta with releases+contributors should exceed delta without them."""
+        base_health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+        )
+        active_health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=2,
+            contributor_count=4,
+        )
+        assert calculate_health_delta(active_health) > calculate_health_delta(base_health)
+
 
 class TestCalculateExperience:
     """Tests for calculate_experience function."""


### PR DESCRIPTION
## What
Extends the health metrics system with two new signals: release frequency and contributor count.

## Changes
- `RepoHealth` dataclass gains `release_count_30d` and `contributor_count`
- Fetches releases published in last 30d and unique commit authors in last 90d from GitHub API
- Both default to 0 on error so polling never breaks
- `calculate_health_delta` gives +2/release (max +10) and +1/contributor (max +8)
- `Pet` model gains `last_release_count` and `last_contributor_count`, persisted on each poll
- Migration 015 adds the two new columns
- Pet profile shows Releases (30d) and Contributors in the stats grid

## Test plan
- [ ] Pet profile shows new stat cards
- [ ] Health calculation rewards active release cadence and broad contributor base
- [ ] New columns survive DB migration
- [ ] CI green

Closes #25, #26