### PR TITLE
fix: add graceful shutdown to prevent k8s rollout timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import httpx; httpx.get('http://localhost:8000/api/v1/health')" || exit 1
 
 # Start the application (migrations run as a k8s initContainer)
-CMD ["uvicorn", "github_tamagotchi.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "github_tamagotchi.main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-graceful-shutdown", "10"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -39,11 +39,16 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: database-url
+      terminationGracePeriodSeconds: 30
       containers:
         - name: github-tamagotchi
           image: ghcr.io/wiebe-xyz/github-tamagotchi:latest
           ports:
             - containerPort: 8000
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
           env:
             - name: DATABASE_URL
               valueFrom:
@@ -174,11 +179,16 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: database-url
+      terminationGracePeriodSeconds: 30
       containers:
         - name: github-tamagotchi
           image: ghcr.io/wiebe-xyz/github-tamagotchi:latest
           ports:
             - containerPort: 8000
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
           env:
             - name: DATABASE_URL
               valueFrom:


### PR DESCRIPTION
## Summary

- Add `preStop` lifecycle hook (5s sleep) on both blue/green containers so the load balancer stops routing traffic before SIGTERM arrives
- Set `terminationGracePeriodSeconds: 30` explicitly on pod specs
- Pass `--timeout-graceful-shutdown 10` to uvicorn so open connections don't block pod termination indefinitely

## Root cause

Rolling updates were timing out because the old replica stayed in `Terminating` state. Uvicorn without a graceful shutdown timeout holds open connections alive indefinitely when it receives SIGTERM, blocking pod eviction and causing the `kubectl rollout status --timeout=900s` to fail.

## Test plan

- [ ] CI lint/test/e2e/build passes
- [ ] Next deploy to main completes without rollout timeout