### PR TITLE
fix: check admin_github_logins at request time, not only on login

### DIFF
--- a/src/github_tamagotchi/api/auth.py
+++ b/src/github_tamagotchi/api/auth.py
@@ -98,7 +98,8 @@ async def get_current_user(
 
 async def get_admin_user(user: Annotated[User, Depends(get_current_user)]) -> User:
     """Dependency to require admin access."""
-    if not user.is_admin:
+    is_admin = user.is_admin or (user.github_login in settings.admin_github_logins)
+    if not is_admin:
         raise HTTPException(status_code=403, detail="Admin access required")
     return user
 


### PR DESCRIPTION
Admin access was gated on `user.is_admin` which is only set in the DB during the OAuth callback. Users in `admin_github_logins` but with a stale session got a 403. Now `get_admin_user` also checks the config list directly so it takes effect immediately.