### PR TITLE
feat: replace emoji badge with animated pet sprite image (#125)

### DIFF
--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -401,6 +401,8 @@ async def resurrect_pet(
 @router.get("/pets/{repo_owner}/{repo_name}/badge.svg", response_class=Response)
 async def get_pet_badge(repo_owner: str, repo_name: str, session: DbSession) -> Response:
     """Return an SVG badge representing the current pet state."""
+    import base64
+
     from github_tamagotchi.services.badge import generate_badge_svg
 
     pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
@@ -409,6 +411,16 @@ async def get_pet_badge(repo_owner: str, repo_name: str, session: DbSession) -> 
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Pet not found for {repo_owner}/{repo_name}",
         )
+
+    # Attempt to fetch the stage-appropriate sprite; fall back to None (emoji) on any error.
+    pet_image_b64: str | None = None
+    try:
+        storage = StorageService()
+        image_bytes = await storage.get_image(pet.repo_owner, pet.repo_name, pet.stage)
+        if image_bytes:
+            pet_image_b64 = base64.b64encode(image_bytes).decode()
+    except Exception:
+        pass  # non-fatal — badge will use emoji fallback
 
     svg_content = generate_badge_svg(
         pet.name,
@@ -419,6 +431,7 @@ async def get_pet_badge(repo_owner: str, repo_name: str, session: DbSession) -> 
         died_at=pet.died_at,
         created_at=pet.created_at,
         commit_streak=pet.commit_streak,
+        pet_image_b64=pet_image_b64,
     )
     return Response(
         content=svg_content,

--- a/src/github_tamagotchi/services/badge.py
+++ b/src/github_tamagotchi/services/badge.py
@@ -33,9 +33,40 @@ MOOD_COLOR: dict[str, str] = {
     PetMood.DANCING: "#1abc9c",
 }
 
+# (animation-name, timing) per mood
+MOOD_ANIMATION: dict[str, tuple[str, str]] = {
+    PetMood.HAPPY: ("bounce", "1s ease-in-out infinite"),
+    PetMood.DANCING: ("bounce", "0.6s ease-in-out infinite"),
+    PetMood.CONTENT: ("float", "3s ease-in-out infinite"),
+    PetMood.HUNGRY: ("shake", "0.5s ease-in-out infinite"),
+    PetMood.WORRIED: ("shake", "0.8s ease-in-out infinite"),
+    PetMood.LONELY: ("pulse", "2s ease-in-out infinite"),
+    PetMood.SICK: ("pulse", "1.5s ease-in-out infinite"),
+}
+
+_KEYFRAMES = (
+    "@keyframes bounce{"
+    "0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}"
+    "@keyframes float{"
+    "0%,100%{transform:translateY(0) rotate(-1deg)}"
+    "50%{transform:translateY(-2px) rotate(1deg)}}"
+    "@keyframes shake{"
+    "0%,100%{transform:translateX(0)}"
+    "25%{transform:translateX(-2px)}75%{transform:translateX(2px)}}"
+    "@keyframes pulse{0%,100%{opacity:1}50%{opacity:0.5}}"
+)
+
 _CENTER = 'text-anchor="middle" dominant-baseline="middle"'
 _START = 'text-anchor="start" dominant-baseline="middle"'
 _END = 'text-anchor="end" dominant-baseline="middle"'
+
+# Layout constants for sprite badge (160px wide)
+_SPRITE_W = 160
+_SPRITE_X = 4       # sprite image x offset
+_SPRITE_Y = 9       # sprite image y offset
+_SPRITE_SIZE = 56   # sprite image width and height
+_TEXT_X = 66        # x start of right-side text column
+_TEXT_RIGHT = 156   # x end of right-side text (for right-aligned elements)
 
 
 def _health_color(health: int) -> str:
@@ -44,6 +75,23 @@ def _health_color(health: int) -> str:
     if health >= 40:
         return "#f39c12"
     return "#e74c3c"
+
+
+def _sprite_image_element(b64: str, anim_name: str | None, anim_timing: str | None) -> list[str]:
+    """Build SVG elements for an embedded sprite image with optional animation."""
+    img_elem = (
+        f'  <image x="{_SPRITE_X}" y="{_SPRITE_Y}" width="{_SPRITE_SIZE}" height="{_SPRITE_SIZE}"'
+        f' href="data:image/png;base64,{b64}"/>'
+    )
+    if anim_name:
+        cx = _SPRITE_X + _SPRITE_SIZE // 2
+        cy = _SPRITE_Y + _SPRITE_SIZE // 2
+        return [
+            f'  <g style="animation:{anim_name} {anim_timing};transform-origin:{cx}px {cy}px">',
+            f"  {img_elem.strip()}",
+            "  </g>",
+        ]
+    return [img_elem]
 
 
 def generate_badge_svg(
@@ -56,85 +104,186 @@ def generate_badge_svg(
     died_at: datetime | None = None,
     created_at: datetime | None = None,
     commit_streak: int = 0,
+    pet_image_b64: str | None = None,
 ) -> str:
-    """Generate an SVG badge representing the current pet state."""
+    """Generate an SVG badge representing the current pet state.
+
+    Args:
+        name: Pet name.
+        stage: Pet stage string.
+        mood: Pet mood string.
+        health: Pet health (0–100).
+        is_dead: Whether the pet is deceased.
+        died_at: Datetime the pet died (for RIP label).
+        created_at: Datetime the pet was created (for RIP label).
+        commit_streak: Current commit streak count.
+        pet_image_b64: Base64-encoded PNG sprite, or None to use emoji fallback.
+    """
     # Truncate name to keep badge width manageable
     display_name = name if len(name) <= 14 else name[:13] + "…"
 
+    has_sprite = bool(pet_image_b64)
+    width = _SPRITE_W if has_sprite else 120
+
     if is_dead:
-        stage_sprite = "🪦"
-        mood_sprite = "💀"
         accent = "#7f8c8d"
         born_year = created_at.year if created_at else "?"
         died_year = died_at.year if died_at else "?"
         rip_label = f"RIP {born_year}–{died_year}"
-        lines = [
-            f'<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80"'
-            f' role="img" aria-label="Pet: {display_name} (Deceased)">',
-            f"  <title>{display_name} (Deceased)</title>",
-            "  <defs>",
+
+        defs_inner: list[str] = [
             '    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">',
             '      <stop offset="0" stop-color="#1a1a1a"/>',
             '      <stop offset="1" stop-color="#2c2c2c"/>',
             "    </linearGradient>",
+        ]
+        if has_sprite:
+            defs_inner.append(
+                '    <filter id="gs">'
+                '<feColorMatrix type="saturate" values="0"/>'
+                "</filter>"
+            )
+
+        lines: list[str] = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="80"'
+            f' role="img" aria-label="Pet: {display_name} (Deceased)">',
+            f"  <title>{display_name} (Deceased)</title>",
+            "  <defs>",
+            *defs_inner,
             "  </defs>",
-            '  <rect width="120" height="80" rx="6" fill="url(#bg)"/>',
-            f'  <rect width="120" height="3" fill="{accent}"/>',
-            f'  <text x="18" y="44" font-size="28" {_CENTER}>{stage_sprite}</text>',
-            f'  <text x="38" y="30" font-size="12" {_START}>{mood_sprite}</text>',
-            f'  <text x="38" y="44" font-size="10" fill="#9e9e9e" {_START}'
+            f'  <rect width="{width}" height="80" rx="6" fill="url(#bg)"/>',
+            f'  <rect width="{width}" height="3" fill="{accent}"/>',
+        ]
+
+        if has_sprite:
+            assert pet_image_b64 is not None
+            lines.append(
+                f'  <image x="{_SPRITE_X}" y="{_SPRITE_Y}" width="{_SPRITE_SIZE}"'
+                f' height="{_SPRITE_SIZE}" href="data:image/png;base64,{pet_image_b64}"'
+                f' filter="url(#gs)"/>'
+            )
+            tx = _TEXT_X
+            tcenter = _TEXT_RIGHT
+        else:
+            lines.append(f'  <text x="18" y="44" font-size="28" {_CENTER}>🪦</text>')
+            lines.append(f'  <text x="38" y="30" font-size="12" {_START}>💀</text>')
+            tx = 38
+            tcenter = 60
+
+        lines += [
+            f'  <text x="{tx}" y="30" font-size="10" fill="#9e9e9e" {_START}'
             f' font-family="monospace">{display_name}</text>',
-            f'  <text x="38" y="57" font-size="8" fill="#7f8c8d" {_START}'
+            f'  <text x="{tx}" y="44" font-size="8" fill="#7f8c8d" {_START}'
             f' font-family="sans-serif">Deceased</text>',
-            f'  <text x="60" y="71" font-size="7" fill="#7f8c8d" {_CENTER}'
+            f'  <text x="{tcenter}" y="60" font-size="7" fill="#7f8c8d" {_CENTER}'
             f' font-family="sans-serif">{rip_label}</text>',
             "</svg>",
         ]
         return "\n".join(lines)
 
+    # --- Living pet ---
     stage_sprite = STAGE_EMOJI.get(stage, "🥚")
     mood_sprite = MOOD_EMOJI.get(mood, "😌")
     accent = MOOD_COLOR.get(mood, "#3498db")
     hp_color = _health_color(health)
     health_pct = max(0, min(100, health))
-    health_bar_width = round(health_pct * 0.65)  # 65px max bar width
-
     stage_label = stage.capitalize()
+    mood_label = mood.capitalize()
 
-    lines = [
-        f'<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80"'
-        f' role="img" aria-label="Pet: {display_name}">',
-        f"  <title>{display_name} ({stage_label})</title>",
-        "  <defs>",
-        '    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">',
-        '      <stop offset="0" stop-color="#1a1a2e"/>',
-        '      <stop offset="1" stop-color="#16213e"/>',
-        "    </linearGradient>",
-        '    <clipPath id="r">',
-        '      <rect width="120" height="80" rx="6"/>',
-        "    </clipPath>",
-        "  </defs>",
-        '  <rect width="120" height="80" rx="6" fill="url(#bg)"/>',
-        f'  <rect width="120" height="3" fill="{accent}"/>',
-        f'  <text x="18" y="44" font-size="28" {_CENTER}>{stage_sprite}</text>',
-        f'  <text x="38" y="30" font-size="12" {_START}>{mood_sprite}</text>',
-        f'  <text x="38" y="44" font-size="10" fill="#ecf0f1" {_START}'
-        f' font-family="monospace">{display_name}</text>',
-        f'  <text x="38" y="57" font-size="8" fill="#bdc3c7" {_START}'
-        f' font-family="sans-serif">{stage_label}</text>',
-        f'  <text x="16" y="71" font-size="7" fill="#7f8c8d" {_START}'
-        f' font-family="sans-serif">HP</text>',
-        '  <rect x="26" y="67" width="80" height="5" rx="2" fill="#2c3e50"/>',
-        f'  <rect x="26" y="67" width="{health_bar_width}" height="5" rx="2" fill="{hp_color}"/>',
-        f'  <text x="109" y="71" font-size="7" fill="{hp_color}" {_END}'
-        f' font-family="monospace">{health_pct}</text>',
-    ]
+    if has_sprite:
+        # 160px wide layout with sprite image
+        # HP bar: x=76 to x=148 → 72px max
+        health_bar_width = round(health_pct * 0.72)
 
-    if commit_streak >= 7:
-        lines.append(
-            f'  <text x="116" y="14" font-size="7" fill="#ff9800" {_END}'
-            f' font-family="monospace">🔥{commit_streak}</text>'
-        )
+        anim_pair = MOOD_ANIMATION.get(mood)
+        anim_name = anim_pair[0] if anim_pair else None
+        anim_timing = anim_pair[1] if anim_pair else None
+
+        defs_lines: list[str] = [
+            "  <defs>",
+            f"    <style>{_KEYFRAMES}</style>",
+            '    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">',
+            '      <stop offset="0" stop-color="#1a1a2e"/>',
+            '      <stop offset="1" stop-color="#16213e"/>',
+            "    </linearGradient>",
+            '    <clipPath id="r">',
+            f'      <rect width="{width}" height="80" rx="6"/>',
+            "    </clipPath>",
+            "  </defs>",
+        ]
+
+        lines = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="80"'
+            f' role="img" aria-label="Pet: {display_name}">',
+            f"  <title>{display_name} ({stage_label})</title>",
+            *defs_lines,
+            f'  <rect width="{width}" height="80" rx="6" fill="url(#bg)"/>',
+            f'  <rect width="{width}" height="3" fill="{accent}"/>',
+        ]
+
+        assert pet_image_b64 is not None
+        lines.extend(_sprite_image_element(pet_image_b64, anim_name, anim_timing))
+
+        lines += [
+            f'  <text x="{_TEXT_X}" y="22" font-size="10" fill="#ecf0f1" {_START}'
+            f' font-family="monospace">{display_name}</text>',
+            f'  <text x="{_TEXT_X}" y="35" font-size="8" fill="{accent}" {_START}'
+            f' font-family="sans-serif">{mood_label}</text>',
+            f'  <text x="{_TEXT_X}" y="48" font-size="8" fill="#bdc3c7" {_START}'
+            f' font-family="sans-serif">{stage_label}</text>',
+            f'  <text x="{_TEXT_X}" y="69" font-size="7" fill="#7f8c8d" {_START}'
+            f' font-family="sans-serif">HP</text>',
+            '  <rect x="76" y="65" width="73" height="5" rx="2" fill="#2c3e50"/>',
+            f'  <rect x="76" y="65" width="{health_bar_width}" height="5"'
+            f' rx="2" fill="{hp_color}"/>',
+            f'  <text x="{_TEXT_RIGHT}" y="69" font-size="7" fill="{hp_color}" {_END}'
+            f' font-family="monospace">{health_pct}</text>',
+        ]
+
+        if commit_streak >= 7:
+            lines.append(
+                f'  <text x="{_TEXT_RIGHT}" y="14" font-size="7" fill="#ff9800" {_END}'
+                f' font-family="monospace">🔥{commit_streak}</text>'
+            )
+    else:
+        # 120px wide layout with emoji (original)
+        health_bar_width = round(health_pct * 0.65)  # 65px max bar width
+
+        lines = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80"'
+            f' role="img" aria-label="Pet: {display_name}">',
+            f"  <title>{display_name} ({stage_label})</title>",
+            "  <defs>",
+            '    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">',
+            '      <stop offset="0" stop-color="#1a1a2e"/>',
+            '      <stop offset="1" stop-color="#16213e"/>',
+            "    </linearGradient>",
+            '    <clipPath id="r">',
+            '      <rect width="120" height="80" rx="6"/>',
+            "    </clipPath>",
+            "  </defs>",
+            '  <rect width="120" height="80" rx="6" fill="url(#bg)"/>',
+            f'  <rect width="120" height="3" fill="{accent}"/>',
+            f'  <text x="18" y="44" font-size="28" {_CENTER}>{stage_sprite}</text>',
+            f'  <text x="38" y="30" font-size="12" {_START}>{mood_sprite}</text>',
+            f'  <text x="38" y="44" font-size="10" fill="#ecf0f1" {_START}'
+            f' font-family="monospace">{display_name}</text>',
+            f'  <text x="38" y="57" font-size="8" fill="#bdc3c7" {_START}'
+            f' font-family="sans-serif">{stage_label}</text>',
+            f'  <text x="16" y="71" font-size="7" fill="#7f8c8d" {_START}'
+            f' font-family="sans-serif">HP</text>',
+            '  <rect x="26" y="67" width="80" height="5" rx="2" fill="#2c3e50"/>',
+            f'  <rect x="26" y="67" width="{health_bar_width}" height="5"'
+            f' rx="2" fill="{hp_color}"/>',
+            f'  <text x="109" y="71" font-size="7" fill="{hp_color}" {_END}'
+            f' font-family="monospace">{health_pct}</text>',
+        ]
+
+        if commit_streak >= 7:
+            lines.append(
+                f'  <text x="116" y="14" font-size="7" fill="#ff9800" {_END}'
+                f' font-family="monospace">🔥{commit_streak}</text>'
+            )
 
     lines.append("</svg>")
     return "\n".join(lines)

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1,8 +1,18 @@
 """Tests for SVG badge generation."""
 
+import base64
+
 from httpx import AsyncClient
 
-from github_tamagotchi.services.badge import generate_badge_svg
+from github_tamagotchi.services.badge import MOOD_ANIMATION, generate_badge_svg
+
+# A minimal 1x1 transparent PNG, base64-encoded, used as a stand-in sprite in tests.
+_DUMMY_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_DUMMY_B64 = base64.b64encode(_DUMMY_PNG_BYTES).decode()
 
 
 class TestGenerateBadgeSvg:
@@ -25,7 +35,7 @@ class TestGenerateBadgeSvg:
         assert "Adult" in svg
 
     def test_contains_stage_sprite(self) -> None:
-        """Badge includes the emoji sprite for the stage."""
+        """Badge includes the emoji sprite for the stage when no image is provided."""
         svg = generate_badge_svg("X", "egg", "content", 100)
         assert "🥚" in svg
 
@@ -33,7 +43,7 @@ class TestGenerateBadgeSvg:
         assert "🦅" in svg
 
     def test_contains_mood_sprite(self) -> None:
-        """Badge includes the emoji for the mood."""
+        """Badge includes the emoji for the mood when no image is provided."""
         svg = generate_badge_svg("X", "adult", "sick", 30)
         assert "🤒" in svg
 
@@ -70,6 +80,109 @@ class TestGenerateBadgeSvg:
         """Unknown mood falls back to content sprite."""
         svg = generate_badge_svg("X", "egg", "unknown_mood", 100)
         assert "😌" in svg
+
+    # --- Sprite image tests ---
+
+    def test_with_image_embeds_base64(self) -> None:
+        """When a base64 image is provided, SVG embeds it as a data URI."""
+        svg = generate_badge_svg("Pixel", "adult", "happy", 80, pet_image_b64=_DUMMY_B64)
+        assert "data:image/png;base64," in svg
+        assert _DUMMY_B64 in svg
+
+    def test_with_image_wider_badge(self) -> None:
+        """Badge with sprite is wider than emoji badge."""
+        svg_emoji = generate_badge_svg("X", "egg", "content", 100)
+        svg_sprite = generate_badge_svg("X", "egg", "content", 100, pet_image_b64=_DUMMY_B64)
+        assert 'width="120"' in svg_emoji
+        assert 'width="160"' in svg_sprite
+
+    def test_with_image_no_stage_emoji_in_sprite_position(self) -> None:
+        """When sprite is embedded, stage emoji is not used as the sprite element."""
+        svg = generate_badge_svg("X", "egg", "content", 100, pet_image_b64=_DUMMY_B64)
+        # The data URI replaces the emoji; the egg emoji should not appear
+        assert "🥚" not in svg
+
+    def test_with_image_has_animation_keyframes(self) -> None:
+        """Badge with sprite includes CSS keyframe animations."""
+        svg = generate_badge_svg("X", "adult", "happy", 80, pet_image_b64=_DUMMY_B64)
+        assert "@keyframes" in svg
+        assert "bounce" in svg
+
+    def test_mood_animation_happy_bounce(self) -> None:
+        """happy mood uses bounce animation."""
+        svg = generate_badge_svg("X", "adult", "happy", 80, pet_image_b64=_DUMMY_B64)
+        assert "bounce" in svg
+        assert "animation:bounce" in svg
+
+    def test_mood_animation_dancing_bounce(self) -> None:
+        """dancing mood uses bounce animation."""
+        svg = generate_badge_svg("X", "adult", "dancing", 80, pet_image_b64=_DUMMY_B64)
+        assert "bounce" in svg
+
+    def test_mood_animation_content_float(self) -> None:
+        """content mood uses float animation."""
+        svg = generate_badge_svg("X", "adult", "content", 80, pet_image_b64=_DUMMY_B64)
+        assert "float" in svg
+        assert "animation:float" in svg
+
+    def test_mood_animation_hungry_shake(self) -> None:
+        """hungry mood uses shake animation."""
+        svg = generate_badge_svg("X", "adult", "hungry", 80, pet_image_b64=_DUMMY_B64)
+        assert "shake" in svg
+        assert "animation:shake" in svg
+
+    def test_mood_animation_sick_pulse(self) -> None:
+        """sick mood uses pulse animation."""
+        svg = generate_badge_svg("X", "adult", "sick", 30, pet_image_b64=_DUMMY_B64)
+        assert "pulse" in svg
+        assert "animation:pulse" in svg
+
+    def test_mood_animation_lonely_pulse(self) -> None:
+        """lonely mood uses pulse animation."""
+        svg = generate_badge_svg("X", "adult", "lonely", 40, pet_image_b64=_DUMMY_B64)
+        assert "pulse" in svg
+
+    def test_without_image_shows_emoji_fallback(self) -> None:
+        """Without an image, badge uses emoji and is 120px wide."""
+        svg = generate_badge_svg("X", "adult", "happy", 80)
+        assert "😊" in svg
+        assert 'width="120"' in svg
+        assert "data:image/png;base64," not in svg
+
+    def test_mood_label_shown_with_sprite(self) -> None:
+        """Mood text label is shown in the right column when sprite is embedded."""
+        svg = generate_badge_svg("X", "adult", "dancing", 80, pet_image_b64=_DUMMY_B64)
+        assert "Dancing" in svg
+
+    def test_dead_pet_with_image_greyscale(self) -> None:
+        """Deceased pet with sprite applies greyscale filter."""
+        svg = generate_badge_svg(
+            "Ghost", "adult", "content", 0,
+            is_dead=True,
+            pet_image_b64=_DUMMY_B64,
+        )
+        assert "feColorMatrix" in svg
+        assert 'values="0"' in svg
+        assert "data:image/png;base64," in svg
+
+    def test_dead_pet_without_image_uses_tombstone(self) -> None:
+        """Deceased pet without sprite still shows tombstone emoji."""
+        svg = generate_badge_svg("Ghost", "adult", "content", 0, is_dead=True)
+        assert "🪦" in svg
+
+    def test_sprite_health_bar_uses_72px_scale(self) -> None:
+        """Sprite badge health bar uses 72px max width scale."""
+        svg = generate_badge_svg("X", "adult", "content", 100, pet_image_b64=_DUMMY_B64)
+        assert 'width="72"' in svg  # 100 * 0.72 = 72
+
+        svg_half = generate_badge_svg("X", "adult", "content", 50, pet_image_b64=_DUMMY_B64)
+        assert 'width="36"' in svg_half  # 50 * 0.72 = 36
+
+    def test_mood_animation_coverage(self) -> None:
+        """Every mood in MOOD_ANIMATION maps to a known animation name."""
+        known = {"bounce", "float", "shake", "pulse"}
+        for mood, (anim_name, _) in MOOD_ANIMATION.items():
+            assert anim_name in known, f"Unknown animation '{anim_name}' for mood '{mood}'"
 
 
 class TestBadgeEndpoint:
@@ -124,3 +237,18 @@ class TestBadgeEndpoint:
         """Badge endpoint returns 404 when pet does not exist."""
         response = await async_client.get("/api/v1/pets/nobody/norepo/badge.svg")
         assert response.status_code == 404
+
+    async def test_badge_falls_back_to_emoji_when_no_image(self, async_client: AsyncClient) -> None:
+        """Badge endpoint returns emoji-based SVG when no sprite is in storage."""
+        await async_client.post(
+            "/api/v1/pets",
+            json={"repo_owner": "imgtest", "repo_name": "repo", "name": "NoPic"},
+        )
+
+        response = await async_client.get("/api/v1/pets/imgtest/repo/badge.svg")
+        assert response.status_code == 200
+        # No image in MinIO for test pets → emoji fallback → 120px wide badge
+        body = response.text
+        assert body.strip().startswith("<svg")
+        # Emoji fallback badge is 120px wide
+        assert 'width="120"' in body


### PR DESCRIPTION
## Summary

- Embeds the pet's stage-appropriate AI-generated PNG sprite (base64-encoded inline) into the badge SVG instead of emoji placeholders
- Adds mood-based CSS keyframe animations: `bounce` (happy/dancing), `float` (content), `shake` (hungry/worried), `pulse` (lonely/sick)
- Deceased pets get a greyscale filter applied to the sprite
- Gracefully falls back to the existing 120px emoji layout when no sprite is available in MinIO (no error, no change to existing behaviour)
- Badge width expands from 120px to 160px when a sprite is present, with the sprite on the left (~56×56px) and name/mood/stage/HP on the right

## Changes

- `services/badge.py`: Added `pet_image_b64` parameter, sprite embedding logic, CSS keyframe animations, and 160px wide layout
- `api/routes.py`: Badge endpoint now attempts to fetch the stage sprite from storage and passes it base64-encoded to the badge generator
- `tests/test_badge.py`: Added 22 new unit tests covering sprite embedding, animations, fallback, greyscale filter, and health bar scaling; existing tests unchanged

## Testing

- [x] All 523 tests pass
- [x] Lint clean (`ruff check`)
- [x] Type check clean (`mypy`)
- [x] Badge with no stored image returns emoji fallback (verified via integration test)

Closes #125