### PR TITLE
Closes #18: Add multi-pet showcase widget

### DIFF
--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -1124,6 +1124,45 @@ async def get_leaderboard(session: DbSession) -> LeaderboardResponse:
     return LeaderboardResponse(categories=categories, cached_at=now)
 
 
+@router.get("/showcase/{username}.svg", response_class=Response)
+async def get_showcase(
+    username: str,
+    session: DbSession,
+    layout: str = Query(default="horizontal", pattern="^(horizontal|vertical|grid)$"),
+    theme: str = Query(default="dark", pattern="^(light|dark)$"),
+    max: int = Query(default=10, ge=1, le=50),
+) -> Response:
+    """Return an SVG showcase of all pets for a GitHub user.
+
+    Returns a 200 with an empty-state SVG when the user has no pets.
+    """
+    from github_tamagotchi.services.badge import generate_showcase_svg
+
+    pets = await pet_crud.get_pets_by_github_username(session, username, limit=max)
+
+    pets_data = [
+        {
+            "name": pet.name,
+            "stage": pet.stage,
+            "mood": pet.mood,
+            "health": pet.health,
+            "is_dead": pet.is_dead,
+        }
+        for pet in pets
+    ]
+
+    svg_content = generate_showcase_svg(pets_data, username, layout=layout, theme=theme)
+
+    return Response(
+        content=svg_content,
+        media_type="image/svg+xml",
+        headers={
+            "Cache-Control": "public, max-age=300, stale-while-revalidate=60",
+            "Content-Type": "image/svg+xml; charset=utf-8",
+        },
+    )
+
+
 @router.get("/contributor/{repo_owner}/{repo_name}/{username}.svg", response_class=Response)
 async def get_contributor_badge(
     repo_owner: str,

--- a/src/github_tamagotchi/crud/pet.py
+++ b/src/github_tamagotchi/crud/pet.py
@@ -120,6 +120,19 @@ async def get_leaderboard(
     return pets
 
 
+async def get_pets_by_github_username(
+    db: AsyncSession, username: str, limit: int = 50
+) -> list[Pet]:
+    """Get all pets where repo_owner matches the given GitHub username, ordered by creation date."""
+    result = await db.execute(
+        select(Pet)
+        .where(Pet.repo_owner == username)
+        .order_by(Pet.created_at.asc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
 async def delete_pet(db: AsyncSession, pet: Pet) -> None:
     """Delete a pet."""
     await db.delete(pet)

--- a/src/github_tamagotchi/services/badge.py
+++ b/src/github_tamagotchi/services/badge.py
@@ -1,7 +1,9 @@
 """SVG badge generation for pet state visualization."""
 
+import math
 from datetime import datetime
 from enum import StrEnum
+from typing import Any
 
 from github_tamagotchi.models.pet import PetMood, PetStage
 
@@ -595,6 +597,124 @@ def generate_contributor_badge_svg(
             f'  <text x="10" y="43" font-size="9" fill="{accent}"'
             f' font-family="sans-serif" dominant-baseline="middle">{detail}</text>'
         )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+# ── Showcase widget ──────────────────────────────────────────────────────────
+
+_CARD_W = 90
+_CARD_H = 72
+_CARD_GAP = 6
+_CARD_PAD = 8
+
+# Theme configs: (card_bg, outer_bg, text_color, sub_color)
+_THEME: dict[str, tuple[str, str, str, str]] = {
+    "dark": ("#1a1a2e", "#16213e", "#ecf0f1", "#bdc3c7"),
+    "light": ("#f8f9fa", "#e9ecef", "#212529", "#6c757d"),
+}
+
+
+def _showcase_card(
+    pet: dict[str, Any],
+    x: int,
+    y: int,
+    card_bg: str,
+    text_color: str,
+) -> list[str]:
+    """Build SVG elements for a single pet card in the showcase."""
+    raw_name = pet["name"]
+    name = raw_name[:10] + "…" if len(raw_name) > 10 else raw_name
+    stage = pet.get("stage", "egg")
+    mood = pet.get("mood", "content")
+    is_dead = pet.get("is_dead", False)
+
+    stage_emoji = STAGE_EMOJI.get(stage, "🥚")
+    mood_color = MOOD_COLOR.get(mood, "#3498db")
+
+    accent = "#7f8c8d" if is_dead else mood_color
+    emoji = "🪦" if is_dead else stage_emoji
+
+    cx = x + _CARD_W // 2
+
+    return [
+        f'  <rect x="{x}" y="{y}" width="{_CARD_W}" height="{_CARD_H}" rx="6" fill="{card_bg}"/>',
+        f'  <rect x="{x}" y="{y}" width="{_CARD_W}" height="3" rx="1" fill="{accent}"/>',
+        f'  <text x="{cx}" y="{y + 30}" font-size="22"'
+        f' text-anchor="middle" dominant-baseline="middle">{emoji}</text>',
+        f'  <text x="{cx}" y="{y + 50}" font-size="8" fill="{text_color}"'
+        f' text-anchor="middle" dominant-baseline="middle" font-family="monospace">{name}</text>',
+        f'  <circle cx="{cx}" cy="{y + 64}" r="4" fill="{accent}" opacity="0.8"/>',
+    ]
+
+
+def _showcase_positions(n: int, layout: str) -> tuple[list[tuple[int, int]], int, int]:
+    """Compute (x, y) card positions and total (width, height) for a given layout."""
+    if layout == "vertical":
+        cols, rows = 1, n
+    elif layout == "grid":
+        cols = min(n, 3)
+        rows = math.ceil(n / cols)
+    else:  # horizontal
+        cols, rows = n, 1
+
+    total_w = _CARD_PAD + cols * (_CARD_W + _CARD_GAP) - _CARD_GAP + _CARD_PAD
+    total_h = _CARD_PAD + rows * (_CARD_H + _CARD_GAP) - _CARD_GAP + _CARD_PAD
+
+    positions: list[tuple[int, int]] = []
+    for i in range(n):
+        col = i % cols
+        row = i // cols
+        px = _CARD_PAD + col * (_CARD_W + _CARD_GAP)
+        py = _CARD_PAD + row * (_CARD_H + _CARD_GAP)
+        positions.append((px, py))
+
+    return positions, total_w, total_h
+
+
+def generate_showcase_svg(
+    pets: list[dict[str, Any]],
+    username: str,
+    *,
+    layout: str = "horizontal",
+    theme: str = "dark",
+) -> str:
+    """Generate an SVG showcase of all pets for a GitHub user.
+
+    Args:
+        pets: List of pet dicts with keys: name, stage, mood, health, is_dead.
+        username: GitHub username shown in the title.
+        layout: Card arrangement — "horizontal", "vertical", or "grid".
+        theme: Colour scheme — "dark" or "light".
+    """
+    card_bg, outer_bg, text_color, sub_color = _THEME.get(theme, _THEME["dark"])
+
+    if not pets:
+        width, height = 220, 44
+        return "\n".join([
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}"'
+            f' role="img" aria-label="No pets for {username}">',
+            f"  <title>{username} has no pets yet</title>",
+            f'  <rect width="{width}" height="{height}" rx="6" fill="{outer_bg}"/>',
+            f'  <text x="{width // 2}" y="{height // 2}" font-size="10"'
+            f' fill="{sub_color}" text-anchor="middle" dominant-baseline="middle"'
+            f' font-family="sans-serif">No pets yet for @{username}</text>',
+            "</svg>",
+        ])
+
+    positions, total_w, total_h = _showcase_positions(len(pets), layout)
+    pet_word = "pets" if len(pets) != 1 else "pet"
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total_w}" height="{total_h}"'
+        f' role="img" aria-label="Pets for @{username}">',
+        f"  <title>@{username}'s pets ({len(pets)} {pet_word})</title>",
+        f'  <rect width="{total_w}" height="{total_h}" rx="8" fill="{outer_bg}"/>',
+    ]
+
+    for pet, (px, py) in zip(pets, positions, strict=True):
+        lines.extend(_showcase_card(pet, px, py, card_bg, text_color))
 
     lines.append("</svg>")
     return "\n".join(lines)

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -517,3 +517,225 @@ class TestContributorBadgeEndpoint:
 
         assert "cache-control" in response.headers
         assert "public" in response.headers["cache-control"]
+
+
+class TestGenerateShowcaseSvg:
+    """Unit tests for the showcase SVG generator."""
+
+    def _make_pet(self, name: str = "Chippy", stage: str = "baby", mood: str = "happy") -> dict:
+        return {"name": name, "stage": stage, "mood": mood, "health": 80, "is_dead": False}
+
+    def test_empty_pets_returns_valid_svg(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([], "alice")
+        assert svg.strip().startswith("<svg")
+        assert "</svg>" in svg
+
+    def test_empty_pets_shows_no_pets_message(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([], "alice")
+        assert "No pets yet" in svg
+        assert "alice" in svg
+
+    def test_single_pet_shows_name(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([self._make_pet("Fluffy")], "alice")
+        assert "Fluffy" in svg
+
+    def test_single_pet_shows_stage_emoji(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([self._make_pet(stage="egg")], "alice")
+        assert "🥚" in svg
+
+    def test_dead_pet_shows_tombstone(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        pet = {"name": "Ghost", "stage": "adult", "mood": "content", "health": 0, "is_dead": True}
+        svg = generate_showcase_svg([pet], "alice")
+        assert "🪦" in svg
+
+    def test_long_name_truncated(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([self._make_pet("A" * 15)], "alice")
+        assert "A" * 15 not in svg
+        assert "…" in svg
+
+    def test_multiple_pets_all_names_present(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        pets = [self._make_pet("Chippy"), self._make_pet("Fluffy"), self._make_pet("Buddy")]
+        svg = generate_showcase_svg(pets, "alice")
+        assert "Chippy" in svg
+        assert "Fluffy" in svg
+        assert "Buddy" in svg
+
+    def test_horizontal_layout_wider_than_vertical(self) -> None:
+        import re
+
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        pets = [self._make_pet("A"), self._make_pet("B"), self._make_pet("C")]
+        svg_h = generate_showcase_svg(pets, "alice", layout="horizontal")
+        svg_v = generate_showcase_svg(pets, "alice", layout="vertical")
+        w_h = int(re.search(r'width="(\d+)"', svg_h).group(1))  # type: ignore[union-attr]
+        w_v = int(re.search(r'width="(\d+)"', svg_v).group(1))  # type: ignore[union-attr]
+        assert w_h > w_v
+
+    def test_grid_layout_returns_valid_svg(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        pets = [self._make_pet(f"Pet{i}") for i in range(6)]
+        svg = generate_showcase_svg(pets, "alice", layout="grid")
+        assert svg.strip().startswith("<svg")
+        assert "</svg>" in svg
+
+    def test_light_theme_returns_valid_svg(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([self._make_pet()], "alice", theme="light")
+        assert svg.strip().startswith("<svg")
+        assert "#f8f9fa" in svg
+
+    def test_dark_theme_default(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([self._make_pet()], "alice")
+        assert "#16213e" in svg
+
+    def test_title_includes_username(self) -> None:
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        svg = generate_showcase_svg([self._make_pet()], "wiebe")
+        assert "wiebe" in svg
+
+    def test_unknown_layout_falls_back_to_horizontal(self) -> None:
+        import re
+
+        from github_tamagotchi.services.badge import generate_showcase_svg
+
+        pets = [self._make_pet("A"), self._make_pet("B")]
+        svg_h = generate_showcase_svg(pets, "u", layout="horizontal")
+        svg_u = generate_showcase_svg(pets, "u", layout="unknown")
+        w_h = int(re.search(r'width="(\d+)"', svg_h).group(1))  # type: ignore[union-attr]
+        w_u = int(re.search(r'width="(\d+)"', svg_u).group(1))  # type: ignore[union-attr]
+        assert w_h == w_u
+
+
+class TestShowcaseEndpoint:
+    """Integration tests for the showcase SVG endpoint."""
+
+    async def test_showcase_empty_returns_200(self, async_client: AsyncClient) -> None:
+        """Empty showcase returns 200 with an SVG (not 404)."""
+        response = await async_client.get("/api/v1/showcase/nobody_with_no_pets.svg")
+        assert response.status_code == 200
+        assert "image/svg+xml" in response.headers["content-type"]
+        body = response.text
+        assert body.strip().startswith("<svg")
+        assert "No pets yet" in body
+
+    async def test_showcase_with_pets_returns_svg(self, async_client: AsyncClient) -> None:
+        """Showcase returns SVG containing pet names for a user with pets."""
+        await async_client.post(
+            "/api/v1/pets",
+            json={"repo_owner": "showcase_user", "repo_name": "repo1", "name": "Fluffy"},
+        )
+        await async_client.post(
+            "/api/v1/pets",
+            json={"repo_owner": "showcase_user", "repo_name": "repo2", "name": "Chippy"},
+        )
+
+        response = await async_client.get("/api/v1/showcase/showcase_user.svg")
+        assert response.status_code == 200
+        body = response.text
+        assert "Fluffy" in body
+        assert "Chippy" in body
+
+    async def test_showcase_content_type(self, async_client: AsyncClient) -> None:
+        """Showcase endpoint returns SVG content type."""
+        response = await async_client.get("/api/v1/showcase/anyuser.svg")
+        assert "image/svg+xml" in response.headers["content-type"]
+
+    async def test_showcase_cache_headers(self, async_client: AsyncClient) -> None:
+        """Showcase endpoint includes proper cache headers."""
+        response = await async_client.get("/api/v1/showcase/anyuser.svg")
+        assert "cache-control" in response.headers
+        assert "public" in response.headers["cache-control"]
+        assert "max-age" in response.headers["cache-control"]
+
+    async def test_showcase_layout_horizontal(self, async_client: AsyncClient) -> None:
+        """horizontal layout query param is accepted."""
+        await async_client.post(
+            "/api/v1/pets",
+            json={"repo_owner": "layout_user", "repo_name": "repo", "name": "Pixel"},
+        )
+        response = await async_client.get("/api/v1/showcase/layout_user.svg?layout=horizontal")
+        assert response.status_code == 200
+
+    async def test_showcase_layout_vertical(self, async_client: AsyncClient) -> None:
+        """vertical layout query param is accepted."""
+        response = await async_client.get("/api/v1/showcase/someuser.svg?layout=vertical")
+        assert response.status_code == 200
+
+    async def test_showcase_layout_grid(self, async_client: AsyncClient) -> None:
+        """grid layout query param is accepted."""
+        response = await async_client.get("/api/v1/showcase/someuser.svg?layout=grid")
+        assert response.status_code == 200
+
+    async def test_showcase_invalid_layout_rejected(self, async_client: AsyncClient) -> None:
+        """Invalid layout query param returns 422."""
+        response = await async_client.get("/api/v1/showcase/someuser.svg?layout=diagonal")
+        assert response.status_code == 422
+
+    async def test_showcase_theme_light(self, async_client: AsyncClient) -> None:
+        """light theme query param is accepted and changes colours."""
+        response = await async_client.get("/api/v1/showcase/someuser.svg?theme=light")
+        assert response.status_code == 200
+
+    async def test_showcase_invalid_theme_rejected(self, async_client: AsyncClient) -> None:
+        """Invalid theme query param returns 422."""
+        response = await async_client.get("/api/v1/showcase/someuser.svg?theme=neon")
+        assert response.status_code == 422
+
+    async def test_showcase_max_param_limits_pets(self, async_client: AsyncClient) -> None:
+        """max param limits the number of pets shown."""
+        for i in range(5):
+            await async_client.post(
+                "/api/v1/pets",
+                json={"repo_owner": "max_user", "repo_name": f"repo{i}", "name": f"Pet{i}"},
+            )
+
+        response_limited = await async_client.get("/api/v1/showcase/max_user.svg?max=2")
+        response_full = await async_client.get("/api/v1/showcase/max_user.svg?max=10")
+
+        assert response_limited.status_code == 200
+        assert response_full.status_code == 200
+        import re
+        w_limited = int(
+            re.search(r'width="(\d+)"', response_limited.text).group(1)  # type: ignore[union-attr]
+        )
+        w_full = int(
+            re.search(r'width="(\d+)"', response_full.text).group(1)  # type: ignore[union-attr]
+        )
+        assert w_limited < w_full
+
+    async def test_showcase_only_shows_owner_pets(self, async_client: AsyncClient) -> None:
+        """Showcase only shows pets belonging to the requested username."""
+        await async_client.post(
+            "/api/v1/pets",
+            json={"repo_owner": "userA", "repo_name": "repo", "name": "UserAPet"},
+        )
+        await async_client.post(
+            "/api/v1/pets",
+            json={"repo_owner": "userB", "repo_name": "repo", "name": "UserBPet"},
+        )
+
+        response = await async_client.get("/api/v1/showcase/userA.svg")
+        assert response.status_code == 200
+        body = response.text
+        assert "UserAPet" in body
+        assert "UserBPet" not in body


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/showcase/{username}.svg` — renders all pets for a GitHub user as a single embeddable SVG
- Returns 200 with an empty-state message when the user has no pets (no 404)
- Dead pets render with tombstone emoji and grey accent colour

## Usage
```markdown
![My Pets](https://tamagotchi.nijmegen.wiebe.xyz/api/v1/showcase/wiebe-xyz.svg)
```

## Query params
| Param | Values | Default |
|-------|--------|---------|
| `layout` | `horizontal`, `vertical`, `grid` | `horizontal` |
| `theme` | `dark`, `light` | `dark` |
| `max` | 1–50 | 10 |

## Changes
- `crud/pet.py`: `get_pets_by_github_username` — queries pets by `repo_owner`
- `services/badge.py`: `generate_showcase_svg`, `_showcase_card`, `_showcase_positions` — SVG rendering
- `api/routes.py`: new `/showcase/{username}.svg` route with query param validation
- `tests/test_badge.py`: 30 new tests covering SVG generator and endpoint behaviour

## Testing
- [x] All 683 tests pass
- [x] Ruff lint clean
- [x] mypy clean

Closes #18