### PR TITLE
Closes #134: Post-process generated pet images to remove background

### DIFF
--- a/src/github_tamagotchi/services/image_generation.py
+++ b/src/github_tamagotchi/services/image_generation.py
@@ -142,19 +142,18 @@ def remove_background(
         PNG image data with the background replaced by transparency.
     """
     img = Image.open(io.BytesIO(image_bytes)).convert("RGBA")
-    pixels = img.load()
-    width, height = img.size
-    for y in range(height):
-        for x in range(width):
-            r, g, b, a = pixels[x, y]  # type: ignore[index,misc]
-            if (
-                abs(r - chroma[0]) < tolerance
-                and abs(g - chroma[1]) < tolerance
-                and abs(b - chroma[2]) < tolerance
-            ):
-                pixels[x, y] = (r, g, b, 0)  # type: ignore[index,misc]
+    raw = bytearray(img.tobytes())
+    for i in range(0, len(raw), 4):
+        r, g, b = raw[i], raw[i + 1], raw[i + 2]
+        if (
+            abs(r - chroma[0]) < tolerance
+            and abs(g - chroma[1]) < tolerance
+            and abs(b - chroma[2]) < tolerance
+        ):
+            raw[i + 3] = 0
+    result = Image.frombytes("RGBA", img.size, bytes(raw))
     out = io.BytesIO()
-    img.save(out, format="PNG")
+    result.save(out, format="PNG")
     return out.getvalue()
 
 

--- a/src/github_tamagotchi/services/image_generation.py
+++ b/src/github_tamagotchi/services/image_generation.py
@@ -1,6 +1,7 @@
 """ComfyUI image generation service for pet sprites."""
 
 import hashlib
+import io
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import Any
 
 import httpx
 import structlog
+from PIL import Image
 
 from github_tamagotchi.core.config import settings
 from github_tamagotchi.models.pet import PetStage
@@ -110,7 +112,7 @@ DEFAULT_STYLE = "kawaii"
 POSITIVE_PROMPT_TEMPLATE = (
     "{style_prefix} {color} and {accent_color} coloring, "
     "{body_type} body shape, {feature} features, {stage_description}, "
-    "white background, centered composition, full body visible"
+    "solid flat bright magenta background #FF00FF, centered composition, full body visible"
 )
 
 NEGATIVE_PROMPT = (
@@ -118,6 +120,42 @@ NEGATIVE_PROMPT = (
     "multiple creatures, text, watermark, signature, cropped, "
     "scary, horror, dark, gritty, nsfw, violent, blood"
 )
+
+# Chroma-key colour used as the background in generated images
+CHROMA_KEY_COLOR: tuple[int, int, int] = (255, 0, 255)
+CHROMA_KEY_TOLERANCE: int = 40
+
+
+def remove_background(
+    image_bytes: bytes,
+    chroma: tuple[int, int, int] = CHROMA_KEY_COLOR,
+    tolerance: int = CHROMA_KEY_TOLERANCE,
+) -> bytes:
+    """Remove the chroma-key background from an image, making it transparent.
+
+    Args:
+        image_bytes: Raw PNG image data.
+        chroma: RGB colour to treat as background (default: magenta #FF00FF).
+        tolerance: Per-channel tolerance for colour matching.
+
+    Returns:
+        PNG image data with the background replaced by transparency.
+    """
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGBA")
+    pixels = img.load()
+    width, height = img.size
+    for y in range(height):
+        for x in range(width):
+            r, g, b, a = pixels[x, y]  # type: ignore[index]
+            if (
+                abs(r - chroma[0]) < tolerance
+                and abs(g - chroma[1]) < tolerance
+                and abs(b - chroma[2]) < tolerance
+            ):
+                pixels[x, y] = (r, g, b, 0)  # type: ignore[index]
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()
 
 
 @dataclass

--- a/src/github_tamagotchi/services/image_generation.py
+++ b/src/github_tamagotchi/services/image_generation.py
@@ -146,13 +146,13 @@ def remove_background(
     width, height = img.size
     for y in range(height):
         for x in range(width):
-            r, g, b, a = pixels[x, y]  # type: ignore[index]
+            r, g, b, a = pixels[x, y]  # type: ignore[index,misc]
             if (
                 abs(r - chroma[0]) < tolerance
                 and abs(g - chroma[1]) < tolerance
                 and abs(b - chroma[2]) < tolerance
             ):
-                pixels[x, y] = (r, g, b, 0)  # type: ignore[index]
+                pixels[x, y] = (r, g, b, 0)  # type: ignore[index,misc]
     out = io.BytesIO()
     img.save(out, format="PNG")
     return out.getvalue()

--- a/src/github_tamagotchi/services/image_queue.py
+++ b/src/github_tamagotchi/services/image_queue.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from github_tamagotchi.core.config import settings
 from github_tamagotchi.models.image_job import ImageGenerationJob, JobStatus
 from github_tamagotchi.models.pet import Pet, PetStage
-from github_tamagotchi.services.image_generation import ImageGenerationService
+from github_tamagotchi.services.image_generation import ImageGenerationService, remove_background
 from github_tamagotchi.services.openrouter import OpenRouterService
 from github_tamagotchi.services.provider import ImageProvider
 
@@ -287,6 +287,10 @@ async def process_job(session: AsyncSession, job: ImageGenerationJob) -> None:
                 raise RuntimeError(
                     f"Image generation failed for stage {stage}: {result.error}"
                 )
+
+            # Remove chroma-key background to produce a transparent PNG
+            if result.image_data:
+                result.image_data = remove_background(result.image_data)
 
             logger.info(
                 "Successfully generated image for stage",

--- a/tests/test_image_queue.py
+++ b/tests/test_image_queue.py
@@ -311,9 +311,15 @@ class TestProcessJob:
             filename="test_image.png",
         )
 
-        with patch(
-            "github_tamagotchi.services.image_queue.get_image_provider"
-        ) as mock_get_provider:
+        with (
+            patch(
+                "github_tamagotchi.services.image_queue.get_image_provider"
+            ) as mock_get_provider,
+            patch(
+                "github_tamagotchi.services.image_queue.remove_background",
+                return_value=b"transparent_png",
+            ),
+        ):
             mock_service = AsyncMock()
             mock_service.generate_pet_image.return_value = mock_result
             mock_get_provider.return_value = mock_service
@@ -336,9 +342,15 @@ class TestProcessJob:
             filename="test_image.png",
         )
 
-        with patch(
-            "github_tamagotchi.services.image_queue.get_image_provider"
-        ) as mock_get_provider:
+        with (
+            patch(
+                "github_tamagotchi.services.image_queue.get_image_provider"
+            ) as mock_get_provider,
+            patch(
+                "github_tamagotchi.services.image_queue.remove_background",
+                return_value=b"transparent_png",
+            ),
+        ):
             mock_service = AsyncMock()
             mock_service.generate_pet_image.return_value = mock_result
             mock_get_provider.return_value = mock_service
@@ -366,9 +378,15 @@ class TestProcessJob:
             filename="test_image.png",
         )
 
-        with patch(
-            "github_tamagotchi.services.image_queue.get_image_provider"
-        ) as mock_get_provider:
+        with (
+            patch(
+                "github_tamagotchi.services.image_queue.get_image_provider"
+            ) as mock_get_provider,
+            patch(
+                "github_tamagotchi.services.image_queue.remove_background",
+                return_value=b"transparent_png",
+            ),
+        ):
             mock_service = AsyncMock()
             mock_service.generate_pet_image.return_value = mock_result
             mock_get_provider.return_value = mock_service
@@ -460,9 +478,15 @@ class TestRunWorker:
             await asyncio.sleep(0.5)
             stop_event.set()
 
-        with patch(
-            "github_tamagotchi.services.image_queue.get_image_provider"
-        ) as mock_get_provider:
+        with (
+            patch(
+                "github_tamagotchi.services.image_queue.get_image_provider"
+            ) as mock_get_provider,
+            patch(
+                "github_tamagotchi.services.image_queue.remove_background",
+                return_value=b"transparent_png",
+            ),
+        ):
             mock_service = AsyncMock()
             mock_service.generate_pet_image.return_value = mock_result
             mock_get_provider.return_value = mock_service

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -350,9 +350,11 @@ class TestRemoveBackground:
 
     def _get_all_pixels(self, img: Image.Image) -> list[tuple[int, int, int, int]]:
         """Return all pixels in the image as a flat list of RGBA tuples."""
-        px = img.load()
-        w, h = img.size
-        return [px[x, y] for y in range(h) for x in range(w)]  # type: ignore[index]
+        raw = img.tobytes()
+        return [
+            (raw[i], raw[i + 1], raw[i + 2], raw[i + 3])
+            for i in range(0, len(raw), 4)
+        ]
 
     def test_flat_magenta_png_becomes_fully_transparent(self) -> None:
         """A solid magenta image should have every pixel alpha=0 after processing."""

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -1,9 +1,11 @@
 """Tests for the ComfyUI image generation service."""
 
+import io
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from PIL import Image
 
 from github_tamagotchi.models.pet import PetStage
 from github_tamagotchi.services.image_generation import (
@@ -19,6 +21,7 @@ from github_tamagotchi.services.image_generation import (
     build_workflow,
     get_pet_appearance,
     load_base_workflow,
+    remove_background,
     repo_to_seed,
 )
 
@@ -332,3 +335,86 @@ class TestGenerationResult:
         assert result.image_data is None
         assert result.filename is None
         assert result.error == "Something went wrong"
+
+
+def _make_png(width: int, height: int, color: tuple[int, int, int, int]) -> bytes:
+    """Create a solid-colour RGBA PNG in memory."""
+    img = Image.new("RGBA", (width, height), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestRemoveBackground:
+    """Tests for the chroma-key background removal function."""
+
+    def _get_all_pixels(self, img: Image.Image) -> list[tuple[int, int, int, int]]:
+        """Return all pixels in the image as a flat list of RGBA tuples."""
+        px = img.load()
+        w, h = img.size
+        return [px[x, y] for y in range(h) for x in range(w)]  # type: ignore[index]
+
+    def test_flat_magenta_png_becomes_fully_transparent(self) -> None:
+        """A solid magenta image should have every pixel alpha=0 after processing."""
+        magenta_png = _make_png(4, 4, (255, 0, 255, 255))
+        result_bytes = remove_background(magenta_png)
+
+        img = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+        pixels = self._get_all_pixels(img)
+        assert all(a == 0 for _, _, _, a in pixels), "All pixels should be transparent"
+
+    def test_non_chroma_pixels_are_preserved(self) -> None:
+        """Pixels that are not near magenta must keep their original colour and opacity."""
+        blue_png = _make_png(4, 4, (0, 0, 255, 255))
+        result_bytes = remove_background(blue_png)
+
+        img = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+        pixels = self._get_all_pixels(img)
+        assert all(a == 255 for _, _, _, a in pixels), "Blue pixels should remain opaque"
+        assert all(r == 0 and g == 0 and b == 255 for r, g, b, _ in pixels)
+
+    def test_mixed_image_transparent_background_opaque_body(self) -> None:
+        """Magenta background pixels become transparent; non-magenta body pixels stay opaque."""
+        # 2×2 image: top row magenta, bottom row blue
+        img = Image.new("RGBA", (2, 2), (255, 0, 255, 255))
+        img.putpixel((0, 1), (0, 0, 255, 255))
+        img.putpixel((1, 1), (0, 0, 255, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+
+        result_bytes = remove_background(buf.getvalue())
+        out = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+
+        # Top row (magenta) → transparent
+        assert out.getpixel((0, 0))[3] == 0
+        assert out.getpixel((1, 0))[3] == 0
+        # Bottom row (blue) → opaque
+        assert out.getpixel((0, 1))[3] == 255
+        assert out.getpixel((1, 1))[3] == 255
+
+    def test_returns_valid_png_bytes(self) -> None:
+        """Output must be valid PNG bytes."""
+        png = _make_png(2, 2, (255, 0, 255, 255))
+        result = remove_background(png)
+
+        assert result[:8] == b"\x89PNG\r\n\x1a\n", "Result should start with PNG magic bytes"
+
+    def test_tolerance_boundary_included(self) -> None:
+        """Pixel within tolerance of chroma colour should also become transparent."""
+        # tolerance=40 by default; use a colour 30 units away from magenta on each channel
+        near_magenta = (255 - 30, 0 + 30, 255 - 30, 255)  # still within tolerance
+        png = _make_png(2, 2, near_magenta)
+        result_bytes = remove_background(png)
+
+        img = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+        pixels = self._get_all_pixels(img)
+        assert all(a == 0 for _, _, _, a in pixels)
+
+    def test_custom_chroma_and_tolerance(self) -> None:
+        """Custom chroma colour and tolerance should be respected."""
+        red_png = _make_png(2, 2, (255, 0, 0, 255))
+        result_bytes = remove_background(red_png, chroma=(255, 0, 0), tolerance=10)
+
+        img = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+        pixels = self._get_all_pixels(img)
+        assert all(a == 0 for _, _, _, a in pixels)


### PR DESCRIPTION
## Summary

- Prompt background changed from white to magenta (`#FF00FF`) — a standard chroma-key colour unlikely to appear in kawaii/pixel-art creature designs
- `remove_background()` added to `image_generation.py`: opens the generated PNG, makes every pixel within tolerance of magenta fully transparent, and returns the result as a PNG with alpha channel
- Background removal is applied in `image_queue.py` immediately after each successful generation, before the image data is used further
- Pillow (`>=10.0.0`) was already a project dependency — no new deps needed

## Changes

- `services/image_generation.py`: change prompt template; add `remove_background()`
- `services/image_queue.py`: call `remove_background()` on result image data after successful generation
- `tests/unit/test_image_generation.py`: 6 new unit tests for `remove_background()` covering transparent background, preserved body pixels, mixed images, PNG output validity, tolerance boundary, and custom chroma
- `tests/test_image_queue.py`: patch `remove_background` in the four queue tests that use fake image bytes so they continue to test queue logic in isolation

## Testing

- [ ] All 566 tests pass
- [ ] `ruff check` clean
- [ ] `remove_background` tested: flat magenta → fully transparent; non-chroma pixels preserved; mixed image; PNG validity; tolerance boundary; custom chroma/tolerance

Closes #134