### PR TITLE
Closes #31: Add personal pet dashboard for contributors

### DIFF
--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -445,6 +445,76 @@ async def register_complete_page(
         },
     )
 
+
+@app.get("/dashboard/{username}", response_class=HTMLResponse)
+async def contributor_dashboard(
+    request: Request,
+    username: str,
+    user: OptionalUser,
+    session: DbSession,
+) -> HTMLResponse:
+    """Personal pet dashboard showing a contributor's standing across all pets."""
+    from sqlalchemy import select as sa_select
+
+    result = await session.execute(sa_select(Pet))
+    all_pets = result.scalars().all()
+
+    # Pets owned by this user (their GitHub repos)
+    my_pets = [p for p in all_pets if p.repo_owner.lower() == username.lower()]
+
+    # Other pets (living) — check if user contributes
+    other_pets = [p for p in all_pets if p.repo_owner.lower() != username.lower() and not p.is_dead]
+
+    github_service = GitHubService()
+    team_pets = []
+    for pet in other_pets:
+        try:
+            stats = await github_service.get_contributor_stats(
+                pet.repo_owner, pet.repo_name, username
+            )
+            if stats.days_since_last_commit is None:
+                continue  # never contributed here
+            if stats.is_top_contributor:
+                standing = "favorite"
+            elif stats.commits_30d > 0:
+                standing = "good"
+            else:
+                standing = "absent"
+            team_pets.append(
+                {
+                    "pet": pet,
+                    "standing": standing,
+                    "commits_30d": stats.commits_30d,
+                    "days_since": stats.days_since_last_commit,
+                }
+            )
+        except Exception:
+            logger.warning(
+                "contributor_dashboard_error",
+                username=username,
+                repo=f"{pet.repo_owner}/{pet.repo_name}",
+            )
+
+    favorite_count = sum(1 for t in team_pets if t["standing"] == "favorite")
+    doghouse_count = sum(1 for t in team_pets if t["standing"] == "doghouse")
+    total_score: int = sum(t["commits_30d"] for t in team_pets)  # type: ignore[misc]
+
+    return templates.TemplateResponse(
+        request,
+        "contributor_dashboard.html",
+        {
+            "user": user,
+            "username": username,
+            "my_pets": my_pets,
+            "team_pets": team_pets,
+            "total_repos": len(team_pets) + len(my_pets),
+            "favorite_count": favorite_count,
+            "doghouse_count": doghouse_count,
+            "total_score": total_score,
+        },
+    )
+
+
 @app.get("/leaderboard", response_class=HTMLResponse)
 async def leaderboard_page(
     request: Request, user: OptionalUser, session: DbSession

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -651,3 +651,140 @@ class GitHubService:
             except Exception as e:
                 logger.warning("Failed to list user repos", error=str(e))
                 return []
+
+    async def get_contributor_stats(self, owner: str, repo: str, username: str) -> ContributorStats:
+        """Fetch activity stats for a specific contributor in a repository."""
+        async with httpx.AsyncClient() as client:
+            since_30d = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+
+            # Get user's commits in last 30d and all commits in last 30d (for top-contributor check)
+            user_commits, all_commits = await self._fetch_commits_parallel(
+                client, owner, repo, username, since_30d
+            )
+
+            commits_30d = len(user_commits)
+
+            # Determine last commit date (from user commits, or fall back to all-time lookup)
+            last_commit_at: datetime | None = None
+            if user_commits:
+                raw_date = (
+                    user_commits[0]
+                    .get("commit", {})
+                    .get("committer", {})
+                    .get("date")
+                )
+                if raw_date:
+                    last_commit_at = datetime.fromisoformat(raw_date.replace("Z", "+00:00"))
+            elif commits_30d == 0:
+                # Try 90d window to detect absence vs. complete stranger
+                last_commit_at = await self._get_user_last_commit(client, owner, repo, username)
+
+            # Determine if this user is the top contributor in last 30d
+            is_top_contributor = False
+            if commits_30d > 0 and all_commits:
+                author_counts: dict[str, int] = {}
+                for c in all_commits:
+                    login = c["author"].get("login") if c.get("author") else None
+                    if login:
+                        author_counts[login] = author_counts.get(login, 0) + 1
+                top_count = max(author_counts.values(), default=0)
+                user_count = author_counts.get(username, 0)
+                is_top_contributor = user_count >= 3 and user_count == top_count
+
+            # Check CI status of user's latest commit
+            has_failed_ci = False
+            if user_commits:
+                latest_sha = user_commits[0].get("sha", "")
+                if latest_sha:
+                    has_failed_ci = await self._has_failed_ci(client, owner, repo, latest_sha)
+
+            days_since: int | None = None
+            if last_commit_at:
+                days_since = max(0, (datetime.now(UTC) - last_commit_at).days)
+
+            return ContributorStats(
+                commits_30d=commits_30d,
+                last_commit_at=last_commit_at,
+                is_top_contributor=is_top_contributor,
+                has_failed_ci=has_failed_ci,
+                days_since_last_commit=days_since,
+            )
+
+    async def _fetch_commits_parallel(
+        self,
+        client: httpx.AsyncClient,
+        owner: str,
+        repo: str,
+        username: str,
+        since: str,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Fetch user-specific and all commits concurrently."""
+        import asyncio
+
+        async def _fetch(params: dict[str, Any]) -> list[dict[str, Any]]:
+            try:
+                resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/commits",
+                    headers=self._get_headers(),
+                    params=params,
+                )
+                self._check_rate_limit(resp)
+                resp.raise_for_status()
+                result: list[dict[str, Any]] = resp.json()
+                return result
+            except RateLimitError:
+                raise
+            except Exception as e:
+                logger.warning("Failed to fetch commits", error=str(e))
+                return []
+
+        user_task = _fetch({"author": username, "since": since, "per_page": 100})
+        all_task = _fetch({"since": since, "per_page": 100})
+        return await asyncio.gather(user_task, all_task)
+
+    async def _get_user_last_commit(
+        self, client: httpx.AsyncClient, owner: str, repo: str, username: str
+    ) -> datetime | None:
+        """Get the date of a user's last commit regardless of time window."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"author": username, "per_page": 1},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            if commits:
+                raw_date = commits[0].get("commit", {}).get("committer", {}).get("date")
+                if raw_date:
+                    return datetime.fromisoformat(raw_date.replace("Z", "+00:00"))
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get user last commit", error=str(e))
+        return None
+
+    async def _has_failed_ci(
+        self, client: httpx.AsyncClient, owner: str, repo: str, sha: str
+    ) -> bool:
+        """Return True if the given commit has any failing CI check runs."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits/{sha}/check-runs",
+                headers=self._get_headers(),
+                params={"per_page": 30},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+            runs: list[dict[str, Any]] = data.get("check_runs", [])
+            return any(
+                r.get("conclusion") in ("failure", "timed_out", "action_required")
+                for r in runs
+            )
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get check runs", sha=sha, error=str(e))
+        return False

--- a/src/github_tamagotchi/templates/contributor_dashboard.html
+++ b/src/github_tamagotchi/templates/contributor_dashboard.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ username }}'s Dashboard - GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <nav class="user-nav">
+        <div class="container">
+            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
+            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
+                {% if user %}
+                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
+                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
+                {% if user.is_admin %}
+                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
+                {% endif %}
+                {% endif %}
+                <a href="/leaderboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Leaderboard</a>
+            </div>
+            <div class="user-info">
+                {% if user %}
+                    {% if user.github_avatar_url %}
+                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
+                    {% endif %}
+                    <span class="user-name">{{ user.github_login }}</span>
+                    <button class="logout-button" id="logout-btn">Log out</button>
+                {% else %}
+                    <a href="/auth/github" class="cta-button" style="padding: 0.4rem 1rem; font-size: 0.875rem;">Login with GitHub</a>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
+
+    <main style="padding-top: 5rem; min-height: 80vh;">
+        <div class="container">
+
+            <!-- Header -->
+            <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem;">
+                <img src="https://github.com/{{ username }}.png?size=64" alt="{{ username }}" style="width: 48px; height: 48px; border-radius: 50%; border: 2px solid var(--surface-light);">
+                <div>
+                    <h1 style="font-size: 1.75rem; font-weight: 700; margin: 0;">{{ username }}</h1>
+                    <div style="color: var(--text-muted); font-size: 0.9rem;">Contributor Dashboard</div>
+                </div>
+            </div>
+
+            <!-- Stats summary -->
+            <div class="feature-grid" style="grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); margin-bottom: 2.5rem; margin-top: 1.5rem;">
+                <div class="feature" style="padding: 1rem; text-align: center;">
+                    <div style="font-size: 1.6rem; font-weight: 700;">{{ total_repos }}</div>
+                    <div style="color: var(--text-muted); font-size: 0.8rem;">Repos</div>
+                </div>
+                <div class="feature" style="padding: 1rem; text-align: center;">
+                    <div style="font-size: 1.6rem; font-weight: 700;">{{ my_pets | length }}</div>
+                    <div style="color: var(--text-muted); font-size: 0.8rem;">Owned Pets</div>
+                </div>
+                <div class="feature" style="padding: 1rem; text-align: center;">
+                    <div style="font-size: 1.6rem; font-weight: 700;">{{ favorite_count }}</div>
+                    <div style="color: var(--text-muted); font-size: 0.8rem;">Favorites</div>
+                </div>
+                <div class="feature" style="padding: 1rem; text-align: center;">
+                    <div style="font-size: 1.6rem; font-weight: 700;">{{ total_score }}</div>
+                    <div style="color: var(--text-muted); font-size: 0.8rem;">Commits (30d)</div>
+                </div>
+            </div>
+
+            <!-- Your Pets -->
+            <h2 style="font-size: 1.2rem; font-weight: 700; margin-bottom: 1rem;">Your Pets</h2>
+
+            {% if my_pets %}
+            <div class="feature-grid" style="margin-bottom: 3rem;">
+                {% for pet in my_pets %}
+                <div class="feature" style="padding: 1.25rem; display: flex; flex-direction: column; gap: 0.6rem;{% if pet.is_dead %} opacity: 0.6; filter: grayscale(0.8);{% endif %}">
+                    <div style="display: flex; align-items: center; gap: 0.6rem;">
+                        <span style="font-size: 1.75rem;">
+                            {% if pet.is_dead %}&#129680;
+                            {% elif pet.stage == "egg" %}🥚
+                            {% elif pet.stage == "baby" %}🐣
+                            {% elif pet.stage == "child" %}🐥
+                            {% elif pet.stage == "teen" %}🐦
+                            {% elif pet.stage == "adult" %}🦉
+                            {% elif pet.stage == "elder" %}🦅
+                            {% else %}🥚
+                            {% endif %}
+                        </span>
+                        <div>
+                            <div style="font-weight: 600;">{{ pet.name }}{% if pet.generation > 1 %} <span style="font-size:0.65em; background: linear-gradient(135deg, #b8860b, #ffd700); color:#1a1a1a; padding:0.1em 0.4em; border-radius:99px;">Gen {{ pet.generation }}</span>{% endif %}</div>
+                            <div style="color: var(--text-muted); font-size: 0.8rem;">{{ pet.repo_owner }}/{{ pet.repo_name }}</div>
+                        </div>
+                    </div>
+                    {% if not pet.is_dead %}
+                    <div style="display: flex; gap: 0.4rem; font-size: 0.8rem;">
+                        <span style="background: var(--surface-light); padding: 0.15rem 0.5rem; border-radius: 99px;">{{ pet.stage | capitalize }}</span>
+                        <span style="background: var(--surface-light); padding: 0.15rem 0.5rem; border-radius: 99px;">{{ pet.mood | capitalize }}</span>
+                    </div>
+                    <div>
+                        <div style="display: flex; justify-content: space-between; font-size: 0.75rem; margin-bottom: 0.2rem;">
+                            <span style="color: var(--text-muted);">Health</span>
+                            <span>{{ pet.health }}%</span>
+                        </div>
+                        <div style="background: var(--surface-light); border-radius: 4px; height: 5px; overflow: hidden;">
+                            <div style="background: {% if pet.health >= 70 %}var(--secondary){% elif pet.health >= 30 %}var(--accent){% else %}#ef4444{% endif %}; width: {{ pet.health }}%; height: 100%;"></div>
+                        </div>
+                    </div>
+                    {% else %}
+                    <div style="font-size: 0.8rem; color: #9e9e9e;">
+                        Deceased{% if pet.cause_of_death %} &mdash; {{ pet.cause_of_death | capitalize }}{% endif %}
+                    </div>
+                    {% endif %}
+                    <a href="/pet/{{ pet.repo_owner }}/{{ pet.repo_name }}" class="secondary-btn" style="text-align: center; font-size: 0.85rem; margin-top: auto;">
+                        {% if pet.is_dead %}View Memorial{% else %}View Profile{% endif %}
+                    </a>
+                </div>
+                {% endfor %}
+            </div>
+            {% else %}
+            <div style="padding: 2rem 0 3rem; color: var(--text-muted); font-size: 0.95rem;">
+                No registered pets for <strong>{{ username }}</strong>'s repos yet.
+            </div>
+            {% endif %}
+
+            <!-- Team Pets -->
+            <h2 style="font-size: 1.2rem; font-weight: 700; margin-bottom: 1rem;">Team Pets <span style="font-size: 0.8rem; font-weight: 400; color: var(--text-muted);">({{ username }}'s standing)</span></h2>
+
+            {% if team_pets %}
+            <div style="overflow-x: auto; margin-bottom: 3rem;">
+                <table style="width: 100%; border-collapse: collapse; font-size: 0.9rem;">
+                    <thead>
+                        <tr style="border-bottom: 1px solid var(--surface-light);">
+                            <th style="text-align: left; padding: 0.5rem 0.75rem; color: var(--text-muted); font-weight: 600;">Pet</th>
+                            <th style="text-align: left; padding: 0.5rem 0.75rem; color: var(--text-muted); font-weight: 600;">Repo</th>
+                            <th style="text-align: left; padding: 0.5rem 0.75rem; color: var(--text-muted); font-weight: 600;">Standing</th>
+                            <th style="text-align: right; padding: 0.5rem 0.75rem; color: var(--text-muted); font-weight: 600;">Last Active</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in team_pets %}
+                        <tr style="border-bottom: 1px solid var(--surface-light);">
+                            <td style="padding: 0.75rem;">
+                                <div style="display: flex; align-items: center; gap: 0.5rem;">
+                                    <span style="font-size: 1.25rem;">
+                                        {% if entry.pet.stage == "egg" %}🥚
+                                        {% elif entry.pet.stage == "baby" %}🐣
+                                        {% elif entry.pet.stage == "child" %}🐥
+                                        {% elif entry.pet.stage == "teen" %}🐦
+                                        {% elif entry.pet.stage == "adult" %}🦉
+                                        {% elif entry.pet.stage == "elder" %}🦅
+                                        {% else %}🥚
+                                        {% endif %}
+                                    </span>
+                                    <a href="/pet/{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}" style="color: var(--text-primary); font-weight: 600; text-decoration: none;">{{ entry.pet.name }}</a>
+                                </div>
+                            </td>
+                            <td style="padding: 0.75rem; color: var(--text-muted);">
+                                <a href="https://github.com/{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}" target="_blank" rel="noopener" style="color: var(--text-muted); text-decoration: none;">{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}</a>
+                            </td>
+                            <td style="padding: 0.75rem;">
+                                {% if entry.standing == "favorite" %}
+                                <span style="background: rgba(var(--secondary-rgb, 34,197,94), 0.15); color: #22c55e; padding: 0.2rem 0.6rem; border-radius: 99px; font-size: 0.8rem;">😍 Favorite</span>
+                                {% elif entry.standing == "good" %}
+                                <span style="background: rgba(59,130,246,0.12); color: #60a5fa; padding: 0.2rem 0.6rem; border-radius: 99px; font-size: 0.8rem;">😊 Good</span>
+                                {% elif entry.standing == "doghouse" %}
+                                <span style="background: rgba(249,115,22,0.12); color: #fb923c; padding: 0.2rem 0.6rem; border-radius: 99px; font-size: 0.8rem;">😤 Doghouse</span>
+                                {% else %}
+                                <span style="background: var(--surface-light); color: var(--text-muted); padding: 0.2rem 0.6rem; border-radius: 99px; font-size: 0.8rem;">😢 Absent</span>
+                                {% endif %}
+                            </td>
+                            <td style="padding: 0.75rem; text-align: right; color: var(--text-muted); font-size: 0.85rem;">
+                                {% if entry.days_since == 0 %}today
+                                {% elif entry.days_since == 1 %}yesterday
+                                {% else %}{{ entry.days_since }} days ago
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Redemption Path (for absent entries) -->
+            {% set absent_pets = team_pets | selectattr("standing", "equalto", "absent") | list %}
+            {% if absent_pets %}
+            <div style="background: var(--surface-light); border-radius: 8px; padding: 1.25rem; margin-bottom: 2rem;">
+                <h3 style="font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem;">Redemption Path</h3>
+                <p style="color: var(--text-muted); font-size: 0.875rem; margin-bottom: 0.75rem;">These pets miss you! Get back in their good graces:</p>
+                <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem;">
+                    {% for entry in absent_pets %}
+                    <li style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem;">
+                        <span>&#128279;</span>
+                        <a href="https://github.com/{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}" target="_blank" rel="noopener" style="color: var(--accent);">{{ entry.pet.repo_owner }}/{{ entry.pet.repo_name }}</a>
+                        <span style="color: var(--text-muted);">&mdash; last seen {{ entry.days_since }} days ago</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+
+            {% else %}
+            <div style="padding: 2rem 0; color: var(--text-muted); font-size: 0.95rem;">
+                {% if my_pets %}
+                No contribution activity found in other registered repos.
+                {% else %}
+                No pets found. <strong>{{ username }}</strong> hasn't contributed to any registered repos yet.
+                {% endif %}
+            </div>
+            {% endif %}
+
+        </div>
+    </main>
+
+    <footer style="margin-top: 4rem; padding: 2rem 0; border-top: 1px solid var(--surface-light);">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-brand">
+                    <span class="logo">GitHub Tamagotchi</span>
+                    <p>Making repository health visible and fun.</p>
+                </div>
+                <div class="footer-links">
+                    <a href="https://github.com/wiebe-xyz/github-tamagotchi" target="_blank" rel="noopener">GitHub</a>
+                    <a href="/docs">API Docs</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    {% if user %}
+    <script>
+        const logoutBtn = document.getElementById('logout-btn');
+        if (logoutBtn) {
+            logoutBtn.addEventListener('click', async () => {
+                await fetch('/auth/logout', { method: 'POST' });
+                window.location.href = '/';
+            });
+        }
+    </script>
+    {% endif %}
+</body>
+</html>

--- a/tests/api/test_contributor_dashboard.py
+++ b/tests/api/test_contributor_dashboard.py
@@ -1,0 +1,262 @@
+"""Tests for the contributor dashboard page at /dashboard/{username}."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from github_tamagotchi.api.auth import _create_jwt
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
+from github_tamagotchi.models.user import User
+from github_tamagotchi.services.github import ContributorStats
+from tests.conftest import test_session_factory
+
+
+def _create_user(user_id: int = 100, github_login: str = "contributor") -> str:
+    async def _setup() -> str:
+        async with test_session_factory() as session:
+            user = User(
+                id=user_id,
+                github_id=user_id * 1000,
+                github_login=github_login,
+                github_avatar_url=f"https://avatars.example.com/{github_login}",
+            )
+            session.add(user)
+            await session.commit()
+        return _create_jwt(user_id=user_id)
+
+    return asyncio.run(_setup())
+
+
+def _create_pet(
+    user_id: int | None = None,
+    repo_owner: str = "teamorg",
+    repo_name: str = "repo",
+    name: str = "Gotchi",
+    stage: str = PetStage.ADULT.value,
+    health: int = 80,
+    is_dead: bool = False,
+) -> None:
+    async def _setup() -> None:
+        async with test_session_factory() as session:
+            pet = Pet(
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                name=name,
+                user_id=user_id,
+                stage=stage,
+                mood=PetMood.HAPPY.value,
+                health=health,
+                is_dead=is_dead,
+                died_at=datetime.now(UTC) if is_dead else None,
+            )
+            session.add(pet)
+            await session.commit()
+
+    asyncio.run(_setup())
+
+
+def _no_contribution_stats() -> ContributorStats:
+    return ContributorStats(
+        commits_30d=0,
+        last_commit_at=None,
+        is_top_contributor=False,
+        has_failed_ci=False,
+        days_since_last_commit=None,
+    )
+
+
+def _active_stats(commits_30d: int = 5, is_top: bool = False) -> ContributorStats:
+    return ContributorStats(
+        commits_30d=commits_30d,
+        last_commit_at=datetime.now(UTC) - timedelta(days=3),
+        is_top_contributor=is_top,
+        has_failed_ci=False,
+        days_since_last_commit=3,
+    )
+
+
+def _absent_stats(days: int = 45) -> ContributorStats:
+    return ContributorStats(
+        commits_30d=0,
+        last_commit_at=datetime.now(UTC) - timedelta(days=days),
+        is_top_contributor=False,
+        has_failed_ci=False,
+        days_since_last_commit=days,
+    )
+
+
+class TestContributorDashboardPublic:
+    def test_page_returns_200_for_any_username(self, client: TestClient) -> None:
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/someuser")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_shows_username_in_header(self, client: TestClient) -> None:
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/alice")
+        assert "alice" in response.text
+
+    def test_no_pets_shows_empty_state(self, client: TestClient) -> None:
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/ghost")
+        assert response.status_code == 200
+        # No pets owned, no team pets
+        assert "ghost" in response.text
+
+
+class TestContributorDashboardOwnedPets:
+    def test_shows_owned_pet_in_your_pets_section(self, client: TestClient) -> None:
+        _create_pet(repo_owner="repoowner", repo_name="myrepo", name="Fluffy")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/repoowner")
+        assert "Fluffy" in response.text
+        assert "repoowner/myrepo" in response.text
+
+    def test_shows_health_bar_for_owned_pet(self, client: TestClient) -> None:
+        _create_pet(repo_owner="healthowner", repo_name="repo", name="Barney", health=75)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/healthowner")
+        assert "75%" in response.text
+
+    def test_shows_view_profile_link_for_owned_pet(self, client: TestClient) -> None:
+        _create_pet(repo_owner="linkowner2", repo_name="linkrepo2", name="Link")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/linkowner2")
+        assert "/pet/linkowner2/linkrepo2" in response.text
+
+
+class TestContributorDashboardTeamPets:
+    def test_shows_team_pet_when_user_is_contributor(self, client: TestClient) -> None:
+        _create_pet(repo_owner="teamorg2", repo_name="api", name="Chippy")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_active_stats(commits_30d=5),
+        ):
+            response = client.get("/dashboard/devuser")
+        assert "Chippy" in response.text
+        assert "teamorg2/api" in response.text
+
+    def test_shows_favorite_standing(self, client: TestClient) -> None:
+        _create_pet(repo_owner="corp3", repo_name="main", name="Star")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_active_stats(commits_30d=10, is_top=True),
+        ):
+            response = client.get("/dashboard/topdev")
+        assert "Favorite" in response.text
+
+    def test_shows_good_standing(self, client: TestClient) -> None:
+        _create_pet(repo_owner="corp4", repo_name="frontend", name="Buddy")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_active_stats(commits_30d=3, is_top=False),
+        ):
+            response = client.get("/dashboard/activedev")
+        assert "Good" in response.text
+
+    def test_shows_absent_standing(self, client: TestClient) -> None:
+        _create_pet(repo_owner="corp5", repo_name="legacy", name="Rex")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_absent_stats(days=45),
+        ):
+            response = client.get("/dashboard/idledev")
+        assert "Absent" in response.text
+
+    def test_excludes_non_contributor_pets(self, client: TestClient) -> None:
+        _create_pet(repo_owner="strangerorg", repo_name="repo", name="Stranger")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/notacontributor")
+        # Pet should not appear in team pets since user never contributed
+        assert "Stranger" not in response.text
+
+    def test_excludes_dead_pets_from_team_pets(self, client: TestClient) -> None:
+        _create_pet(repo_owner="deadorg", repo_name="deadrepo", name="Ghost", is_dead=True)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_active_stats(),
+        ) as mock_stats:
+            client.get("/dashboard/anydev")
+        # Dead pets in OTHER users' repos should not appear in team pets
+        assert mock_stats.call_count == 0
+
+    def test_shows_redemption_path_for_absent_pets(self, client: TestClient) -> None:
+        _create_pet(repo_owner="corp6", repo_name="infra", name="Spot")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_absent_stats(days=34),
+        ):
+            response = client.get("/dashboard/idledev2")
+        assert "Redemption Path" in response.text
+        assert "34 days ago" in response.text
+
+    def test_shows_link_to_pet_profile_in_team(self, client: TestClient) -> None:
+        _create_pet(repo_owner="corp7", repo_name="backend", name="Zippy")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_active_stats(),
+        ):
+            response = client.get("/dashboard/devlink")
+        assert "/pet/corp7/backend" in response.text
+
+
+class TestContributorDashboardStats:
+    def test_shows_total_repos_count(self, client: TestClient) -> None:
+        _create_pet(repo_owner="statowner", repo_name="r1", name="Pet1")
+        _create_pet(repo_owner="statteam", repo_name="r2", name="Pet2")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_active_stats(commits_30d=2),
+        ):
+            response = client.get("/dashboard/statowner")
+        assert response.status_code == 200
+
+    def test_authenticated_user_sees_nav_links(self, client: TestClient) -> None:
+        token = _create_user(user_id=200, github_login="navuser")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_contributor_stats",
+            new_callable=AsyncMock,
+            return_value=_no_contribution_stats(),
+        ):
+            response = client.get("/dashboard/navuser", cookies={"session_token": token})
+        assert "My Pets" in response.text
+        assert "Register" in response.text


### PR DESCRIPTION
## Summary

- Adds `/dashboard/{username}` — a public personal dashboard showing a contributor's standing across all registered pets
- **Your Pets** section lists pets in repos owned by the user (from the system DB, matched by `repo_owner`)
- **Team Pets** section shows pets in other repos where the user has recent GitHub commits, with standings:
  - 😍 **Favorite** — top committer in last 30 days
  - 😊 **Good** — active contributor in last 30 days
  - 😢 **Absent** — had commits before but not recently
- **Redemption Path** — for absent pets, links back to the repos to get re-engaged
- Summary stats bar: total repos, owned pets, favorites, and commits (30d)

## Changes

- `src/github_tamagotchi/main.py` — new `GET /dashboard/{username}` route
- `src/github_tamagotchi/services/github.py` — adds `ContributorStats` dataclass, `get_contributor_stats()`, and helper methods (`_fetch_commits_parallel`, `_get_user_last_commit`, `_has_failed_ci`)
- `src/github_tamagotchi/templates/contributor_dashboard.html` — new page template
- `tests/api/test_contributor_dashboard.py` — 16 tests covering public access, owned pets, team pet standings, and redemption path

## Testing

- [x] All 576 tests pass
- [x] Ruff lint clean
- [x] Mypy type check clean
- [x] New tests cover all standing types (favorite, good, absent), non-contributor exclusion, dead pet exclusion, and authenticated nav

Closes #31