### PR TITLE
Closes #32: Add org-wide pet overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/src/github_tamagotchi/crud/pet.py
+++ b/src/github_tamagotchi/crud/pet.py
@@ -133,6 +133,18 @@ async def get_pets_by_github_username(
     return list(result.scalars().all())
 
 
+async def get_org_pets(db: AsyncSession, org_name: str) -> list[Pet]:
+    """Get all pets belonging to an org, case-insensitive, ordered by health desc."""
+    from sqlalchemy import func as sqlfunc
+
+    result = await db.execute(
+        select(Pet)
+        .where(sqlfunc.lower(Pet.repo_owner) == org_name.lower())
+        .order_by(Pet.health.desc())
+    )
+    return list(result.scalars().all())
+
+
 async def delete_pet(db: AsyncSession, pet: Pet) -> None:
     """Delete a pet."""
     await db.delete(pet)

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -587,6 +587,74 @@ async def leaderboard_page(
     )
 
 
+@app.get("/org/{org_name}", response_class=HTMLResponse)
+async def org_overview(
+    request: Request,
+    org_name: str,
+    user: OptionalUser,
+    session: DbSession,
+) -> HTMLResponse:
+    """Org-wide pet overview: all pets, aggregate health, and contributor leaderboard."""
+    import asyncio
+
+    from github_tamagotchi.crud.pet import get_org_pets
+
+    pets = await get_org_pets(session, org_name)
+
+    # Aggregate health stats
+    total = len(pets)
+    healthy = sum(1 for p in pets if p.health >= 70 and not p.is_dead)
+    hungry = sum(1 for p in pets if 30 <= p.health < 70 and not p.is_dead)
+    sick = sum(1 for p in pets if p.health < 30 and not p.is_dead)
+    dead = sum(1 for p in pets if p.is_dead)
+    avg_health = int(sum(p.health for p in pets) / total) if total else 0
+
+    # Neglected repos: health < 30 or dead
+    neglected = [p for p in pets if p.is_dead or p.health < 30]
+
+    # Fetch top contributor per pet in parallel (best-effort)
+    top_contributors: list[str | None] = []
+    if pets:
+        tasks = [
+            GitHubService().get_top_contributor(p.repo_owner, p.repo_name) for p in pets
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in results:
+            top_contributors.append(r if isinstance(r, str) else None)
+
+    # Build per-pet display entries
+    pet_entries = [
+        {"pet": p, "top_caretaker": top_contributors[i] if i < len(top_contributors) else None}
+        for i, p in enumerate(pets)
+    ]
+
+    # Build org contributor leaderboard (count of repos per top contributor)
+    caretaker_counts: dict[str, int] = {}
+    for entry in pet_entries:
+        caretaker = entry["top_caretaker"]
+        if caretaker:
+            caretaker_counts[caretaker] = caretaker_counts.get(caretaker, 0) + 1
+    org_leaderboard = sorted(caretaker_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+
+    return templates.TemplateResponse(
+        request,
+        "org_overview.html",
+        {
+            "user": user,
+            "org_name": org_name,
+            "pet_entries": pet_entries,
+            "total": total,
+            "healthy": healthy,
+            "hungry": hungry,
+            "sick": sick,
+            "dead": dead,
+            "avg_health": avg_health,
+            "neglected": neglected,
+            "org_leaderboard": org_leaderboard,
+        },
+    )
+
+
 @app.get("/pet/{repo_owner}/{repo_name}", response_class=HTMLResponse)
 async def pet_profile(
     request: Request,

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -632,7 +632,7 @@ async def org_overview(
     caretaker_counts: dict[str, int] = {}
     for entry in pet_entries:
         caretaker = entry["top_caretaker"]
-        if caretaker:
+        if isinstance(caretaker, str):
             caretaker_counts[caretaker] = caretaker_counts.get(caretaker, 0) + 1
     org_leaderboard = sorted(caretaker_counts.items(), key=lambda x: x[1], reverse=True)[:10]
 

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -1180,3 +1180,34 @@ class GitHubService:
                 logger.warning("Failed to list user repos", error=str(e))
                 return []
 
+    async def get_top_contributor(self, owner: str, repo: str) -> str | None:
+        """Return the GitHub login of the top committer in the last 30 days, or None."""
+        async with httpx.AsyncClient() as client:
+            since_30d = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+            try:
+                resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/commits",
+                    headers=self._get_headers(),
+                    params={"since": since_30d, "per_page": 100},
+                )
+                self._check_rate_limit(resp)
+                resp.raise_for_status()
+                commits: list[dict[str, Any]] = resp.json()
+            except RateLimitError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "Failed to get top contributor", repo=f"{owner}/{repo}", error=str(e)
+                )
+                return None
+
+        author_counts: dict[str, int] = {}
+        for c in commits:
+            login = c["author"].get("login") if c.get("author") else None
+            if login:
+                author_counts[login] = author_counts.get(login, 0) + 1
+
+        if not author_counts:
+            return None
+        return max(author_counts, key=lambda k: author_counts[k])
+

--- a/src/github_tamagotchi/templates/org_overview.html
+++ b/src/github_tamagotchi/templates/org_overview.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ org_name }}'s Pets — GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <nav class="user-nav">
+        <div class="container">
+            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
+            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
+                {% if user %}
+                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
+                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
+                {% if user.is_admin %}
+                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
+                {% endif %}
+                {% endif %}
+                <a href="/leaderboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Leaderboard</a>
+            </div>
+            <div class="user-info">
+                {% if user %}
+                    {% if user.github_avatar_url %}
+                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
+                    {% endif %}
+                    <span class="user-name">{{ user.github_login }}</span>
+                    <button class="logout-button" id="logout-btn">Log out</button>
+                {% else %}
+                    <a href="/auth/github" class="cta-button" style="padding:0.4rem 1rem; font-size:0.875rem;">Login with GitHub</a>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
+
+    <main style="padding-top: 5rem; min-height: 80vh;">
+        <div class="container">
+
+            <!-- Header -->
+            <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem;">
+                <img src="https://github.com/{{ org_name }}.png?size=64" alt="{{ org_name }}" style="width: 48px; height: 48px; border-radius: 50%; border: 2px solid var(--surface-light);">
+                <div>
+                    <h1 style="font-size: 1.75rem; font-weight: 700; margin: 0;">{{ org_name }}</h1>
+                    <div style="color: var(--text-muted); font-size: 0.9rem;">Org Pet Overview</div>
+                </div>
+            </div>
+
+            {% if total == 0 %}
+            <!-- Empty state -->
+            <div style="text-align: center; padding: 4rem 0; color: var(--text-muted);">
+                <div style="font-size: 4rem; margin-bottom: 1rem;">&#129361;</div>
+                <p>No pets registered for <strong>{{ org_name }}</strong> yet.</p>
+                <a href="/register" style="color: var(--accent);">Register a repo</a> to get started.
+            </div>
+            {% else %}
+
+            <!-- Health overview banner -->
+            <div class="feature" style="padding: 1.25rem; margin-top: 1.5rem; margin-bottom: 1.5rem; display: flex; flex-wrap: wrap; align-items: center; gap: 1.5rem; justify-content: space-between;">
+                <div>
+                    <div style="font-size: 1.1rem; font-weight: 700;">{{ org_name }}'s Pets</div>
+                    <div style="color: var(--text-muted); font-size: 0.85rem; margin-top: 0.2rem;">
+                        {{ total }} pet{{ 's' if total != 1 else '' }}
+                        &nbsp;&middot;&nbsp;
+                        avg health {{ avg_health }}
+                    </div>
+                </div>
+                <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+                    <div style="text-align: center;">
+                        <div style="font-size: 1.4rem; font-weight: 700; color: #4caf50;">{{ healthy }}</div>
+                        <div style="color: var(--text-muted); font-size: 0.75rem;">Healthy</div>
+                    </div>
+                    <div style="text-align: center;">
+                        <div style="font-size: 1.4rem; font-weight: 700; color: #ff9800;">{{ hungry }}</div>
+                        <div style="color: var(--text-muted); font-size: 0.75rem;">Hungry</div>
+                    </div>
+                    <div style="text-align: center;">
+                        <div style="font-size: 1.4rem; font-weight: 700; color: #f44336;">{{ sick }}</div>
+                        <div style="color: var(--text-muted); font-size: 0.75rem;">Sick</div>
+                    </div>
+                    {% if dead > 0 %}
+                    <div style="text-align: center;">
+                        <div style="font-size: 1.4rem; font-weight: 700; color: var(--text-muted);">{{ dead }}</div>
+                        <div style="color: var(--text-muted); font-size: 0.75rem;">Dead</div>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- All Pets table -->
+            <h2 style="font-size: 1.15rem; font-weight: 700; margin-bottom: 0.75rem;">All Pets</h2>
+            <div class="feature" style="padding: 0; overflow: hidden; margin-bottom: 2.5rem;">
+                <table style="width: 100%; border-collapse: collapse; font-size: 0.9rem;">
+                    <thead>
+                        <tr style="border-bottom: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.03);">
+                            <th style="padding: 0.75rem 1rem; text-align: left; font-weight: 600; color: var(--text-muted);">Pet</th>
+                            <th style="padding: 0.75rem 1rem; text-align: left; font-weight: 600; color: var(--text-muted);">Repo</th>
+                            <th style="padding: 0.75rem 1rem; text-align: left; font-weight: 600; color: var(--text-muted);">Stage</th>
+                            <th style="padding: 0.75rem 1rem; text-align: left; font-weight: 600; color: var(--text-muted);">Health</th>
+                            <th style="padding: 0.75rem 1rem; text-align: left; font-weight: 600; color: var(--text-muted);">Top Caretaker</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in pet_entries %}
+                        {% set pet = entry.pet %}
+                        <tr style="border-bottom: 1px solid rgba(255,255,255,0.05);{% if pet.is_dead %} opacity: 0.5;{% endif %}">
+                            <td style="padding: 0.75rem 1rem;">
+                                <a href="/pet/{{ pet.repo_owner }}/{{ pet.repo_name }}" style="display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: inherit;">
+                                    <span style="font-size: 1.2rem;">
+                                        {% if pet.is_dead %}&#129680;
+                                        {% elif pet.stage == "egg" %}🥚
+                                        {% elif pet.stage == "baby" %}🐣
+                                        {% elif pet.stage == "child" %}🐥
+                                        {% elif pet.stage == "teen" %}🐦
+                                        {% elif pet.stage == "adult" %}🦉
+                                        {% elif pet.stage == "elder" %}🦅
+                                        {% else %}🥚{% endif %}
+                                    </span>
+                                    <span style="font-weight: 600;">{{ pet.name }}</span>
+                                </a>
+                            </td>
+                            <td style="padding: 0.75rem 1rem; color: var(--text-muted); font-size: 0.85rem;">{{ pet.repo_owner }}/{{ pet.repo_name }}</td>
+                            <td style="padding: 0.75rem 1rem;">
+                                <span style="background: var(--surface-light); padding: 0.15rem 0.5rem; border-radius: 99px; font-size: 0.8rem;">{{ pet.stage | capitalize }}</span>
+                            </td>
+                            <td style="padding: 0.75rem 1rem;">
+                                <div style="display: flex; align-items: center; gap: 0.5rem;">
+                                    <div style="width: 60px; height: 6px; background: var(--surface-light); border-radius: 3px; overflow: hidden;">
+                                        <div style="height: 100%; width: {{ pet.health }}%; background: {% if pet.health >= 70 %}#4caf50{% elif pet.health >= 30 %}#ff9800{% else %}#f44336{% endif %}; border-radius: 3px;"></div>
+                                    </div>
+                                    <span style="font-size: 0.85rem; color: {% if pet.health >= 70 %}#4caf50{% elif pet.health >= 30 %}#ff9800{% else %}#f44336{% endif %};">{{ pet.health }}</span>
+                                </div>
+                            </td>
+                            <td style="padding: 0.75rem 1rem; font-size: 0.85rem;">
+                                {% if entry.top_caretaker %}
+                                <a href="/dashboard/{{ entry.top_caretaker }}" style="color: var(--accent); text-decoration: none;">@{{ entry.top_caretaker }}</a>
+                                {% else %}
+                                <span style="color: var(--text-muted);">Nobody (!)</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            {% if org_leaderboard %}
+            <h2 style="font-size: 1.15rem; font-weight: 700; margin-bottom: 0.75rem;">Org Leaderboard</h2>
+            <div class="feature" style="padding: 1.25rem; margin-bottom: 2.5rem;">
+                <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 1rem;">Top caretakers across all {{ org_name }} repos (last 30 days)</p>
+                <ol style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem;">
+                    {% for username, count in org_leaderboard %}
+                    <li style="display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0.25rem;">
+                        <span style="font-size: 0.95rem; font-weight: 700; width: 1.5rem; text-align: center; color: {% if loop.index == 1 %}#ffd700{% elif loop.index == 2 %}#c0c0c0{% elif loop.index == 3 %}#cd7f32{% else %}var(--text-muted){% endif %};">
+                            {% if loop.index == 1 %}&#129351;
+                            {% elif loop.index == 2 %}&#129352;
+                            {% elif loop.index == 3 %}&#129353;
+                            {% else %}{{ loop.index }}{% endif %}
+                        </span>
+                        <img src="https://github.com/{{ username }}.png?size=32" alt="{{ username }}" style="width: 24px; height: 24px; border-radius: 50%;">
+                        <a href="/dashboard/{{ username }}" style="flex: 1; color: inherit; text-decoration: none; font-weight: 500;">@{{ username }}</a>
+                        <span style="color: var(--text-muted); font-size: 0.85rem;">Favorite of {{ count }} pet{{ 's' if count != 1 else '' }}</span>
+                    </li>
+                    {% endfor %}
+                </ol>
+            </div>
+            {% endif %}
+
+            {% if neglected %}
+            <h2 style="font-size: 1.15rem; font-weight: 700; margin-bottom: 0.75rem; color: #f44336;">Neglected Repos</h2>
+            <div class="feature" style="padding: 1.25rem; border: 1px solid rgba(244, 67, 54, 0.3); margin-bottom: 2.5rem;">
+                <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 1rem;">These repos need attention:</p>
+                <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem;">
+                    {% for pet in neglected %}
+                    <li style="display: flex; align-items: center; gap: 0.75rem;">
+                        <span>{% if pet.is_dead %}&#129680;{% else %}&#128565;{% endif %}</span>
+                        <a href="/pet/{{ pet.repo_owner }}/{{ pet.repo_name }}" style="color: var(--accent); text-decoration: none; font-weight: 500;">{{ pet.repo_owner }}/{{ pet.repo_name }}</a>
+                        <span style="color: var(--text-muted); font-size: 0.85rem;">
+                            {% if pet.is_dead %}Dead{% else %}Health {{ pet.health }}{% endif %}
+                        </span>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+
+            {% endif %}
+        </div>
+    </main>
+
+    <footer style="padding: 2rem; text-align: center; color: var(--text-muted); font-size: 0.85rem; border-top: 1px solid rgba(255,255,255,0.08);">
+        <a href="/" style="color: var(--text-muted); text-decoration: none;">GitHub Tamagotchi</a>
+    </footer>
+
+    {% if user %}
+    <script>
+        document.getElementById('logout-btn')?.addEventListener('click', async () => {
+            await fetch('/auth/logout', { method: 'POST' });
+            window.location.href = '/';
+        });
+    </script>
+    {% endif %}
+</body>
+</html>

--- a/tests/api/test_org_overview.py
+++ b/tests/api/test_org_overview.py
@@ -1,0 +1,234 @@
+"""Tests for the org-wide pet overview page at /org/{org_name}."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
+from tests.conftest import test_session_factory
+
+
+def _create_pet(
+    repo_owner: str = "bigcorp",
+    repo_name: str = "api",
+    name: str = "Gotchi",
+    stage: str = PetStage.ADULT.value,
+    health: int = 80,
+    is_dead: bool = False,
+) -> None:
+    async def _setup() -> None:
+        async with test_session_factory() as session:
+            pet = Pet(
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                name=name,
+                stage=stage,
+                mood=PetMood.HAPPY.value,
+                health=health,
+                is_dead=is_dead,
+            )
+            session.add(pet)
+            await session.commit()
+
+    asyncio.run(_setup())
+
+
+class TestOrgOverviewBasic:
+    def test_page_returns_200(self, client: TestClient) -> None:
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/someorg")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_shows_org_name_in_header(self, client: TestClient) -> None:
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/bigcorp")
+        assert "bigcorp" in response.text
+
+    def test_empty_org_shows_empty_state(self, client: TestClient) -> None:
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/nopetshere")
+        assert response.status_code == 200
+        assert "No pets registered" in response.text
+
+
+class TestOrgOverviewPets:
+    def test_shows_org_pets(self, client: TestClient) -> None:
+        _create_pet(repo_owner="acme", repo_name="backend", name="Atlas")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/acme")
+        assert "Atlas" in response.text
+        assert "acme/backend" in response.text
+
+    def test_does_not_show_other_org_pets(self, client: TestClient) -> None:
+        _create_pet(repo_owner="otheracme", repo_name="repo", name="Stranger")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/acme2")
+        assert "Stranger" not in response.text
+
+    def test_case_insensitive_org_match(self, client: TestClient) -> None:
+        _create_pet(repo_owner="MyOrg", repo_name="project", name="Cased")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/myorg")
+        assert "Cased" in response.text
+
+    def test_shows_pet_profile_link(self, client: TestClient) -> None:
+        _create_pet(repo_owner="linkorg", repo_name="proj", name="Linky")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/linkorg")
+        assert "/pet/linkorg/proj" in response.text
+
+    def test_shows_health_bar(self, client: TestClient) -> None:
+        _create_pet(repo_owner="healthorg", repo_name="svc", name="Barney", health=60)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/healthorg")
+        assert "60" in response.text
+
+
+class TestOrgOverviewHealthStats:
+    def test_shows_aggregate_pet_count(self, client: TestClient) -> None:
+        _create_pet(repo_owner="statsorg", repo_name="r1", name="P1", health=90)
+        _create_pet(repo_owner="statsorg", repo_name="r2", name="P2", health=50)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/statsorg")
+        assert "2 pets" in response.text
+
+    def test_shows_healthy_hungry_sick_counts(self, client: TestClient) -> None:
+        _create_pet(repo_owner="countorg", repo_name="r1", name="H", health=80)
+        _create_pet(repo_owner="countorg", repo_name="r2", name="N", health=50)
+        _create_pet(repo_owner="countorg", repo_name="r3", name="S", health=10)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/countorg")
+        assert "Healthy" in response.text
+        assert "Hungry" in response.text
+        assert "Sick" in response.text
+
+
+class TestOrgOverviewCaretaker:
+    def test_shows_top_caretaker_when_available(self, client: TestClient) -> None:
+        _create_pet(repo_owner="caretakerorg", repo_name="repo", name="Fluffy")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value="alice",
+        ):
+            response = client.get("/org/caretakerorg")
+        assert "@alice" in response.text
+
+    def test_shows_nobody_when_no_caretaker(self, client: TestClient) -> None:
+        _create_pet(repo_owner="nocaretakerorg", repo_name="repo", name="Lonely")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/nocaretakerorg")
+        assert "Nobody" in response.text
+
+    def test_caretaker_links_to_dashboard(self, client: TestClient) -> None:
+        _create_pet(repo_owner="linkcaretakerorg", repo_name="repo", name="Dino")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value="bob",
+        ):
+            response = client.get("/org/linkcaretakerorg")
+        assert "/dashboard/bob" in response.text
+
+
+class TestOrgOverviewLeaderboard:
+    def test_shows_org_leaderboard_section(self, client: TestClient) -> None:
+        _create_pet(repo_owner="lbdorg", repo_name="r1", name="L1")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value="topdev",
+        ):
+            response = client.get("/org/lbdorg")
+        assert "Org Leaderboard" in response.text
+        assert "@topdev" in response.text
+
+    def test_leaderboard_not_shown_when_no_caretakers(self, client: TestClient) -> None:
+        _create_pet(repo_owner="nolbdorg", repo_name="r1", name="N1")
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/nolbdorg")
+        assert "Org Leaderboard" not in response.text
+
+
+class TestOrgOverviewNeglected:
+    def test_shows_neglected_section_for_sick_pet(self, client: TestClient) -> None:
+        _create_pet(repo_owner="neglectorg", repo_name="legacy", name="Sick", health=15)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/neglectorg")
+        assert "Neglected Repos" in response.text
+        assert "neglectorg/legacy" in response.text
+
+    def test_shows_neglected_section_for_dead_pet(self, client: TestClient) -> None:
+        _create_pet(repo_owner="deadorg", repo_name="rip", name="Ghost", is_dead=True)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/deadorg")
+        assert "Neglected Repos" in response.text
+        assert "deadorg/rip" in response.text
+
+    def test_neglected_not_shown_for_healthy_pets(self, client: TestClient) -> None:
+        _create_pet(repo_owner="healthyorg", repo_name="good", name="Fit", health=90)
+        with patch(
+            "github_tamagotchi.main.GitHubService.get_top_contributor",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = client.get("/org/healthyorg")
+        assert "Neglected Repos" not in response.text


### PR DESCRIPTION
## Summary
- Adds `/org/{org_name}` page showing all pets registered under a GitHub org
- Aggregate health banner: total pets, healthy/hungry/sick/dead counts, avg health
- Pet table with stage emoji, health bar, link to pet profile, and top caretaker (fetched from GitHub API in parallel)
- Org contributor leaderboard: top caretakers ranked by number of repos they lead
- Neglected repos alert for pets with health < 30 or that are dead
- 18 new tests covering all acceptance criteria

## Testing
- [x] All 648 tests pass
- [x] Linter clean
- [x] Empty org shows empty state
- [x] Case-insensitive org name matching
- [x] Caretaker and leaderboard sections conditionally rendered

Closes #32