### PR TITLE
fix: sync is_admin from config on every request so admin nav link appears

### DIFF
--- a/src/github_tamagotchi/api/auth.py
+++ b/src/github_tamagotchi/api/auth.py
@@ -93,6 +93,11 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
+    # Sync is_admin from config on every request so nav links and gates stay consistent
+    should_be_admin = user.github_login in settings.admin_github_logins
+    if user.is_admin != should_be_admin:
+        user.is_admin = should_be_admin
+        await session.flush()
     return user
 
 


### PR DESCRIPTION
The admin nav link in templates checks `user.is_admin` from the DB, but that flag is only written during the OAuth callback. Any user added to `admin_github_logins` after their first login never sees the admin menu (even though the route now lets them through via #136). This syncs the DB flag from config on every `get_current_user` call so templates and route guards stay consistent — no re-login required.