### PR TITLE
Closes #27: Add security alert severity to pet health

### DIFF
--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -33,6 +33,10 @@ class RepoHealth:
     has_stale_dependencies: bool
     release_count_30d: int = field(default=0)
     contributor_count: int = field(default=0)
+    security_alerts_critical: int = 0
+    security_alerts_high: int = 0
+    security_alerts_medium: int = 0
+    security_alerts_low: int = 0
 
 
 @dataclass
@@ -158,6 +162,9 @@ class GitHubService:
             # Get contributor count (last 90 days)
             contributor_count = await self._get_contributor_count_90d(client, owner, repo)
 
+            # Get security alerts
+            security_counts = await self._get_security_alerts(client, owner, repo)
+
             return RepoHealth(
                 last_commit_at=last_commit_at,
                 open_prs_count=open_prs_count,
@@ -168,6 +175,10 @@ class GitHubService:
                 has_stale_dependencies=False,  # TODO: Check dependabot
                 release_count_30d=release_count_30d,
                 contributor_count=contributor_count,
+                security_alerts_critical=security_counts["critical"],
+                security_alerts_high=security_counts["high"],
+                security_alerts_medium=security_counts["medium"],
+                security_alerts_low=security_counts["low"],
             )
 
     async def _get_last_commit(
@@ -261,6 +272,33 @@ class GitHubService:
         except Exception as e:
             logger.warning("Failed to get CI status", error=str(e))
         return None
+
+    async def _get_security_alerts(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> dict[str, int]:
+        """Get open Dependabot security alert counts by severity."""
+        counts: dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/dependabot/alerts",
+                headers=self._get_headers(),
+                params={"state": "open", "per_page": 100},
+            )
+            self._check_rate_limit(resp)
+            if resp.status_code == 404:
+                # Dependabot not enabled or no access — treat as no alerts
+                return counts
+            resp.raise_for_status()
+            alerts: list[dict[str, Any]] = resp.json()
+            for alert in alerts:
+                severity = alert.get("security_advisory", {}).get("severity", "").lower()
+                if severity in counts:
+                    counts[severity] += 1
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get security alerts", error=str(e))
+        return counts
 
     def _get_oldest_age_hours(self, items: list[dict[str, Any]]) -> float:
         """Get age in hours of the oldest item."""

--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -14,6 +14,14 @@ HUNGRY_THRESHOLD_DAYS = 3  # No commits in 3 days = hungry
 WORRIED_THRESHOLD_HOURS = 48  # PR open > 48 hours = worried
 LONELY_THRESHOLD_DAYS = 7  # Issue unanswered > 1 week = lonely
 
+# Security alert health penalties per poll cycle
+SECURITY_HEALTH_PENALTY = {
+    "critical": 20,
+    "high": 10,
+    "medium": 5,
+    "low": 2,
+}
+
 # Experience thresholds for evolution
 EVOLUTION_THRESHOLDS = {
     PetStage.EGG: 0,
@@ -28,6 +36,10 @@ EVOLUTION_THRESHOLDS = {
 def calculate_mood(health: RepoHealth, current_health: int) -> PetMood:
     """Determine pet mood based on repository health metrics."""
     now = datetime.now(UTC)
+
+    # Check for sick (critical/high security alerts — highest priority)
+    if health.security_alerts_critical > 0 or health.security_alerts_high > 0:
+        return PetMood.SICK
 
     # Check for sick (stale dependencies)
     if health.has_stale_dependencies:
@@ -83,6 +95,16 @@ def calculate_health_delta(health: RepoHealth) -> int:
         delta -= 5
     if health.oldest_issue_age_days and health.oldest_issue_age_days > LONELY_THRESHOLD_DAYS:
         delta -= 5
+
+    # Security alert penalties (capped per severity to avoid instant death)
+    if health.security_alerts_critical > 0:
+        delta -= min(health.security_alerts_critical * SECURITY_HEALTH_PENALTY["critical"], 40)
+    if health.security_alerts_high > 0:
+        delta -= min(health.security_alerts_high * SECURITY_HEALTH_PENALTY["high"], 20)
+    if health.security_alerts_medium > 0:
+        delta -= min(health.security_alerts_medium * SECURITY_HEALTH_PENALTY["medium"], 10)
+    if health.security_alerts_low > 0:
+        delta -= min(health.security_alerts_low * SECURITY_HEALTH_PENALTY["low"], 4)
 
     return delta
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,10 @@ def healthy_repo() -> RepoHealth:
         oldest_issue_age_days=None,
         last_ci_success=True,
         has_stale_dependencies=False,
+        security_alerts_critical=0,
+        security_alerts_high=0,
+        security_alerts_medium=0,
+        security_alerts_low=0,
     )
 
 
@@ -204,6 +208,10 @@ def unhealthy_repo() -> RepoHealth:
         oldest_issue_age_days=30,
         last_ci_success=False,
         has_stale_dependencies=True,
+        security_alerts_critical=0,
+        security_alerts_high=0,
+        security_alerts_medium=0,
+        security_alerts_low=0,
     )
 
 
@@ -290,3 +298,36 @@ def mock_status_response_failure() -> dict[str, Any]:
         "state": "failure",
         "statuses": [],
     }
+
+
+@pytest.fixture
+def mock_security_alerts_response() -> list[dict[str, Any]]:
+    """Mock GitHub Dependabot alerts API response with mixed severities."""
+    return [
+        {
+            "number": 1,
+            "state": "open",
+            "security_advisory": {"severity": "critical", "summary": "Critical vuln"},
+        },
+        {
+            "number": 2,
+            "state": "open",
+            "security_advisory": {"severity": "high", "summary": "High vuln"},
+        },
+        {
+            "number": 3,
+            "state": "open",
+            "security_advisory": {"severity": "medium", "summary": "Medium vuln"},
+        },
+        {
+            "number": 4,
+            "state": "open",
+            "security_advisory": {"severity": "low", "summary": "Low vuln"},
+        },
+    ]
+
+
+@pytest.fixture
+def mock_security_alerts_empty() -> list[dict[str, Any]]:
+    """Mock GitHub Dependabot alerts API response with no alerts."""
+    return []

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -371,6 +371,101 @@ class TestAgeCalculations:
         assert 0 <= age < 1
 
 
+class TestGetSecurityAlerts:
+    """Tests for fetching Dependabot security alerts."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_counts_by_severity(
+        self, mock_security_alerts_response: list[dict[str, Any]]
+    ) -> None:
+        """Should return alert counts grouped by severity."""
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(200, json=mock_security_alerts_response)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_security_alerts(client, "owner", "repo")
+
+        assert result["critical"] == 1
+        assert result["high"] == 1
+        assert result["medium"] == 1
+        assert result["low"] == 1
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zeros_when_no_alerts(
+        self, mock_security_alerts_empty: list[dict[str, Any]]
+    ) -> None:
+        """Should return all zeros when there are no open alerts."""
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(200, json=mock_security_alerts_empty)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_security_alerts(client, "owner", "repo")
+
+        assert result == {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zeros_on_404(self) -> None:
+        """Should return zeros when Dependabot is not enabled (404)."""
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(404, json={"message": "Not Found"})
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_security_alerts(client, "owner", "repo")
+
+        assert result == {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zeros_on_error(self) -> None:
+        """Should return zeros when API call fails."""
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_security_alerts(client, "owner", "repo")
+
+        assert result == {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError when rate limit is hit."""
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(RateLimitError):
+                await service._get_security_alerts(client, "owner", "repo")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_counts_multiple_alerts_per_severity(self) -> None:
+        """Should count multiple alerts of the same severity correctly."""
+        alerts = [
+            {"number": i, "state": "open", "security_advisory": {"severity": "critical"}}
+            for i in range(1, 4)
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(200, json=alerts)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_security_alerts(client, "owner", "repo")
+
+        assert result["critical"] == 3
+        assert result["high"] == 0
+
+
 class TestGetRepoHealth:
     """Tests for the main get_repo_health method."""
 
@@ -383,6 +478,7 @@ class TestGetRepoHealth:
         mock_issues_response: list[dict[str, Any]],
         mock_repo_response: dict[str, Any],
         mock_status_response_success: dict[str, Any],
+        mock_security_alerts_empty: list[dict[str, Any]],
     ) -> None:
         """Should return a complete RepoHealth object."""
         respx.get("https://api.github.com/repos/owner/repo/commits").mock(
@@ -400,6 +496,9 @@ class TestGetRepoHealth:
         respx.get("https://api.github.com/repos/owner/repo/commits/main/status").mock(
             return_value=httpx.Response(200, json=mock_status_response_success)
         )
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(200, json=mock_security_alerts_empty)
+        )
 
         service = GitHubService(token="test")
         result = await service.get_repo_health("owner", "repo")
@@ -410,6 +509,47 @@ class TestGetRepoHealth:
         assert result.open_issues_count == 2  # 3 - 1 PR filtered
         assert result.last_ci_success is True
         assert result.has_stale_dependencies is False
+        assert result.security_alerts_critical == 0
+        assert result.security_alerts_high == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_security_alert_counts(
+        self,
+        mock_commit_response: list[dict[str, Any]],
+        mock_prs_response: list[dict[str, Any]],
+        mock_issues_response: list[dict[str, Any]],
+        mock_repo_response: dict[str, Any],
+        mock_status_response_success: dict[str, Any],
+        mock_security_alerts_response: list[dict[str, Any]],
+    ) -> None:
+        """Should include security alert counts in RepoHealth."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=mock_commit_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=mock_prs_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=mock_issues_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=mock_repo_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/main/status").mock(
+            return_value=httpx.Response(200, json=mock_status_response_success)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(200, json=mock_security_alerts_response)
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_repo_health("owner", "repo")
+
+        assert result.security_alerts_critical == 1
+        assert result.security_alerts_high == 1
+        assert result.security_alerts_medium == 1
+        assert result.security_alerts_low == 1
 
     @respx.mock
     @pytest.mark.asyncio
@@ -428,6 +568,9 @@ class TestGetRepoHealth:
         respx.get("https://api.github.com/repos/owner/repo/releases").mock(
             return_value=httpx.Response(500)
         )
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(500)
+        )
 
         service = GitHubService(token="test")
         result = await service.get_repo_health("owner", "repo")
@@ -439,6 +582,8 @@ class TestGetRepoHealth:
         assert result.last_ci_success is None
         assert result.release_count_30d == 0
         assert result.contributor_count == 0
+        assert result.security_alerts_critical == 0
+        assert result.security_alerts_high == 0
 
 
 class TestGetReleaseCount30d:

--- a/tests/unit/test_pet_logic.py
+++ b/tests/unit/test_pet_logic.py
@@ -10,6 +10,7 @@ from github_tamagotchi.services.pet_logic import (
     EVOLUTION_THRESHOLDS,
     HUNGRY_THRESHOLD_DAYS,
     LONELY_THRESHOLD_DAYS,
+    SECURITY_HEALTH_PENALTY,
     WORRIED_THRESHOLD_HOURS,
     calculate_experience,
     calculate_health_delta,
@@ -135,6 +136,63 @@ class TestCalculateMood:
             oldest_issue_age_days=None,
             last_ci_success=True,
             has_stale_dependencies=False,
+        )
+        assert calculate_mood(health, current_health=100) == PetMood.DANCING
+
+    def test_sick_when_critical_security_alert(self) -> None:
+        """Pet should be sick when there are critical security alerts."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=True,
+            has_stale_dependencies=False,
+            security_alerts_critical=1,
+        )
+        assert calculate_mood(health, current_health=100) == PetMood.SICK
+
+    def test_sick_when_high_security_alert(self) -> None:
+        """Pet should be sick when there are high severity security alerts."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=True,
+            has_stale_dependencies=False,
+            security_alerts_high=2,
+        )
+        assert calculate_mood(health, current_health=100) == PetMood.SICK
+
+    def test_security_alerts_take_priority_over_dancing(self) -> None:
+        """Critical security alerts take priority over CI success (dancing)."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=True,
+            has_stale_dependencies=False,
+            security_alerts_critical=1,
+        )
+        assert calculate_mood(health, current_health=100) == PetMood.SICK
+
+    def test_medium_low_security_alerts_do_not_cause_sick(self) -> None:
+        """Medium/low security alerts alone should not make pet sick."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=True,
+            has_stale_dependencies=False,
+            security_alerts_medium=3,
+            security_alerts_low=5,
         )
         assert calculate_mood(health, current_health=100) == PetMood.DANCING
 
@@ -340,6 +398,89 @@ class TestCalculateHealthDelta:
             contributor_count=4,
         )
         assert calculate_health_delta(active_health) > calculate_health_delta(base_health)
+
+    def test_critical_alert_penalty(self) -> None:
+        """Single critical alert should apply full penalty."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_critical=1,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["critical"]
+
+    def test_high_alert_penalty(self) -> None:
+        """Single high alert should apply penalty."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_high=1,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["high"]
+
+    def test_medium_alert_penalty(self) -> None:
+        """Single medium alert should apply penalty."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_medium=1,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["medium"]
+
+    def test_low_alert_penalty(self) -> None:
+        """Single low alert should apply penalty."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_low=1,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["low"]
+
+    def test_critical_alert_penalty_is_capped(self) -> None:
+        """Many critical alerts should be capped at max penalty."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_critical=100,
+        )
+        assert calculate_health_delta(health) == -40  # capped at 40
+
+    def test_no_security_alert_penalty_when_none(self) -> None:
+        """No security alerts means no penalty."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+        )
+        assert calculate_health_delta(health) == 0
 
 
 class TestCalculateExperience:


### PR DESCRIPTION
## Summary

- Fetches open Dependabot alerts from GitHub API, grouped by severity (critical, high, medium, low)
- Critical and high alerts make the pet SICK (higher priority than stale dependencies)
- All severity levels impose health penalties per poll cycle (capped to prevent instant death)
- 404 responses are handled gracefully — repos without Dependabot enabled return zero alerts

## Changes

- `RepoHealth` dataclass: 4 new fields for alert counts by severity
- `GitHubService._get_security_alerts()`: calls `/repos/{owner}/{repo}/dependabot/alerts`
- `pet_logic.py`: security alerts checked before stale deps in mood priority; health delta includes severity-scaled penalties
- Tests: 6 new tests for `_get_security_alerts`, 2 updated `TestGetRepoHealth` tests, 5 new mood tests, 6 new health delta tests, mock fixtures in conftest

## Testing

- [x] All new and existing tests pass (193 passed)
- [x] No regressions introduced
- [x] Pre-existing failures in test_mcp_server.py and test_landing.py are unchanged

Closes #27