### PR TITLE
Closes #30: Add blame/heroes board to pet profile

### DIFF
--- a/alembic/versions/019_add_blame_board_enabled.py
+++ b/alembic/versions/019_add_blame_board_enabled.py
@@ -1,0 +1,35 @@
+"""Add blame_board_enabled to pets
+
+Revision ID: 019
+Revises: 018
+Create Date: 2026-04-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "019"
+down_revision: str | None = "018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "blame_board_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "blame_board_enabled")

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -241,6 +241,31 @@ class MilestonesResponse(BaseModel):
     milestones: list[MilestoneItem]
 
 
+class BlameEntryItem(BaseModel):
+    """A single blame entry on the blame board."""
+
+    issue: str
+    culprit: str
+    how_long: str
+
+
+class HeroEntryItem(BaseModel):
+    """A single hero entry on the heroes board."""
+
+    good_deed: str
+    hero: str
+    when: str
+
+
+class BlameBoardResponse(BaseModel):
+    """Response model for the blame/heroes board."""
+
+    is_healthy: bool
+    blame_board_enabled: bool
+    blame_entries: list[BlameEntryItem]
+    hero_entries: list[HeroEntryItem]
+
+
 class LeaderboardEntry(BaseModel):
     """A single entry on the leaderboard."""
 
@@ -758,6 +783,53 @@ async def get_pet_milestones(
     milestones = await get_milestones(session, pet.id)
     return MilestonesResponse(
         milestones=[MilestoneItem.model_validate(m) for m in milestones]
+    )
+
+
+@router.get("/pets/{repo_owner}/{repo_name}/blame-board", response_model=BlameBoardResponse)
+async def get_blame_board(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+) -> BlameBoardResponse:
+    """Get the blame/heroes board for a pet. Public endpoint.
+
+    Returns blame entries when the pet is unhealthy, and hero entries when healthy.
+    Returns empty lists when blame_board_enabled is False.
+    """
+    from github_tamagotchi.services.github import GitHubService
+
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Pet not found for {repo_owner}/{repo_name}",
+        )
+
+    if not pet.blame_board_enabled or pet.is_dead:
+        return BlameBoardResponse(
+            is_healthy=pet.health >= 50,
+            blame_board_enabled=pet.blame_board_enabled,
+            blame_entries=[],
+            hero_entries=[],
+        )
+
+    gh = GitHubService()
+    board = await gh.get_blame_board_data(
+        repo_owner, repo_name, pet.health, pet.mood
+    )
+
+    return BlameBoardResponse(
+        is_healthy=board.is_healthy,
+        blame_board_enabled=True,
+        blame_entries=[
+            BlameEntryItem(issue=e.issue, culprit=e.culprit, how_long=e.how_long)
+            for e in board.blame_entries
+        ],
+        hero_entries=[
+            HeroEntryItem(good_deed=e.good_deed, hero=e.hero, when=e.when)
+            for e in board.hero_entries
+        ],
     )
 
 

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -114,6 +114,11 @@ class Pet(Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
 
+    # Blame board visibility (opt-out by repo admin)
+    blame_board_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -77,6 +77,33 @@ class ContributorStats:
     days_since_last_commit: int | None  # None if no commits ever found
 
 
+@dataclass
+class BlameEntry:
+    """A single blame entry showing who is responsible for a pet health issue."""
+
+    issue: str  # human-readable description of the problem
+    culprit: str  # GitHub username
+    how_long: str  # human-readable duration (e.g. "2 days", "4 hours")
+
+
+@dataclass
+class HeroEntry:
+    """A single hero entry showing who contributed positively to pet health."""
+
+    good_deed: str  # human-readable description of the good deed
+    hero: str  # GitHub username
+    when: str  # human-readable time (e.g. "Today", "This week")
+
+
+@dataclass
+class BlameBoardData:
+    """Aggregated blame/hero board data for a repository."""
+
+    is_healthy: bool
+    blame_entries: list[BlameEntry]
+    hero_entries: list[HeroEntry]
+
+
 class GitHubService:
     """Service for fetching GitHub repository health metrics."""
 
@@ -625,6 +652,469 @@ class GitHubService:
         except Exception as e:
             logger.warning("Failed to get CI pass rate", error=str(e))
         return None, 0
+
+    async def get_blame_board_data(
+        self, owner: str, repo: str, pet_health: int, pet_mood: str
+    ) -> BlameBoardData:
+        """Fetch blame/hero board data for a repository.
+
+        When the pet is unhealthy (health < 50 or mood is negative), returns blame
+        entries showing who is responsible. When healthy, returns hero entries showing
+        who deserves credit.
+        """
+        unhealthy_moods = {"sick", "hungry", "worried", "lonely"}
+        is_healthy = pet_health >= 50 and pet_mood not in unhealthy_moods
+
+        async with httpx.AsyncClient() as client:
+            if is_healthy:
+                hero_entries = await self._build_hero_entries(client, owner, repo)
+                return BlameBoardData(
+                    is_healthy=True,
+                    blame_entries=[],
+                    hero_entries=hero_entries,
+                )
+            else:
+                blame_entries = await self._build_blame_entries(
+                    client, owner, repo, pet_mood
+                )
+                return BlameBoardData(
+                    is_healthy=False,
+                    blame_entries=blame_entries,
+                    hero_entries=[],
+                )
+
+    def _format_duration(self, dt: datetime) -> str:
+        """Format a datetime as a human-readable 'how long ago' string."""
+        now = datetime.now(UTC)
+        delta = now - dt
+        total_hours = delta.total_seconds() / 3600
+        if total_hours < 2:
+            return "just now"
+        if total_hours < 24:
+            return f"{int(total_hours)} hours"
+        days = int(total_hours / 24)
+        if days == 1:
+            return "1 day"
+        return f"{days} days"
+
+    def _format_when(self, dt: datetime) -> str:
+        """Format a datetime as a human-readable 'when' string."""
+        now = datetime.now(UTC)
+        delta = now - dt
+        total_hours = delta.total_seconds() / 3600
+        if total_hours < 24:
+            return "Today"
+        if total_hours < 48:
+            return "Yesterday"
+        days = int(total_hours / 24)
+        if days <= 7:
+            return "This week"
+        return f"{days} days ago"
+
+    async def _build_blame_entries(
+        self,
+        client: httpx.AsyncClient,
+        owner: str,
+        repo: str,
+        pet_mood: str,
+    ) -> list[BlameEntry]:
+        """Build blame entries for an unhealthy pet."""
+        entries: list[BlameEntry] = []
+
+        # Broken CI: find the author of the last failing commit on the default branch
+        ci_blame = await self._get_ci_blame(client, owner, repo)
+        if ci_blame:
+            entries.append(ci_blame)
+
+        # Stale PRs: find reviewers on long-open PRs
+        pr_blames = await self._get_stale_pr_blames(client, owner, repo)
+        entries.extend(pr_blames)
+
+        # No recent commits: show last committer
+        if pet_mood == "hungry" and not entries:
+            commit_blame = await self._get_last_committer_blame(client, owner, repo)
+            if commit_blame:
+                entries.append(commit_blame)
+
+        return entries[:5]  # cap at 5 entries
+
+    async def _get_ci_blame(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> BlameEntry | None:
+        """Return a blame entry if CI is currently broken."""
+        try:
+            # Get default branch
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}",
+                headers=self._get_headers(),
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            repo_data: dict[str, Any] = resp.json()
+            default_branch: str = repo_data["default_branch"]
+
+            # Get latest commit on default branch
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"sha": default_branch, "per_page": 1},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            if not commits:
+                return None
+
+            latest_commit = commits[0]
+            sha = latest_commit["sha"]
+            author_login: str | None = (
+                latest_commit["author"]["login"] if latest_commit.get("author") else None
+            )
+            commit_date_raw: str | None = (
+                latest_commit.get("commit", {}).get("committer", {}).get("date")
+            )
+
+            # Check CI status for this commit
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits/{sha}/check-runs",
+                headers={**self._get_headers(), "Accept": "application/vnd.github+json"},
+                params={"per_page": 30},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+            runs: list[dict[str, Any]] = data.get("check_runs", [])
+
+            has_failure = any(
+                r.get("conclusion") in ("failure", "timed_out", "action_required")
+                for r in runs
+                if r.get("status") == "completed"
+            )
+            all_success = runs and all(
+                r.get("conclusion") == "success"
+                for r in runs
+                if r.get("status") == "completed"
+            )
+
+            if not has_failure or all_success:
+                return None
+
+            if not author_login:
+                return None
+
+            how_long = "unknown"
+            if commit_date_raw:
+                commit_dt = datetime.fromisoformat(commit_date_raw.replace("Z", "+00:00"))
+                how_long = self._format_duration(commit_dt)
+
+            return BlameEntry(
+                issue="CI broken",
+                culprit=author_login,
+                how_long=how_long,
+            )
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get CI blame", error=str(e))
+        return None
+
+    async def _get_stale_pr_blames(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> list[BlameEntry]:
+        """Return blame entries for PRs with requested reviewers that are long overdue."""
+        entries: list[BlameEntry] = []
+        try:
+            prs = await self._get_open_prs(client, owner, repo)
+            now = datetime.now(UTC)
+            for pr in prs:
+                created_at_raw: str | None = pr.get("created_at")
+                if not created_at_raw:
+                    continue
+                created_at = datetime.fromisoformat(created_at_raw.replace("Z", "+00:00"))
+                age_hours = (now - created_at).total_seconds() / 3600
+                if age_hours < 48:
+                    continue
+
+                # Get requested reviewers
+                reviewers: list[dict[str, Any]] = pr.get("requested_reviewers", [])
+                pr_title: str = pr.get("title", f"PR #{pr.get('number', '?')}")
+                pr_number: int = pr.get("number", 0)
+                display_title = f"PR #{pr_number} needs review"
+                if len(pr_title) <= 40:
+                    display_title = f'"{pr_title}" needs review'
+
+                how_long = self._format_duration(created_at)
+                if reviewers:
+                    for reviewer in reviewers[:2]:  # at most 2 reviewers per PR
+                        login: str | None = reviewer.get("login")
+                        if login:
+                            entries.append(
+                                BlameEntry(
+                                    issue=display_title,
+                                    culprit=login,
+                                    how_long=how_long,
+                                )
+                            )
+                else:
+                    # No reviewer assigned — blame the PR author
+                    pr_user: dict[str, Any] | None = pr.get("user")
+                    author_login: str | None = pr_user.get("login") if pr_user else None
+                    if author_login:
+                        entries.append(
+                            BlameEntry(
+                                issue=display_title,
+                                culprit=author_login,
+                                how_long=how_long,
+                            )
+                        )
+                if len(entries) >= 3:
+                    break
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get stale PR blames", error=str(e))
+        return entries
+
+    async def _get_last_committer_blame(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> BlameEntry | None:
+        """Return a blame entry for the last committer when repo has gone quiet."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"per_page": 1},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            if not commits:
+                return None
+
+            commit = commits[0]
+            author_login: str | None = (
+                commit["author"]["login"] if commit.get("author") else None
+            )
+            commit_date_raw: str | None = (
+                commit.get("commit", {}).get("committer", {}).get("date")
+            )
+            if not author_login or not commit_date_raw:
+                return None
+
+            commit_dt = datetime.fromisoformat(commit_date_raw.replace("Z", "+00:00"))
+            how_long = self._format_duration(commit_dt)
+            return BlameEntry(
+                issue="No recent commits",
+                culprit=author_login,
+                how_long=f"last commit {how_long} ago",
+            )
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get last committer", error=str(e))
+        return None
+
+    async def _build_hero_entries(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> list[HeroEntry]:
+        """Build hero entries for a healthy pet."""
+        entries: list[HeroEntry] = []
+
+        # Top committer in last 30d
+        top_committer = await self._get_top_committer_hero(client, owner, repo)
+        if top_committer:
+            entries.append(top_committer)
+
+        # Recent PR mergers
+        pr_heroes = await self._get_pr_merger_heroes(client, owner, repo)
+        entries.extend(pr_heroes)
+
+        # CI passing — author of latest commit
+        ci_hero = await self._get_ci_fixer_hero(client, owner, repo)
+        if ci_hero:
+            entries.append(ci_hero)
+
+        # Deduplicate by hero+deed pair while preserving order
+        seen: set[tuple[str, str]] = set()
+        unique: list[HeroEntry] = []
+        for e in entries:
+            key = (e.hero, e.good_deed)
+            if key not in seen:
+                seen.add(key)
+                unique.append(e)
+
+        return unique[:5]  # cap at 5 entries
+
+    async def _get_top_committer_hero(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> HeroEntry | None:
+        """Return a hero entry for the top committer in the last 30 days."""
+        try:
+            since = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"since": since, "per_page": 100},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            if not commits:
+                return None
+
+            counts: dict[str, int] = {}
+            for c in commits:
+                login = c["author"]["login"] if c.get("author") else None
+                if login:
+                    counts[login] = counts.get(login, 0) + 1
+
+            if not counts:
+                return None
+
+            top_login = max(counts, key=lambda k: counts[k])
+            top_count = counts[top_login]
+            if top_count < 2:
+                return None
+
+            return HeroEntry(
+                good_deed=f"Merged {top_count} commit{'s' if top_count != 1 else ''} (30d)",
+                hero=top_login,
+                when="This month",
+            )
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get top committer hero", error=str(e))
+        return None
+
+    async def _get_pr_merger_heroes(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> list[HeroEntry]:
+        """Return hero entries for contributors who merged PRs recently."""
+        entries: list[HeroEntry] = []
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/pulls",
+                headers=self._get_headers(),
+                params={
+                    "state": "closed",
+                    "per_page": 20,
+                    "sort": "updated",
+                    "direction": "desc",
+                },
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            prs: list[dict[str, Any]] = resp.json()
+
+            merger_counts: dict[str, int] = {}
+            merger_latest: dict[str, datetime] = {}
+            cutoff = datetime.now(UTC) - timedelta(days=30)
+
+            for pr in prs:
+                merged_at_raw: str | None = pr.get("merged_at")
+                merged_by: dict[str, Any] | None = pr.get("merged_by")
+                if not merged_at_raw or not merged_by:
+                    continue
+                merged_at = datetime.fromisoformat(merged_at_raw.replace("Z", "+00:00"))
+                if merged_at < cutoff:
+                    continue
+                login: str | None = merged_by.get("login")
+                if not login:
+                    continue
+                merger_counts[login] = merger_counts.get(login, 0) + 1
+                if login not in merger_latest or merged_at > merger_latest[login]:
+                    merger_latest[login] = merged_at
+
+            # Return top 2 mergers
+            sorted_mergers = sorted(merger_counts, key=lambda k: merger_counts[k], reverse=True)
+            for login in sorted_mergers[:2]:
+                count = merger_counts[login]
+                when = self._format_when(merger_latest[login])
+                entries.append(
+                    HeroEntry(
+                        good_deed=f"Merged {count} PR{'s' if count != 1 else ''}",
+                        hero=login,
+                        when=when,
+                    )
+                )
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get PR merger heroes", error=str(e))
+        return entries
+
+    async def _get_ci_fixer_hero(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> HeroEntry | None:
+        """Return a hero entry for the author of the latest successful commit with passing CI."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}",
+                headers=self._get_headers(),
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            repo_data: dict[str, Any] = resp.json()
+            default_branch: str = repo_data["default_branch"]
+
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits",
+                headers=self._get_headers(),
+                params={"sha": default_branch, "per_page": 1},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            commits: list[dict[str, Any]] = resp.json()
+            if not commits:
+                return None
+
+            commit = commits[0]
+            sha = commit["sha"]
+            author_login: str | None = (
+                commit["author"]["login"] if commit.get("author") else None
+            )
+            commit_date_raw: str | None = (
+                commit.get("commit", {}).get("committer", {}).get("date")
+            )
+
+            if not author_login:
+                return None
+
+            # Check if CI is passing for this commit
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}/commits/{sha}/check-runs",
+                headers={**self._get_headers(), "Accept": "application/vnd.github+json"},
+                params={"per_page": 30},
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+            runs: list[dict[str, Any]] = data.get("check_runs", [])
+
+            completed_runs = [r for r in runs if r.get("status") == "completed"]
+            if not completed_runs:
+                return None
+
+            all_pass = all(r.get("conclusion") == "success" for r in completed_runs)
+            if not all_pass:
+                return None
+
+            when = "Today"
+            if commit_date_raw:
+                commit_dt = datetime.fromisoformat(commit_date_raw.replace("Z", "+00:00"))
+                when = self._format_when(commit_dt)
+
+            return HeroEntry(
+                good_deed="CI passing",
+                hero=author_login,
+                when=when,
+            )
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get CI fixer hero", error=str(e))
+        return None
 
     async def list_user_repos(
         self, page: int = 1, per_page: int = 100

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -288,6 +288,13 @@
                 </div>
             </section>
 
+            <!-- Blame / Heroes Board -->
+            <section class="profile-section" id="blame-board-section" style="margin-top: 2rem; display:none;">
+                <h2 id="blame-board-title"></h2>
+                <div id="blame-board-table" style="overflow-x:auto; margin-top:1rem;"></div>
+                <div id="blame-board-sins" style="margin-top:1rem;"></div>
+            </section>
+
             <!-- Comments Section -->
             <section class="profile-section" id="comments-section" style="margin-top: 2rem;">
                 <h2>Discussion</h2>
@@ -631,6 +638,64 @@
         }
 
         loadAchievements();
+
+        // Blame / Heroes Board
+        {% if not pet.is_dead %}
+        (async function loadBlameBoard() {
+            try {
+                const resp = await fetch('/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/blame-board');
+                if (!resp.ok) return;
+                const data = await resp.json();
+
+                if (!data.blame_board_enabled) return;
+
+                const section = document.getElementById('blame-board-section');
+                const title = document.getElementById('blame-board-title');
+                const tableWrap = document.getElementById('blame-board-table');
+                const sinsWrap = document.getElementById('blame-board-sins');
+
+                const entries = data.is_healthy ? data.hero_entries : data.blame_entries;
+                if (!entries || entries.length === 0) return;
+
+                if (data.is_healthy) {
+                    title.textContent = '\uD83D\uDE0A Why {{ pet.name }} is Happy';
+                } else {
+                    title.textContent = '\uD83D\uDE24 Why {{ pet.name }} is Upset';
+                }
+
+                // Build table
+                const table = document.createElement('table');
+                table.style.cssText = 'width:100%; border-collapse:collapse; font-size:0.9rem;';
+
+                const thead = document.createElement('thead');
+                thead.innerHTML = data.is_healthy
+                    ? '<tr><th style="text-align:left;padding:0.4rem 0.6rem;color:rgba(255,255,255,0.5);font-weight:600;border-bottom:1px solid rgba(255,255,255,0.1);">Good Deed</th><th style="text-align:left;padding:0.4rem 0.6rem;color:rgba(255,255,255,0.5);font-weight:600;border-bottom:1px solid rgba(255,255,255,0.1);">Hero</th><th style="text-align:left;padding:0.4rem 0.6rem;color:rgba(255,255,255,0.5);font-weight:600;border-bottom:1px solid rgba(255,255,255,0.1);">When</th></tr>'
+                    : '<tr><th style="text-align:left;padding:0.4rem 0.6rem;color:rgba(255,255,255,0.5);font-weight:600;border-bottom:1px solid rgba(255,255,255,0.1);">Issue</th><th style="text-align:left;padding:0.4rem 0.6rem;color:rgba(255,255,255,0.5);font-weight:600;border-bottom:1px solid rgba(255,255,255,0.1);">Culprit</th><th style="text-align:left;padding:0.4rem 0.6rem;color:rgba(255,255,255,0.5);font-weight:600;border-bottom:1px solid rgba(255,255,255,0.1);">How Long</th></tr>';
+                table.appendChild(thead);
+
+                const tbody = document.createElement('tbody');
+                entries.forEach(entry => {
+                    const tr = document.createElement('tr');
+                    const label = data.is_healthy ? entry.good_deed : entry.issue;
+                    const actor = data.is_healthy ? entry.hero : entry.culprit;
+                    const time = data.is_healthy ? entry.when : entry.how_long;
+                    const ghUrl = `https://github.com/${actor}`;
+                    tr.innerHTML = `
+                        <td style="padding:0.5rem 0.6rem; border-bottom:1px solid rgba(255,255,255,0.06);">${label.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</td>
+                        <td style="padding:0.5rem 0.6rem; border-bottom:1px solid rgba(255,255,255,0.06);"><a href="${ghUrl}" target="_blank" rel="noopener" style="color:#7c9bd6;text-decoration:none;">@${actor}</a></td>
+                        <td style="padding:0.5rem 0.6rem; border-bottom:1px solid rgba(255,255,255,0.06); color:rgba(255,255,255,0.55);">${time}</td>
+                    `;
+                    tbody.appendChild(tr);
+                });
+                table.appendChild(tbody);
+                tableWrap.appendChild(table);
+
+                section.style.display = 'block';
+            } catch {
+                // silently ignore
+            }
+        })();
+        {% endif %}
     </script>
 </body>
 </html>

--- a/tests/api/test_blame_board.py
+++ b/tests/api/test_blame_board.py
@@ -1,0 +1,150 @@
+"""Tests for the blame/heroes board API endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
+from github_tamagotchi.services.github import BlameBoardData, BlameEntry, HeroEntry
+
+
+async def _create_pet(
+    session_factory,
+    repo_owner: str = "testowner",
+    repo_name: str = "testrepo",
+    health: int = 80,
+    mood: str = PetMood.HAPPY.value,
+    blame_board_enabled: bool = True,
+    is_dead: bool = False,
+) -> None:
+    async with session_factory() as session:
+        pet = Pet(
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            name="Gotchi",
+            stage=PetStage.BABY.value,
+            mood=mood,
+            health=health,
+            experience=150,
+            blame_board_enabled=blame_board_enabled,
+            is_dead=is_dead,
+        )
+        session.add(pet)
+        await session.commit()
+
+
+class TestBlameBoardEndpoint:
+    """Tests for GET /api/v1/pets/{owner}/{repo}/blame-board."""
+
+    async def test_returns_404_for_missing_pet(self, async_client: AsyncClient) -> None:
+        """Should return 404 when pet does not exist."""
+        response = await async_client.get("/api/v1/pets/noowner/norepo/blame-board")
+        assert response.status_code == 404
+
+    async def test_returns_empty_when_disabled(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Should return empty lists when blame_board_enabled is False."""
+        from tests.conftest import test_session_factory
+
+        await _create_pet(test_session_factory, blame_board_enabled=False)
+
+        response = await async_client.get("/api/v1/pets/testowner/testrepo/blame-board")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["blame_board_enabled"] is False
+        assert data["blame_entries"] == []
+        assert data["hero_entries"] == []
+
+    async def test_returns_empty_for_dead_pet(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Should return empty lists for dead pets."""
+        from tests.conftest import test_session_factory
+
+        await _create_pet(test_session_factory, is_dead=True)
+
+        response = await async_client.get("/api/v1/pets/testowner/testrepo/blame-board")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["blame_entries"] == []
+        assert data["hero_entries"] == []
+
+    async def test_returns_heroes_for_healthy_pet(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Should return hero entries for a healthy pet."""
+        from tests.conftest import test_session_factory
+
+        await _create_pet(test_session_factory, health=80, mood=PetMood.HAPPY.value)
+
+        board = BlameBoardData(
+            is_healthy=True,
+            blame_entries=[],
+            hero_entries=[
+                HeroEntry(good_deed="Merged 5 PRs", hero="alice", when="This week"),
+            ],
+        )
+        with patch(
+            "github_tamagotchi.api.routes.GitHubService.get_blame_board_data",
+            new_callable=AsyncMock,
+            return_value=board,
+        ):
+            response = await async_client.get("/api/v1/pets/testowner/testrepo/blame-board")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_healthy"] is True
+        assert data["blame_board_enabled"] is True
+        assert len(data["hero_entries"]) == 1
+        assert data["hero_entries"][0]["hero"] == "alice"
+        assert data["hero_entries"][0]["good_deed"] == "Merged 5 PRs"
+        assert data["blame_entries"] == []
+
+    async def test_returns_blame_for_unhealthy_pet(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Should return blame entries for an unhealthy pet."""
+        from tests.conftest import test_session_factory
+
+        await _create_pet(test_session_factory, health=30, mood=PetMood.WORRIED.value)
+
+        board = BlameBoardData(
+            is_healthy=False,
+            blame_entries=[
+                BlameEntry(issue="CI broken", culprit="charlie", how_long="2 days"),
+                BlameEntry(issue="PR #42 needs review", culprit="alice", how_long="4 days"),
+            ],
+            hero_entries=[],
+        )
+        with patch(
+            "github_tamagotchi.api.routes.GitHubService.get_blame_board_data",
+            new_callable=AsyncMock,
+            return_value=board,
+        ):
+            response = await async_client.get("/api/v1/pets/testowner/testrepo/blame-board")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_healthy"] is False
+        assert data["blame_board_enabled"] is True
+        assert len(data["blame_entries"]) == 2
+        assert data["blame_entries"][0]["culprit"] == "charlie"
+        assert data["blame_entries"][0]["issue"] == "CI broken"
+        assert data["blame_entries"][0]["how_long"] == "2 days"
+        assert data["hero_entries"] == []
+
+    async def test_response_schema_keys_present(
+        self, async_client: AsyncClient, test_db: object
+    ) -> None:
+        """Response should always include required schema keys."""
+        from tests.conftest import test_session_factory
+
+        await _create_pet(test_session_factory, blame_board_enabled=False)
+
+        response = await async_client.get("/api/v1/pets/testowner/testrepo/blame-board")
+        data = response.json()
+        assert "is_healthy" in data
+        assert "blame_board_enabled" in data
+        assert "blame_entries" in data
+        assert "hero_entries" in data

--- a/tests/services/test_blame_board_service.py
+++ b/tests/services/test_blame_board_service.py
@@ -1,0 +1,330 @@
+"""Tests for GitHubService blame board methods."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from github_tamagotchi.services.github import GitHubService
+
+
+def _make_commit(login: str, days_ago: int = 0) -> dict[str, Any]:
+    dt = (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+    return {
+        "sha": f"sha_{login}_{days_ago}",
+        "author": {"login": login},
+        "commit": {"committer": {"date": dt}},
+    }
+
+
+def _make_pr(
+    number: int,
+    title: str,
+    days_old: int = 3,
+    reviewers: list[str] | None = None,
+    author: str = "prauthor",
+) -> dict[str, Any]:
+    created = (datetime.now(UTC) - timedelta(days=days_old)).isoformat()
+    return {
+        "number": number,
+        "title": title,
+        "created_at": created,
+        "user": {"login": author},
+        "requested_reviewers": [{"login": r} for r in (reviewers or [])],
+    }
+
+
+class TestFormatDuration:
+    """Tests for _format_duration helper."""
+
+    def test_just_now(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(minutes=30)
+        assert service._format_duration(dt) == "just now"
+
+    def test_hours(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(hours=5)
+        result = service._format_duration(dt)
+        assert "hours" in result
+
+    def test_days(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(days=3)
+        result = service._format_duration(dt)
+        assert "days" in result or "day" in result
+
+    def test_one_day(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(hours=25)
+        result = service._format_duration(dt)
+        assert result == "1 day"
+
+
+class TestFormatWhen:
+    """Tests for _format_when helper."""
+
+    def test_today(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(hours=2)
+        assert service._format_when(dt) == "Today"
+
+    def test_yesterday(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(hours=30)
+        assert service._format_when(dt) == "Yesterday"
+
+    def test_this_week(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(days=5)
+        assert service._format_when(dt) == "This week"
+
+    def test_days_ago(self) -> None:
+        service = GitHubService(token=None)
+        dt = datetime.now(UTC) - timedelta(days=10)
+        result = service._format_when(dt)
+        assert "ago" in result
+
+
+class TestGetBlameBoardData:
+    """Tests for get_blame_board_data orchestration."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_healthy_pet_returns_is_healthy_true(self) -> None:
+        """A healthy pet (health >= 50, happy mood) should yield is_healthy=True."""
+        # Mock all GitHub API calls to return empty/success
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json={"default_branch": "main"})
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=[_make_commit("alice")])
+        )
+        respx.get(
+            "https://api.github.com/repos/owner/repo/commits/sha_alice_0/check-runs"
+        ).mock(return_value=httpx.Response(200, json={"check_runs": []}))
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_blame_board_data(
+            "owner", "repo", pet_health=80, pet_mood="happy"
+        )
+        assert result.is_healthy is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_unhealthy_mood_returns_is_healthy_false(self) -> None:
+        """A worried mood should yield is_healthy=False regardless of health %."""
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json={"default_branch": "main"})
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=[_make_commit("alice")])
+        )
+        respx.get(
+            "https://api.github.com/repos/owner/repo/commits/sha_alice_0/check-runs"
+        ).mock(return_value=httpx.Response(200, json={"check_runs": []}))
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_blame_board_data(
+            "owner", "repo", pet_health=80, pet_mood="worried"
+        )
+        assert result.is_healthy is False
+
+
+class TestGetStalePrBlames:
+    """Tests for _get_stale_pr_blames."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_reviewer_as_culprit(self) -> None:
+        """Should blame a requested reviewer for a stale PR."""
+        pr = _make_pr(1, "Add feature", days_old=3, reviewers=["bob"])
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[pr])
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            entries = await service._get_stale_pr_blames(client, "owner", "repo")
+
+        assert len(entries) == 1
+        assert entries[0].culprit == "bob"
+        assert "review" in entries[0].issue.lower()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_blames_author_when_no_reviewer(self) -> None:
+        """Should blame PR author when no reviewers are assigned."""
+        pr = _make_pr(2, "Fix bug", days_old=4, reviewers=[], author="carol")
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[pr])
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            entries = await service._get_stale_pr_blames(client, "owner", "repo")
+
+        assert len(entries) == 1
+        assert entries[0].culprit == "carol"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skips_fresh_prs(self) -> None:
+        """PRs less than 48h old should not appear in blame."""
+        pr = _make_pr(3, "New PR", days_old=0, reviewers=["dave"])
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[pr])
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            entries = await service._get_stale_pr_blames(client, "owner", "repo")
+
+        assert entries == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_api_error(self) -> None:
+        """Should return empty list on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(500)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            entries = await service._get_stale_pr_blames(client, "owner", "repo")
+
+        assert entries == []
+
+
+class TestGetTopCommitterHero:
+    """Tests for _get_top_committer_hero."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_top_committer(self) -> None:
+        """Should return the user with the most commits in 30d."""
+        commits = [
+            _make_commit("alice"),
+            _make_commit("alice"),
+            _make_commit("alice"),
+            _make_commit("bob"),
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            hero = await service._get_top_committer_hero(client, "owner", "repo")
+
+        assert hero is not None
+        assert hero.hero == "alice"
+        assert "3" in hero.good_deed
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_for_single_commit(self) -> None:
+        """Should not credit someone for a single commit."""
+        commits = [_make_commit("alice")]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            hero = await service._get_top_committer_hero(client, "owner", "repo")
+
+        assert hero is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        """Should return None on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            hero = await service._get_top_committer_hero(client, "owner", "repo")
+
+        assert hero is None
+
+
+class TestGetPrMergerHeroes:
+    """Tests for _get_pr_merger_heroes."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_counts_merged_prs_per_merger(self) -> None:
+        """Should count and return top PR mergers."""
+        now = datetime.now(UTC)
+        prs = [
+            {
+                "merged_at": (now - timedelta(days=1)).isoformat(),
+                "merged_by": {"login": "alice"},
+            },
+            {
+                "merged_at": (now - timedelta(days=2)).isoformat(),
+                "merged_by": {"login": "alice"},
+            },
+            {
+                "merged_at": (now - timedelta(days=3)).isoformat(),
+                "merged_by": {"login": "bob"},
+            },
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            heroes = await service._get_pr_merger_heroes(client, "owner", "repo")
+
+        assert len(heroes) >= 1
+        assert heroes[0].hero == "alice"
+        assert "2" in heroes[0].good_deed
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ignores_old_merges(self) -> None:
+        """Should ignore merges older than 30 days."""
+        now = datetime.now(UTC)
+        prs = [
+            {
+                "merged_at": (now - timedelta(days=40)).isoformat(),
+                "merged_by": {"login": "alice"},
+            },
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            heroes = await service._get_pr_merger_heroes(client, "owner", "repo")
+
+        assert heroes == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_api_error(self) -> None:
+        """Should return empty list on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(500)
+        )
+
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            heroes = await service._get_pr_merger_heroes(client, "owner", "repo")
+
+        assert heroes == []


### PR DESCRIPTION
## Summary

- When a pet is **unhealthy** (mood: sick/hungry/worried/lonely, or health < 50%), shows a blame board: who broke CI, who hasn't reviewed stale PRs, who let the repo go quiet
- When a pet is **healthy**, shows a heroes board: top committer in 30d, most active PR merger, CI passer
- Board is loaded asynchronously in the browser — no server-side render overhead
- Per-repo opt-out: `blame_board_enabled` field on Pet (default: true). Repo owner can disable

## Changes

- `GitHubService`: `get_blame_board_data()`, `BlameEntry`, `HeroEntry`, `BlameBoardData` dataclasses; sub-methods for CI blame, stale PR blame, top committer hero, PR merger heroes, CI fixer hero
- `GET /api/v1/pets/{owner}/{repo}/blame-board` endpoint with `BlameBoardResponse` model
- `pet_profile.html`: blame/heroes board section, populated by JS (same pattern as achievements)
- `Pet` model: `blame_board_enabled` boolean field (server default: true)
- Migration `019`: adds `blame_board_enabled` column
- Tests: `tests/api/test_blame_board.py`, `tests/services/test_blame_board_service.py`

## Testing

- [x] All tests pass (656 passed)
- [x] Linter clean
- [x] Coverage above 70% (71.84%)
- [x] No breaking changes

Closes #30