### PR TITLE
Closes #17: Add public leaderboard

### DIFF
--- a/alembic/versions/016_add_leaderboard_opt_out.py
+++ b/alembic/versions/016_add_leaderboard_opt_out.py
@@ -1,0 +1,35 @@
+"""Add leaderboard_opt_out to pets
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-04-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "016"
+down_revision: str | None = "015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "leaderboard_opt_out",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "leaderboard_opt_out")

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -207,6 +207,35 @@ class AchievementsResponse(BaseModel):
     achievements: list[AchievementItem]
 
 
+class LeaderboardEntry(BaseModel):
+    """A single entry on the leaderboard."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    rank: int
+    pet_name: str
+    repo_owner: str
+    repo_name: str
+    stage: str
+    value: int
+
+
+class LeaderboardCategory(BaseModel):
+    """A leaderboard category with its ranked entries."""
+
+    id: str
+    title: str
+    description: str
+    entries: list[LeaderboardEntry]
+
+
+class LeaderboardResponse(BaseModel):
+    """Response model for the full leaderboard."""
+
+    categories: list[LeaderboardCategory]
+    cached_at: datetime
+
+
 @router.get("/health", response_model=HealthResponse)
 async def health_check(session: DbSession) -> HealthResponse:
     """Health check endpoint."""
@@ -898,3 +927,50 @@ async def github_webhook(request: Request, session: DbSession) -> WebhookRespons
         logger.exception("Failed to log webhook event")
 
     return WebhookResponse(status="processed", message=message)
+
+
+_LEADERBOARD_CATEGORIES = [
+    {
+        "id": "most_experienced",
+        "title": "Most Experienced",
+        "description": "Highest total XP earned",
+        "value_field": "experience",
+    },
+    {
+        "id": "longest_streak",
+        "title": "Longest Streak",
+        "description": "Most consecutive days with commits",
+        "value_field": "longest_streak",
+    },
+]
+
+
+@router.get("/leaderboard", response_model=LeaderboardResponse)
+async def get_leaderboard(session: DbSession) -> LeaderboardResponse:
+    """Return the public leaderboard with multiple categories (cached hourly)."""
+    categories: list[LeaderboardCategory] = []
+    now = datetime.now(UTC)
+
+    for cat in _LEADERBOARD_CATEGORIES:
+        pets = await pet_crud.get_leaderboard(session, cat["id"], limit=10)
+        entries = [
+            LeaderboardEntry(
+                rank=i + 1,
+                pet_name=p.name,
+                repo_owner=p.repo_owner,
+                repo_name=p.repo_name,
+                stage=p.stage,
+                value=getattr(p, cat["value_field"]),
+            )
+            for i, p in enumerate(pets)
+        ]
+        categories.append(
+            LeaderboardCategory(
+                id=cat["id"],
+                title=cat["title"],
+                description=cat["description"],
+                entries=entries,
+            )
+        )
+
+    return LeaderboardResponse(categories=categories, cached_at=now)

--- a/src/github_tamagotchi/crud/pet.py
+++ b/src/github_tamagotchi/crud/pet.py
@@ -7,6 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.models.pet import Pet, PetMood
 
+# Simple in-memory leaderboard cache: stores (timestamp, data) per category
+_leaderboard_cache: dict[str, tuple[datetime, list[Pet]]] = {}
+_LEADERBOARD_CACHE_TTL_SECONDS = 3600  # 1 hour
+
 
 async def create_pet(
     db: AsyncSession,
@@ -79,6 +83,41 @@ async def get_pets_with_owners(
     )
     rows = [{"pet": row.Pet, "owner": row.User} for row in result]
     return rows, total
+
+
+async def get_leaderboard(
+    db: AsyncSession, category: str, limit: int = 10
+) -> list[Pet]:
+    """Return top pets for the given leaderboard category, with hourly caching.
+
+    Categories:
+      - "most_experienced": top by experience (XP)
+      - "longest_streak": top by longest_streak
+    """
+    now = datetime.now(UTC)
+    cache_key = f"{category}:{limit}"
+    cached = _leaderboard_cache.get(cache_key)
+    if cached is not None:
+        cached_at, cached_data = cached
+        if (now - cached_at).total_seconds() < _LEADERBOARD_CACHE_TTL_SECONDS:
+            return cached_data
+
+    base_filter = Pet.leaderboard_opt_out.is_(False), Pet.is_dead.is_(False)
+
+    if category == "most_experienced":
+        order_col = Pet.experience.desc()
+    elif category == "longest_streak":
+        order_col = Pet.longest_streak.desc()
+    else:
+        return []
+
+    result = await db.execute(
+        select(Pet).where(*base_filter).order_by(order_col).limit(limit)
+    )
+    pets = list(result.scalars().all())
+
+    _leaderboard_cache[cache_key] = (now, pets)
+    return pets
 
 
 async def delete_pet(db: AsyncSession, pet: Pet) -> None:

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -445,6 +445,62 @@ async def register_complete_page(
         },
     )
 
+@app.get("/leaderboard", response_class=HTMLResponse)
+async def leaderboard_page(
+    request: Request, user: OptionalUser, session: DbSession
+) -> HTMLResponse:
+    """Public leaderboard page showing top pets by category."""
+    from github_tamagotchi.crud.pet import get_leaderboard
+
+    categories = [
+        {
+            "id": "most_experienced",
+            "title": "Most Experienced",
+            "description": "Highest total XP earned",
+            "value_field": "experience",
+            "value_label": "XP",
+        },
+        {
+            "id": "longest_streak",
+            "title": "Longest Streak",
+            "description": "Most consecutive days with commits",
+            "value_field": "longest_streak",
+            "value_label": "days",
+        },
+    ]
+
+    leaderboard_data = []
+    for cat in categories:
+        pets = await get_leaderboard(session, cat["id"], limit=10)
+        entries = [
+            {
+                "rank": i + 1,
+                "pet": p,
+                "value": getattr(p, cat["value_field"]),
+            }
+            for i, p in enumerate(pets)
+        ]
+        leaderboard_data.append(
+            {
+                "id": cat["id"],
+                "title": cat["title"],
+                "description": cat["description"],
+                "value_label": cat["value_label"],
+                "entries": entries,
+            }
+        )
+
+    return templates.TemplateResponse(
+        request,
+        "leaderboard.html",
+        {
+            "user": user,
+            "leaderboard_data": leaderboard_data,
+        },
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
 @app.get("/pet/{repo_owner}/{repo_name}", response_class=HTMLResponse)
 async def pet_profile(
     request: Request,

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -106,6 +106,11 @@ class Pet(Base):
         Integer, nullable=False, default=0, server_default="0"
     )
 
+    # Leaderboard visibility (opt-out)
+    leaderboard_opt_out: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/templates/leaderboard.html
+++ b/src/github_tamagotchi/templates/leaderboard.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Leaderboard — GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <nav class="user-nav">
+        <div class="container">
+            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
+            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
+                <a href="/leaderboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Leaderboard</a>
+                {% if user %}
+                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
+                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
+                {% if user.is_admin %}
+                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
+                {% endif %}
+                {% endif %}
+            </div>
+            <div class="user-info">
+                {% if user %}
+                    {% if user.github_avatar_url %}
+                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
+                    {% endif %}
+                    <span class="user-name">{{ user.github_login }}</span>
+                    <button class="logout-button" id="logout-btn">Log out</button>
+                {% else %}
+                    <a href="/auth/github" class="cta-button" style="padding:0.4rem 1rem; font-size:0.85rem;">Login</a>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
+
+    <main style="padding-top: 5rem; min-height: 80vh;">
+        <div class="container">
+            <div style="text-align: center; margin-bottom: 3rem;">
+                <h1 style="font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem;">&#127942; Hall of Fame</h1>
+                <p style="color: var(--text-muted); font-size: 1rem;">The most dedicated pets across all repositories. Updated hourly.</p>
+            </div>
+
+            {% if leaderboard_data %}
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 2rem;">
+                {% for category in leaderboard_data %}
+                <div class="feature" style="padding: 1.75rem;">
+                    <h2 style="font-size: 1.2rem; font-weight: 700; margin-bottom: 0.25rem;">{{ category.title }}</h2>
+                    <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 1.25rem;">{{ category.description }}</p>
+
+                    {% if category.entries %}
+                    <ol style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.6rem;">
+                        {% for entry in category.entries %}
+                        <li>
+                            <a href="/pet/{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}"
+                               style="display: flex; align-items: center; gap: 0.75rem; padding: 0.6rem 0.75rem; border-radius: 8px; text-decoration: none; color: inherit; transition: background 0.15s;"
+                               onmouseover="this.style.background='rgba(255,255,255,0.05)'"
+                               onmouseout="this.style.background='transparent'">
+                                <span style="font-size: 1rem; font-weight: 700; width: 1.5rem; text-align: center; color: {% if entry.rank == 1 %}#ffd700{% elif entry.rank == 2 %}#c0c0c0{% elif entry.rank == 3 %}#cd7f32{% else %}var(--text-muted){% endif %};">
+                                    {% if entry.rank == 1 %}&#129351;
+                                    {% elif entry.rank == 2 %}&#129352;
+                                    {% elif entry.rank == 3 %}&#129353;
+                                    {% else %}{{ entry.rank }}{% endif %}
+                                </span>
+                                <span style="font-size: 1.25rem;">
+                                    {% if entry.pet.stage == "egg" %}🥚
+                                    {% elif entry.pet.stage == "baby" %}🐣
+                                    {% elif entry.pet.stage == "child" %}🐥
+                                    {% elif entry.pet.stage == "teen" %}🐦
+                                    {% elif entry.pet.stage == "adult" %}🦉
+                                    {% elif entry.pet.stage == "elder" %}🦅
+                                    {% else %}🥚{% endif %}
+                                </span>
+                                <div style="flex: 1; min-width: 0;">
+                                    <div style="font-weight: 600; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ entry.pet.name }}</div>
+                                    <div style="color: var(--text-muted); font-size: 0.8rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}</div>
+                                </div>
+                                <span style="font-size: 0.9rem; font-weight: 600; white-space: nowrap; color: var(--accent);">
+                                    {{ entry.value | int }} {{ category.value_label }}
+                                </span>
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ol>
+                    {% else %}
+                    <p style="color: var(--text-muted); font-size: 0.9rem; text-align: center; padding: 1rem 0;">No pets yet — be the first!</p>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% else %}
+            <div style="text-align: center; padding: 4rem 0; color: var(--text-muted);">
+                <div style="font-size: 4rem; margin-bottom: 1rem;">&#129361;</div>
+                <p>No pets on the leaderboard yet. <a href="/auth/github" style="color: var(--accent);">Register your repo</a> to get started!</p>
+            </div>
+            {% endif %}
+        </div>
+    </main>
+
+    <footer style="padding: 2rem; text-align: center; color: var(--text-muted); font-size: 0.85rem; border-top: 1px solid rgba(255,255,255,0.08);">
+        <a href="/" style="color: var(--text-muted); text-decoration: none;">GitHub Tamagotchi</a>
+        &nbsp;&middot;&nbsp;
+        Leaderboard refreshes hourly
+    </footer>
+
+    {% if user %}
+    <script>
+        document.getElementById('logout-btn')?.addEventListener('click', async () => {
+            await fetch('/auth/logout', { method: 'POST' });
+            window.location.href = '/';
+        });
+    </script>
+    {% endif %}
+</body>
+</html>

--- a/tests/api/test_leaderboard.py
+++ b/tests/api/test_leaderboard.py
@@ -1,0 +1,168 @@
+"""Tests for the leaderboard API endpoint."""
+
+from httpx import AsyncClient
+
+from github_tamagotchi.crud.pet import _leaderboard_cache
+from github_tamagotchi.models.pet import Pet
+
+
+class TestLeaderboardEndpoint:
+    """Tests for GET /api/v1/leaderboard."""
+
+    async def test_leaderboard_returns_200(self, async_client: AsyncClient) -> None:
+        """Leaderboard endpoint should return 200 OK."""
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        assert response.status_code == 200
+
+    async def test_leaderboard_returns_two_categories(self, async_client: AsyncClient) -> None:
+        """Leaderboard should return both required categories."""
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+        assert "categories" in data
+        ids = [c["id"] for c in data["categories"]]
+        assert "most_experienced" in ids
+        assert "longest_streak" in ids
+
+    async def test_leaderboard_empty_when_no_pets(self, async_client: AsyncClient) -> None:
+        """Each category should have empty entries when there are no pets."""
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+        for cat in data["categories"]:
+            assert cat["entries"] == []
+
+    async def test_leaderboard_ranks_pets_by_experience(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Most Experienced category should rank pets by XP descending."""
+        from tests.conftest import test_session_factory
+
+        _leaderboard_cache.clear()
+        async with test_session_factory() as session:
+            # Create pets with different XP
+            high_xp = Pet(repo_owner="org", repo_name="high", name="HighXP", experience=5000)
+            low_xp = Pet(repo_owner="org", repo_name="low", name="LowXP", experience=100)
+            session.add_all([low_xp, high_xp])
+            await session.commit()
+
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+
+        most_exp = next(c for c in data["categories"] if c["id"] == "most_experienced")
+        assert len(most_exp["entries"]) == 2
+        assert most_exp["entries"][0]["pet_name"] == "HighXP"
+        assert most_exp["entries"][0]["rank"] == 1
+        assert most_exp["entries"][1]["pet_name"] == "LowXP"
+        assert most_exp["entries"][1]["rank"] == 2
+
+    async def test_leaderboard_ranks_pets_by_longest_streak(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Longest Streak category should rank pets by longest_streak descending."""
+        from tests.conftest import test_session_factory
+
+        _leaderboard_cache.clear()
+        async with test_session_factory() as session:
+            short_streak = Pet(
+                repo_owner="org2", repo_name="short", name="ShortStreak", longest_streak=3
+            )
+            long_streak = Pet(
+                repo_owner="org2", repo_name="long", name="LongStreak", longest_streak=42
+            )
+            session.add_all([short_streak, long_streak])
+            await session.commit()
+
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+
+        streak_cat = next(c for c in data["categories"] if c["id"] == "longest_streak")
+        assert streak_cat["entries"][0]["pet_name"] == "LongStreak"
+        assert streak_cat["entries"][0]["value"] == 42
+
+    async def test_leaderboard_excludes_opted_out_pets(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Pets with leaderboard_opt_out=True should not appear."""
+        from tests.conftest import test_session_factory
+
+        _leaderboard_cache.clear()
+        async with test_session_factory() as session:
+            opted_out = Pet(
+                repo_owner="priv", repo_name="secret", name="HiddenPet",
+                experience=9999, leaderboard_opt_out=True,
+            )
+            visible = Pet(
+                repo_owner="pub", repo_name="open", name="VisiblePet",
+                experience=1,
+            )
+            session.add_all([opted_out, visible])
+            await session.commit()
+
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+
+        most_exp = next(c for c in data["categories"] if c["id"] == "most_experienced")
+        names = [e["pet_name"] for e in most_exp["entries"]]
+        assert "HiddenPet" not in names
+        assert "VisiblePet" in names
+
+    async def test_leaderboard_excludes_dead_pets(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Dead pets should not appear in the leaderboard."""
+        from tests.conftest import test_session_factory
+
+        _leaderboard_cache.clear()
+        async with test_session_factory() as session:
+            dead_pet = Pet(
+                repo_owner="ghost", repo_name="dead", name="DeadPet",
+                experience=8888, is_dead=True,
+            )
+            alive_pet = Pet(
+                repo_owner="ghost", repo_name="alive", name="AlivePet",
+                experience=10,
+            )
+            session.add_all([dead_pet, alive_pet])
+            await session.commit()
+
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+
+        most_exp = next(c for c in data["categories"] if c["id"] == "most_experienced")
+        names = [e["pet_name"] for e in most_exp["entries"]]
+        assert "DeadPet" not in names
+        assert "AlivePet" in names
+
+    async def test_leaderboard_entry_links_to_pet_profile(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Each entry should expose repo_owner and repo_name for linking."""
+        from tests.conftest import test_session_factory
+
+        _leaderboard_cache.clear()
+        async with test_session_factory() as session:
+            pet = Pet(repo_owner="linktest", repo_name="myrepo", name="Linky", experience=500)
+            session.add(pet)
+            await session.commit()
+
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+
+        most_exp = next(c for c in data["categories"] if c["id"] == "most_experienced")
+        entry = next(e for e in most_exp["entries"] if e["pet_name"] == "Linky")
+        assert entry["repo_owner"] == "linktest"
+        assert entry["repo_name"] == "myrepo"
+
+    async def test_leaderboard_includes_cached_at(self, async_client: AsyncClient) -> None:
+        """Response should include a cached_at timestamp."""
+        _leaderboard_cache.clear()
+        response = await async_client.get("/api/v1/leaderboard")
+        data = response.json()
+        assert "cached_at" in data


### PR DESCRIPTION
## Summary
- Adds `/leaderboard` HTML page and `/api/v1/leaderboard` JSON endpoint
- Two categories: **Most Experienced** (top XP) and **Longest Streak** (top commit streak)
- Each entry links to the pet profile page (`/pet/{owner}/{repo}`)
- Results are cached in memory for 1 hour; page served with `Cache-Control: max-age=3600`
- Dead pets and pets with `leaderboard_opt_out=True` are excluded
- Adds `leaderboard_opt_out` boolean column to `pets` table (migration 016)

## Changes
- `models/pet.py`: added `leaderboard_opt_out` field
- `alembic/versions/016_add_leaderboard_opt_out.py`: migration for new column
- `crud/pet.py`: `get_leaderboard()` with in-memory hourly cache
- `api/routes.py`: `GET /api/v1/leaderboard` endpoint with response models
- `main.py`: `GET /leaderboard` page route
- `templates/leaderboard.html`: leaderboard page using existing CSS
- `tests/api/test_leaderboard.py`: 9 tests covering all acceptance criteria

## Testing
- [x] All 515 tests pass
- [x] Lint clean (`ruff check`)
- [x] Type check clean (`mypy`)

Closes #17