### PR TITLE
fix: set revisionHistoryLimit=2 to prune stale ReplicaSets

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     version: blue
 spec:
   progressDeadlineSeconds: 900
+  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:
@@ -148,6 +149,7 @@ metadata:
     version: green
 spec:
   progressDeadlineSeconds: 900
+  revisionHistoryLimit: 2
   replicas: 0
   selector:
     matchLabels:


### PR DESCRIPTION
## Problem

Old ReplicaSets accumulate in the `nijmegen-testing` namespace indefinitely. Kubernetes defaults to keeping all revision history, so every deploy leaves a zero-replica RS behind for both the blue and green deployments.

## Fix

Set `revisionHistoryLimit: 2` on both Deployments. Kubernetes will retain only the 2 most recent ReplicaSets (enough for a manual rollback if needed) and garbage-collect the rest on the next `kubectl apply`.

## Effect

- Existing orphaned ReplicaSets will be pruned automatically on the next deploy
- Future deploys stay clean