### PR TITLE
Closes #28: Add team pet with per-contributor relationships

### DIFF
--- a/alembic/versions/020_add_contributor_relationships_table.py
+++ b/alembic/versions/020_add_contributor_relationships_table.py
@@ -1,0 +1,45 @@
+"""Add contributor_relationships table
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-04-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "020"
+down_revision: str | None = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "contributor_relationships",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("pet_id", sa.Integer(), nullable=False),
+        sa.Column("github_username", sa.String(255), nullable=False),
+        sa.Column("standing", sa.String(20), nullable=False, server_default="neutral"),
+        sa.Column("score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_activity", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("sins", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("good_deeds", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.ForeignKeyConstraint(["pet_id"], ["pets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("pet_id", "github_username"),
+    )
+    op.create_index("ix_contributor_relationships_pet_id", "contributor_relationships", ["pet_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_contributor_relationships_pet_id", table_name="contributor_relationships")
+    op.drop_table("contributor_relationships")

--- a/alembic/versions/020_add_contributor_relationships_table.py
+++ b/alembic/versions/020_add_contributor_relationships_table.py
@@ -31,7 +31,10 @@ def upgrade() -> None:
         sa.Column("sins", sa.JSON(), nullable=False, server_default="[]"),
         sa.Column("good_deeds", sa.JSON(), nullable=False, server_default="[]"),
         sa.Column(
-            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
         ),
         sa.ForeignKeyConstraint(["pet_id"], ["pets.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),

--- a/alembic/versions/021_add_contributor_relationships_table.py
+++ b/alembic/versions/021_add_contributor_relationships_table.py
@@ -1,7 +1,7 @@
 """Add contributor_relationships table
 
-Revision ID: 020
-Revises: 019
+Revision ID: 021
+Revises: 020
 Create Date: 2026-04-10
 
 """
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "020"
-down_revision: str | None = "019"
+revision: str = "021"
+down_revision: str | None = "020"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -266,6 +266,25 @@ class BlameBoardResponse(BaseModel):
     hero_entries: list[HeroEntryItem]
 
 
+class ContributorRelationshipItem(BaseModel):
+    """A single contributor relationship item."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    github_username: str
+    standing: str
+    score: int
+    last_activity: datetime | None
+    good_deeds: list[str]
+    sins: list[str]
+
+
+class ContributorRelationshipsResponse(BaseModel):
+    """Response model for contributor relationships."""
+
+    contributors: list[ContributorRelationshipItem]
+
+
 class LeaderboardEntry(BaseModel):
     """A single entry on the leaderboard."""
 
@@ -783,6 +802,31 @@ async def get_pet_milestones(
     milestones = await get_milestones(session, pet.id)
     return MilestonesResponse(
         milestones=[MilestoneItem.model_validate(m) for m in milestones]
+    )
+
+
+@router.get(
+    "/pets/{repo_owner}/{repo_name}/contributors",
+    response_model=ContributorRelationshipsResponse,
+)
+async def get_pet_contributors(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+) -> ContributorRelationshipsResponse:
+    """Get contributor relationships for a pet. Public endpoint."""
+    from github_tamagotchi.crud.contributor_relationship import get_contributors_for_pet
+
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Pet not found for {repo_owner}/{repo_name}",
+        )
+
+    contributors = await get_contributors_for_pet(session, pet.id)
+    return ContributorRelationshipsResponse(
+        contributors=[ContributorRelationshipItem.model_validate(c) for c in contributors]
     )
 
 

--- a/src/github_tamagotchi/crud/contributor_relationship.py
+++ b/src/github_tamagotchi/crud/contributor_relationship.py
@@ -1,0 +1,127 @@
+"""CRUD operations for contributor relationships."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.models.contributor_relationship import ContributorRelationship
+
+
+async def get_contributors_for_pet(
+    db: AsyncSession, pet_id: int
+) -> list[ContributorRelationship]:
+    """Return all contributor relationships for a pet, ordered by score descending."""
+    result = await db.execute(
+        select(ContributorRelationship)
+        .where(ContributorRelationship.pet_id == pet_id)
+        .order_by(ContributorRelationship.score.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def upsert_contributor_relationship(
+    db: AsyncSession,
+    pet_id: int,
+    github_username: str,
+    score: int,
+    standing: str,
+    last_activity: datetime | None,
+    good_deeds: list[Any],
+    sins: list[Any],
+) -> ContributorRelationship:
+    """Insert or update a contributor relationship record."""
+    result = await db.execute(
+        select(ContributorRelationship).where(
+            ContributorRelationship.pet_id == pet_id,
+            ContributorRelationship.github_username == github_username,
+        )
+    )
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        existing.score = score
+        existing.standing = standing
+        existing.last_activity = last_activity
+        existing.good_deeds = good_deeds
+        existing.sins = sins
+        return existing
+
+    relationship = ContributorRelationship(
+        pet_id=pet_id,
+        github_username=github_username,
+        score=score,
+        standing=standing,
+        last_activity=last_activity,
+        good_deeds=good_deeds,
+        sins=sins,
+    )
+    db.add(relationship)
+    return relationship
+
+
+async def apply_score_delta(
+    db: AsyncSession,
+    pet_id: int,
+    github_username: str,
+    delta: int,
+    event_description: str,
+    now: datetime | None = None,
+) -> ContributorRelationship | None:
+    """Apply a score delta to an existing contributor relationship.
+
+    Used for real-time webhook updates between poll cycles.
+    Returns None if the relationship does not yet exist.
+    """
+    from datetime import UTC
+
+    from github_tamagotchi.models.contributor_relationship import ContributorStanding
+    from github_tamagotchi.services.contributor_relationships import calculate_standing
+
+    if now is None:
+        from datetime import UTC
+
+        now = datetime.now(UTC)
+
+    result = await db.execute(
+        select(ContributorRelationship).where(
+            ContributorRelationship.pet_id == pet_id,
+            ContributorRelationship.github_username == github_username,
+        )
+    )
+    rel = result.scalar_one_or_none()
+    if rel is None:
+        # Create a minimal record for this contributor
+        rel = ContributorRelationship(
+            pet_id=pet_id,
+            github_username=github_username,
+            score=0,
+            standing=ContributorStanding.NEUTRAL,
+            last_activity=now,
+            good_deeds=[],
+            sins=[],
+        )
+        db.add(rel)
+
+    rel.score += delta
+    rel.last_activity = now
+
+    if delta > 0:
+        deeds = list(rel.good_deeds or [])
+        deeds.insert(0, event_description)
+        rel.good_deeds = deeds[:5]
+    else:
+        sins = list(rel.sins or [])
+        sins.insert(0, event_description)
+        rel.sins = sins[:5]
+
+    # Recalculate standing
+    rel.standing = calculate_standing(
+        score=rel.score,
+        is_top_scorer=False,  # Don't recalculate top scorer during webhook; poll will fix it
+        last_activity=rel.last_activity,
+        now=now,
+    )
+
+    return rel

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -31,6 +31,7 @@ from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.config import settings
 from github_tamagotchi.core.database import async_session_factory, close_database, get_session
 from github_tamagotchi.crud import pet as pet_crud
+from github_tamagotchi.crud.contributor_relationship import upsert_contributor_relationship
 from github_tamagotchi.crud.milestone import create_milestone
 from github_tamagotchi.mcp.server import get_mcp_server
 from github_tamagotchi.models.job_run import JobRun
@@ -40,6 +41,7 @@ from github_tamagotchi.models.webhook_event import WebhookEvent
 from github_tamagotchi.services import image_queue
 from github_tamagotchi.services.achievements import check_and_unlock_achievements
 from github_tamagotchi.services.alerting import AlertChecker
+from github_tamagotchi.services.contributor_relationships import build_contributor_updates
 from github_tamagotchi.services.github import GitHubService, RateLimitError, RepoInsights
 from github_tamagotchi.services.pet_logic import (
     EVOLUTION_THRESHOLDS,
@@ -187,6 +189,33 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             pet_id=pet.id,
                             pet_name=pet.name,
                             achievements=newly_unlocked,
+                        )
+
+                    # Update contributor relationships from GitHub activity
+                    try:
+                        activity = await github_service.get_all_contributor_activity(
+                            pet.repo_owner, pet.repo_name
+                        )
+                        contributor_updates = build_contributor_updates(activity, now)
+                        for update in contributor_updates:
+                            await upsert_contributor_relationship(
+                                db=session,
+                                pet_id=pet.id,
+                                github_username=str(update["github_username"]),
+                                score=int(update["score"]),  # type: ignore[arg-type]
+                                standing=str(update["standing"]),
+                                last_activity=update["last_activity"],  # type: ignore[arg-type]
+                                good_deeds=update["good_deeds"],  # type: ignore[arg-type]
+                                sins=update["sins"],  # type: ignore[arg-type]
+                            )
+                    except RateLimitError:
+                        raise
+                    except Exception as e:
+                        logger.warning(
+                            "contributor_relationship_update_failed",
+                            pet_id=pet.id,
+                            repo=f"{pet.repo_owner}/{pet.repo_name}",
+                            error=str(e),
                         )
 
                     updated_count += 1
@@ -622,6 +651,11 @@ async def pet_profile(
     else:
         age_days = (now - created).days
 
+    # Fetch contributor relationships
+    from github_tamagotchi.crud.contributor_relationship import get_contributors_for_pet
+
+    contributor_relationships = await get_contributors_for_pet(session, pet.id)
+
     page_url = str(request.url)
     return templates.TemplateResponse(
         request,
@@ -637,6 +671,7 @@ async def pet_profile(
             "repo_name": repo_name,
             "base_url": settings.base_url,
             "now_utc": now,
+            "contributor_relationships": contributor_relationships,
         },
         headers={"Cache-Control": "public, max-age=60"},
     )

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -201,12 +201,12 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             await upsert_contributor_relationship(
                                 db=session,
                                 pet_id=pet.id,
-                                github_username=str(update["github_username"]),
-                                score=int(update["score"]),  # type: ignore[arg-type]
-                                standing=str(update["standing"]),
-                                last_activity=update["last_activity"],  # type: ignore[arg-type]
-                                good_deeds=update["good_deeds"],  # type: ignore[arg-type]
-                                sins=update["sins"],  # type: ignore[arg-type]
+                                github_username=update.github_username,
+                                score=update.score,
+                                standing=update.standing,
+                                last_activity=update.last_activity,
+                                good_deeds=update.good_deeds,
+                                sins=update.sins,
                             )
                     except RateLimitError:
                         raise

--- a/src/github_tamagotchi/models/__init__.py
+++ b/src/github_tamagotchi/models/__init__.py
@@ -3,6 +3,10 @@
 from github_tamagotchi.models.achievement import PetAchievement
 from github_tamagotchi.models.alert import Alert, AlertSeverity, AlertStatus, AlertType
 from github_tamagotchi.models.comment import PetComment
+from github_tamagotchi.models.contributor_relationship import (
+    ContributorRelationship,
+    ContributorStanding,
+)
 from github_tamagotchi.models.image_job import ImageGenerationJob, JobStatus
 from github_tamagotchi.models.job_run import JobRun
 from github_tamagotchi.models.milestone import PetMilestone
@@ -15,6 +19,8 @@ __all__ = [
     "AlertSeverity",
     "AlertStatus",
     "AlertType",
+    "ContributorRelationship",
+    "ContributorStanding",
     "ImageGenerationJob",
     "JobRun",
     "JobStatus",

--- a/src/github_tamagotchi/models/contributor_relationship.py
+++ b/src/github_tamagotchi/models/contributor_relationship.py
@@ -1,0 +1,43 @@
+"""ContributorRelationship model for tracking per-contributor pet standing."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from github_tamagotchi.models.pet import Base
+
+
+class ContributorStanding:
+    """Standing values for contributor relationships."""
+
+    FAVORITE = "favorite"
+    GOOD = "good"
+    NEUTRAL = "neutral"
+    DOGHOUSE = "doghouse"
+    ABSENT = "absent"
+
+
+class ContributorRelationship(Base):
+    """A pet's relationship with a contributor (github user)."""
+
+    __tablename__ = "contributor_relationships"
+    __table_args__ = (UniqueConstraint("pet_id", "github_username"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    pet_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("pets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    github_username: Mapped[str] = mapped_column(String(255), nullable=False)
+    standing: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=ContributorStanding.NEUTRAL
+    )
+    score: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_activity: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    sins: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list)
+    good_deeds: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/src/github_tamagotchi/services/contributor_relationships.py
+++ b/src/github_tamagotchi/services/contributor_relationships.py
@@ -1,0 +1,107 @@
+"""Service for managing pet-contributor relationship scores and standings."""
+
+from datetime import UTC, datetime
+
+from github_tamagotchi.models.contributor_relationship import ContributorStanding
+from github_tamagotchi.services.github import AllContributorActivity
+
+# Score weights (matching issue specification)
+SCORE_PER_COMMIT = 5
+SCORE_PER_MERGED_PR = 10
+
+# Standing thresholds
+GOOD_SCORE_THRESHOLD = 50
+ABSENT_DAYS_THRESHOLD = 30
+
+# Maximum recent events to keep in sins/good_deeds lists
+MAX_RECENT_EVENTS = 5
+
+
+def calculate_score(commits_30d: int, merged_prs_30d: int) -> int:
+    """Calculate contributor score from 30-day activity."""
+    return commits_30d * SCORE_PER_COMMIT + merged_prs_30d * SCORE_PER_MERGED_PR
+
+
+def calculate_standing(
+    score: int,
+    is_top_scorer: bool,
+    last_activity: datetime | None,
+    now: datetime,
+) -> str:
+    """Determine standing from score and activity.
+
+    Returns one of: favorite, good, neutral, doghouse, absent.
+    """
+    if last_activity is None:
+        return ContributorStanding.ABSENT
+
+    days_inactive = (now - last_activity).total_seconds() / 86400
+    if days_inactive >= ABSENT_DAYS_THRESHOLD:
+        return ContributorStanding.ABSENT
+
+    if score < 0:
+        return ContributorStanding.DOGHOUSE
+
+    if is_top_scorer:
+        return ContributorStanding.FAVORITE
+
+    if score > GOOD_SCORE_THRESHOLD:
+        return ContributorStanding.GOOD
+
+    return ContributorStanding.NEUTRAL
+
+
+def build_contributor_updates(
+    activity: AllContributorActivity,
+    now: datetime | None = None,
+) -> list[dict[str, object]]:
+    """Compute score, standing, and event lists for each contributor.
+
+    Returns a list of dicts with keys: github_username, score, standing,
+    last_activity, good_deeds, sins.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    all_usernames = set(activity.commits_by_user) | set(activity.merged_prs_by_user)
+
+    # Find top scorer for "favorite" standing
+    scores: dict[str, int] = {
+        username: calculate_score(
+            activity.commits_by_user.get(username, 0),
+            activity.merged_prs_by_user.get(username, 0),
+        )
+        for username in all_usernames
+    }
+    max_score = max(scores.values(), default=0)
+
+    updates = []
+    for username in all_usernames:
+        commits = activity.commits_by_user.get(username, 0)
+        merged_prs = activity.merged_prs_by_user.get(username, 0)
+        score = scores[username]
+        last_activity = activity.last_activity_by_user.get(username)
+        is_top = score > 0 and score == max_score
+
+        standing = calculate_standing(score, is_top, last_activity, now)
+
+        good_deeds: list[str] = []
+        if commits > 0:
+            good_deeds.append(f"{commits} commit{'s' if commits != 1 else ''} in last 30 days")
+        if merged_prs > 0:
+            pr_label = f"PR{'s' if merged_prs != 1 else ''}"
+            good_deeds.append(f"{merged_prs} {pr_label} merged in last 30 days")
+        good_deeds = good_deeds[:MAX_RECENT_EVENTS]
+
+        updates.append(
+            {
+                "github_username": username,
+                "score": score,
+                "standing": standing,
+                "last_activity": last_activity,
+                "good_deeds": good_deeds,
+                "sins": [],
+            }
+        )
+
+    return updates

--- a/src/github_tamagotchi/services/contributor_relationships.py
+++ b/src/github_tamagotchi/services/contributor_relationships.py
@@ -1,9 +1,23 @@
 """Service for managing pet-contributor relationship scores and standings."""
 
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from github_tamagotchi.models.contributor_relationship import ContributorStanding
 from github_tamagotchi.services.github import AllContributorActivity
+
+
+@dataclass
+class ContributorUpdate:
+    """Computed update data for a single contributor."""
+
+    github_username: str
+    score: int
+    standing: str
+    last_activity: datetime | None
+    good_deeds: list[str] = field(default_factory=list)
+    sins: list[str] = field(default_factory=list)
+
 
 # Score weights (matching issue specification)
 SCORE_PER_COMMIT = 5
@@ -54,12 +68,8 @@ def calculate_standing(
 def build_contributor_updates(
     activity: AllContributorActivity,
     now: datetime | None = None,
-) -> list[dict[str, object]]:
-    """Compute score, standing, and event lists for each contributor.
-
-    Returns a list of dicts with keys: github_username, score, standing,
-    last_activity, good_deeds, sins.
-    """
+) -> list[ContributorUpdate]:
+    """Compute score, standing, and event lists for each contributor."""
     if now is None:
         now = datetime.now(UTC)
 
@@ -75,7 +85,7 @@ def build_contributor_updates(
     }
     max_score = max(scores.values(), default=0)
 
-    updates = []
+    updates: list[ContributorUpdate] = []
     for username in all_usernames:
         commits = activity.commits_by_user.get(username, 0)
         merged_prs = activity.merged_prs_by_user.get(username, 0)
@@ -94,14 +104,14 @@ def build_contributor_updates(
         good_deeds = good_deeds[:MAX_RECENT_EVENTS]
 
         updates.append(
-            {
-                "github_username": username,
-                "score": score,
-                "standing": standing,
-                "last_activity": last_activity,
-                "good_deeds": good_deeds,
-                "sins": [],
-            }
+            ContributorUpdate(
+                github_username=username,
+                score=score,
+                standing=standing,
+                last_activity=last_activity,
+                good_deeds=good_deeds,
+                sins=[],
+            )
         )
 
     return updates

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -82,6 +82,18 @@ class ContributorStats:
 
 
 @dataclass
+class AllContributorActivity:
+    """Activity for all contributors in a repository over the last 30 days."""
+
+    # Maps github_username -> commit count in last 30d
+    commits_by_user: dict[str, int]
+    # Maps github_username -> merged PR count in last 30d
+    merged_prs_by_user: dict[str, int]
+    # Maps github_username -> last activity datetime
+    last_activity_by_user: dict[str, datetime]
+
+
+@dataclass
 class BlameEntry:
     """A single blame entry showing who is responsible for a pet health issue."""
 
@@ -505,6 +517,83 @@ class GitHubService:
         except Exception as e:
             logger.warning("Failed to get check runs", sha=sha, error=str(e))
         return False
+
+    async def get_all_contributor_activity(
+        self, owner: str, repo: str
+    ) -> AllContributorActivity:
+        """Fetch commit and PR activity for all contributors in the last 30 days."""
+        async with httpx.AsyncClient() as client:
+            since_30d = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+
+            commits_by_user: dict[str, int] = {}
+            last_activity_by_user: dict[str, datetime] = {}
+
+            try:
+                resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/commits",
+                    headers=self._get_headers(),
+                    params={"since": since_30d, "per_page": 100},
+                )
+                self._check_rate_limit(resp)
+                resp.raise_for_status()
+                commits: list[dict[str, Any]] = resp.json()
+                for commit in commits:
+                    login = (
+                        commit["author"].get("login") if commit.get("author") else None
+                    )
+                    if not login:
+                        continue
+                    commits_by_user[login] = commits_by_user.get(login, 0) + 1
+                    raw_date = commit.get("commit", {}).get("committer", {}).get("date")
+                    if raw_date:
+                        commit_dt = datetime.fromisoformat(raw_date.replace("Z", "+00:00"))
+                        existing = last_activity_by_user.get(login)
+                        if existing is None or commit_dt > existing:
+                            last_activity_by_user[login] = commit_dt
+            except RateLimitError:
+                raise
+            except Exception as e:
+                logger.warning("Failed to fetch all contributor commits", error=str(e))
+
+            merged_prs_by_user: dict[str, int] = {}
+
+            try:
+                resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/pulls",
+                    headers=self._get_headers(),
+                    params={"state": "closed", "per_page": 100},
+                )
+                self._check_rate_limit(resp)
+                resp.raise_for_status()
+                prs: list[dict[str, Any]] = resp.json()
+                cutoff = datetime.now(UTC) - timedelta(days=30)
+                for pr in prs:
+                    merged_at_raw = pr.get("merged_at")
+                    if not merged_at_raw:
+                        continue
+                    merged_at = datetime.fromisoformat(merged_at_raw.replace("Z", "+00:00"))
+                    if merged_at < cutoff:
+                        continue
+                    merged_by = pr.get("merged_by") or {}
+                    login = merged_by.get("login")
+                    if not login:
+                        continue
+                    merged_prs_by_user[login] = merged_prs_by_user.get(login, 0) + 1
+                    existing = last_activity_by_user.get(login)
+                    if existing is None or merged_at > existing:
+                        last_activity_by_user[login] = merged_at
+            except RateLimitError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "Failed to fetch merged PRs for contributor activity", error=str(e)
+                )
+
+            return AllContributorActivity(
+                commits_by_user=commits_by_user,
+                merged_prs_by_user=merged_prs_by_user,
+                last_activity_by_user=last_activity_by_user,
+            )
 
     async def get_repo_insights(self, owner: str, repo: str) -> RepoInsights:
         """Fetch detailed insights metrics for a repository."""

--- a/src/github_tamagotchi/services/webhook.py
+++ b/src/github_tamagotchi/services/webhook.py
@@ -9,6 +9,7 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.crud import pet as pet_crud
+from github_tamagotchi.crud.contributor_relationship import apply_score_delta
 from github_tamagotchi.crud.milestone import create_milestone
 from github_tamagotchi.models.pet import PetMood, PetStage
 from github_tamagotchi.services.pet_logic import get_next_stage
@@ -73,9 +74,10 @@ async def handle_push_event(payload: dict[str, Any], db: AsyncSession) -> str:
     if not pet:
         return f"no pet found for {owner}/{name}"
 
+    now = datetime.now(UTC)
     pet.health = min(100, pet.health + PUSH_HEALTH_BONUS)
     pet.experience = pet.experience + PUSH_EXPERIENCE_BONUS
-    pet.last_fed_at = datetime.now(UTC)
+    pet.last_fed_at = now
     pet.mood = PetMood.HAPPY.value
 
     # Check for evolution
@@ -89,6 +91,18 @@ async def handle_push_event(payload: dict[str, Any], db: AsyncSession) -> str:
             pet_id=pet.id,
             old_stage=current_stage.value,
             new_stage=new_stage.value,
+        )
+
+    # Update contributor score for the pusher
+    pusher = payload.get("pusher", {}).get("name") or payload.get("sender", {}).get("login")
+    if pusher:
+        await apply_score_delta(
+            db=db,
+            pet_id=pet.id,
+            github_username=pusher,
+            delta=5,  # SCORE_PER_COMMIT
+            event_description="pushed commits",
+            now=now,
         )
 
     await db.commit()
@@ -115,6 +129,7 @@ async def handle_pull_request_event(payload: dict[str, Any], db: AsyncSession) -
         return f"no pet found for {owner}/{name}"
 
     action = payload.get("action", "")
+    now = datetime.now(UTC)
 
     if action == "opened":
         pet.mood = PetMood.WORRIED.value
@@ -125,6 +140,17 @@ async def handle_pull_request_event(payload: dict[str, Any], db: AsyncSession) -
             pet.mood = PetMood.HAPPY.value
             pet.health = min(100, pet.health + PR_MERGED_HEALTH_BONUS)
             pet.experience = pet.experience + PR_MERGED_EXPERIENCE_BONUS
+            # Credit the merger in contributor relationships
+            merged_by = (pr.get("merged_by") or {}).get("login")
+            if merged_by:
+                await apply_score_delta(
+                    db=db,
+                    pet_id=pet.id,
+                    github_username=merged_by,
+                    delta=10,  # SCORE_PER_MERGED_PR
+                    event_description="merged a PR",
+                    now=now,
+                )
         else:
             # PR closed without merge
             pet.mood = PetMood.CONTENT.value
@@ -205,6 +231,7 @@ async def handle_check_run_event(payload: dict[str, Any], db: AsyncSession) -> s
 
     check_run = payload.get("check_run", {})
     conclusion = check_run.get("conclusion", "")
+    now = datetime.now(UTC)
 
     if conclusion == "success":
         pet.health = min(100, pet.health + CI_SUCCESS_HEALTH_BONUS)
@@ -213,6 +240,17 @@ async def handle_check_run_event(payload: dict[str, Any], db: AsyncSession) -> s
     elif conclusion in ("failure", "timed_out"):
         pet.health = max(0, pet.health + CI_FAILURE_HEALTH_PENALTY)
         pet.mood = PetMood.WORRIED.value
+        # Penalise the person who triggered the failing check
+        sender = payload.get("sender", {}).get("login")
+        if sender:
+            await apply_score_delta(
+                db=db,
+                pet_id=pet.id,
+                github_username=sender,
+                delta=-20,
+                event_description="broke CI",
+                now=now,
+            )
 
     # Check for evolution
     current_stage = PetStage(pet.stage)

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -295,6 +295,35 @@
                 <div id="blame-board-sins" style="margin-top:1rem;"></div>
             </section>
 
+            <!-- Chippy's Humans (Contributor Relationships) -->
+            {% if contributor_relationships %}
+            <section class="profile-section" style="margin-top: 2rem;">
+                <h2>{{ pet.name }}'s Humans</h2>
+                <div style="display: flex; flex-direction: column; gap: 0.5rem; margin-top: 1rem;">
+                    {% for rel in contributor_relationships %}
+                    <div style="display: flex; align-items: center; justify-content: space-between; padding: 0.6rem 0.9rem; border-radius: 10px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08);">
+                        <div style="display: flex; align-items: center; gap: 0.75rem;">
+                            <img src="https://github.com/{{ rel.github_username }}.png?size=28" alt="{{ rel.github_username }}" width="28" height="28" style="border-radius: 50%; object-fit: cover;" onerror="this.style.display='none'">
+                            <a href="https://github.com/{{ rel.github_username }}" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.9); text-decoration: none; font-weight: 500;">@{{ rel.github_username }}</a>
+                        </div>
+                        <div style="display: flex; align-items: center; gap: 1rem;">
+                            <span style="font-size: 0.8rem; color: rgba(255,255,255,0.5);">{{ rel.score }} pts</span>
+                            <span style="font-size: 1.1rem;" title="{{ rel.standing | capitalize }}">
+                                {% if rel.standing == "favorite" %}&#128525;
+                                {% elif rel.standing == "good" %}&#128522;
+                                {% elif rel.standing == "doghouse" %}&#128545;
+                                {% elif rel.standing == "absent" %}&#128532;
+                                {% else %}&#128512;
+                                {% endif %}
+                            </span>
+                            <span style="font-size: 0.8rem; color: rgba(255,255,255,0.6); min-width: 60px; text-align: right;">{{ rel.standing | capitalize }}</span>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </section>
+            {% endif %}
+
             <!-- Comments Section -->
             <section class="profile-section" id="comments-section" style="margin-top: 2rem;">
                 <h2>Discussion</h2>

--- a/tests/api/test_contributor_relationships_api.py
+++ b/tests/api/test_contributor_relationships_api.py
@@ -1,0 +1,111 @@
+"""Tests for the contributor relationships API endpoint."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from github_tamagotchi.models.contributor_relationship import (
+    ContributorRelationship,
+    ContributorStanding,
+)
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
+from tests.conftest import test_session_factory
+
+
+async def _create_pet_with_contributors() -> int:
+    """Create a pet and two contributor relationships. Returns pet id."""
+    async with test_session_factory() as session:
+        pet = Pet(
+            repo_owner="testowner",
+            repo_name="testrepo",
+            name="Chippy",
+            stage=PetStage.BABY.value,
+            mood=PetMood.HAPPY.value,
+        )
+        session.add(pet)
+        await session.flush()
+
+        now = datetime.now(UTC)
+        alice = ContributorRelationship(
+            pet_id=pet.id,
+            github_username="alice",
+            standing=ContributorStanding.FAVORITE,
+            score=100,
+            last_activity=now - timedelta(days=1),
+            good_deeds=["20 commits in last 30 days"],
+            sins=[],
+        )
+        bob = ContributorRelationship(
+            pet_id=pet.id,
+            github_username="bob",
+            standing=ContributorStanding.DOGHOUSE,
+            score=-20,
+            last_activity=now - timedelta(days=2),
+            good_deeds=[],
+            sins=["broke CI"],
+        )
+        session.add(alice)
+        session.add(bob)
+        await session.commit()
+        return pet.id
+
+
+class TestGetPetContributors:
+    @pytest.mark.asyncio
+    async def test_returns_contributors(self, async_client: AsyncClient) -> None:
+        """Should return contributor relationships for a pet."""
+        await _create_pet_with_contributors()
+        response = await async_client.get("/api/v1/pets/testowner/testrepo/contributors")
+        assert response.status_code == 200
+        data = response.json()
+        assert "contributors" in data
+        assert len(data["contributors"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_pet(self, async_client: AsyncClient) -> None:
+        """Should return 404 when pet does not exist."""
+        response = await async_client.get("/api/v1/pets/nobody/norepo/contributors")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_contributor_fields(self, async_client: AsyncClient) -> None:
+        """Each contributor item should have required fields."""
+        await _create_pet_with_contributors()
+        response = await async_client.get("/api/v1/pets/testowner/testrepo/contributors")
+        assert response.status_code == 200
+        contributors = response.json()["contributors"]
+        assert len(contributors) >= 1
+        for c in contributors:
+            assert "github_username" in c
+            assert "standing" in c
+            assert "score" in c
+            assert "good_deeds" in c
+            assert "sins" in c
+
+    @pytest.mark.asyncio
+    async def test_ordered_by_score_descending(self, async_client: AsyncClient) -> None:
+        """Contributors should be ordered by score descending."""
+        await _create_pet_with_contributors()
+        response = await async_client.get("/api/v1/pets/testowner/testrepo/contributors")
+        contributors = response.json()["contributors"]
+        scores = [c["score"] for c in contributors]
+        assert scores == sorted(scores, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_contributors(self, async_client: AsyncClient) -> None:
+        """Should return empty list when pet has no contributor relationships."""
+        async with test_session_factory() as session:
+            pet = Pet(
+                repo_owner="soloowner",
+                repo_name="solorepo",
+                name="Lonely",
+                stage=PetStage.EGG.value,
+                mood=PetMood.CONTENT.value,
+            )
+            session.add(pet)
+            await session.commit()
+
+        response = await async_client.get("/api/v1/pets/soloowner/solorepo/contributors")
+        assert response.status_code == 200
+        assert response.json()["contributors"] == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,13 @@ from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 
 # Import all models to ensure they're registered with Base.metadata
-from github_tamagotchi.models import ImageGenerationJob, Pet, PetAchievement, User  # noqa: F401
+from github_tamagotchi.models import (  # noqa: F401
+    ContributorRelationship,
+    ImageGenerationJob,
+    Pet,
+    PetAchievement,
+    User,
+)
 from github_tamagotchi.models.pet import Base
 from github_tamagotchi.services.github import RepoHealth
 

--- a/tests/services/test_contributor_relationships.py
+++ b/tests/services/test_contributor_relationships.py
@@ -1,0 +1,153 @@
+"""Tests for contributor relationship score and standing logic."""
+
+from datetime import UTC, datetime, timedelta
+
+from github_tamagotchi.models.contributor_relationship import ContributorStanding
+from github_tamagotchi.services.contributor_relationships import (
+    build_contributor_updates,
+    calculate_score,
+    calculate_standing,
+)
+from github_tamagotchi.services.github import AllContributorActivity
+
+
+class TestCalculateScore:
+    def test_empty(self) -> None:
+        assert calculate_score(0, 0) == 0
+
+    def test_commits_only(self) -> None:
+        assert calculate_score(3, 0) == 15  # 3 * 5
+
+    def test_merged_prs_only(self) -> None:
+        assert calculate_score(0, 2) == 20  # 2 * 10
+
+    def test_both(self) -> None:
+        assert calculate_score(4, 1) == 30  # 4*5 + 1*10
+
+
+class TestCalculateStanding:
+    def _now(self) -> datetime:
+        return datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+
+    def test_absent_when_no_activity(self) -> None:
+        now = self._now()
+        assert calculate_standing(100, False, None, now) == ContributorStanding.ABSENT
+
+    def test_absent_when_stale(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=31)
+        assert calculate_standing(50, False, last, now) == ContributorStanding.ABSENT
+
+    def test_doghouse_when_negative_score(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=1)
+        assert calculate_standing(-5, False, last, now) == ContributorStanding.DOGHOUSE
+
+    def test_favorite_when_top_scorer(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=1)
+        assert calculate_standing(80, True, last, now) == ContributorStanding.FAVORITE
+
+    def test_good_when_score_above_threshold(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=1)
+        assert calculate_standing(51, False, last, now) == ContributorStanding.GOOD
+
+    def test_neutral_when_score_below_threshold(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=1)
+        assert calculate_standing(30, False, last, now) == ContributorStanding.NEUTRAL
+
+    def test_neutral_at_zero_score(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=1)
+        assert calculate_standing(0, False, last, now) == ContributorStanding.NEUTRAL
+
+    def test_good_at_threshold_boundary(self) -> None:
+        now = self._now()
+        last = now - timedelta(days=1)
+        # score > 50 is good, exactly 50 is neutral
+        assert calculate_standing(50, False, last, now) == ContributorStanding.NEUTRAL
+        assert calculate_standing(51, False, last, now) == ContributorStanding.GOOD
+
+
+class TestBuildContributorUpdates:
+    def _now(self) -> datetime:
+        return datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+
+    def _recent(self) -> datetime:
+        return self._now() - timedelta(days=1)
+
+    def test_empty_activity(self) -> None:
+        activity = AllContributorActivity(
+            commits_by_user={},
+            merged_prs_by_user={},
+            last_activity_by_user={},
+        )
+        updates = build_contributor_updates(activity, self._now())
+        assert updates == []
+
+    def test_single_contributor(self) -> None:
+        activity = AllContributorActivity(
+            commits_by_user={"alice": 3},
+            merged_prs_by_user={},
+            last_activity_by_user={"alice": self._recent()},
+        )
+        updates = build_contributor_updates(activity, self._now())
+        assert len(updates) == 1
+        alice = updates[0]
+        assert alice["github_username"] == "alice"
+        assert alice["score"] == 15  # 3 * 5
+        # As the sole contributor, alice is the top scorer → favorite
+        assert alice["standing"] == ContributorStanding.FAVORITE
+        assert "3 commits" in alice["good_deeds"][0]
+
+    def test_favorite_is_top_scorer(self) -> None:
+        activity = AllContributorActivity(
+            commits_by_user={"alice": 20, "bob": 2},
+            merged_prs_by_user={},
+            last_activity_by_user={"alice": self._recent(), "bob": self._recent()},
+        )
+        updates = build_contributor_updates(activity, self._now())
+        by_user = {u["github_username"]: u for u in updates}
+        # alice has 100 pts (top scorer, and >50)
+        assert by_user["alice"]["standing"] == ContributorStanding.FAVORITE
+        # bob has 10 pts → neutral
+        assert by_user["bob"]["standing"] == ContributorStanding.NEUTRAL
+
+    def test_absent_contributor_not_in_list(self) -> None:
+        """Contributors with no activity data in last 30 days are absent."""
+        old = self._now() - timedelta(days=35)
+        activity = AllContributorActivity(
+            commits_by_user={"alice": 0},
+            merged_prs_by_user={},
+            last_activity_by_user={"alice": old},
+        )
+        # alice is in commits_by_user but with 0 commits, so no entry
+        # (AllContributorActivity only holds non-zero counts, but let's test explicit)
+        updates = build_contributor_updates(activity, self._now())
+        # alice has 0 score but is in the activity keys from commits_by_user
+        # She will appear but be marked absent due to stale last_activity
+        by_user = {u["github_username"]: u for u in updates}
+        assert by_user["alice"]["standing"] == ContributorStanding.ABSENT
+
+    def test_merged_prs_add_good_deeds(self) -> None:
+        activity = AllContributorActivity(
+            commits_by_user={},
+            merged_prs_by_user={"bob": 2},
+            last_activity_by_user={"bob": self._recent()},
+        )
+        updates = build_contributor_updates(activity, self._now())
+        bob = updates[0]
+        assert bob["score"] == 20  # 2 * 10
+        assert any("PR" in deed for deed in bob["good_deeds"])
+
+    def test_no_favorite_when_all_zero_score(self) -> None:
+        """When max score is 0, no one gets favorite standing."""
+        activity = AllContributorActivity(
+            commits_by_user={"alice": 0},
+            merged_prs_by_user={},
+            last_activity_by_user={"alice": self._recent()},
+        )
+        updates = build_contributor_updates(activity, self._now())
+        assert updates[0]["standing"] == ContributorStanding.NEUTRAL

--- a/tests/services/test_contributor_relationships.py
+++ b/tests/services/test_contributor_relationships.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 from github_tamagotchi.models.contributor_relationship import ContributorStanding
 from github_tamagotchi.services.contributor_relationships import (
+    ContributorUpdate,
     build_contributor_updates,
     calculate_score,
     calculate_standing,
@@ -96,11 +97,12 @@ class TestBuildContributorUpdates:
         updates = build_contributor_updates(activity, self._now())
         assert len(updates) == 1
         alice = updates[0]
-        assert alice["github_username"] == "alice"
-        assert alice["score"] == 15  # 3 * 5
+        assert isinstance(alice, ContributorUpdate)
+        assert alice.github_username == "alice"
+        assert alice.score == 15  # 3 * 5
         # As the sole contributor, alice is the top scorer → favorite
-        assert alice["standing"] == ContributorStanding.FAVORITE
-        assert "3 commits" in alice["good_deeds"][0]
+        assert alice.standing == ContributorStanding.FAVORITE
+        assert "3 commits" in alice.good_deeds[0]
 
     def test_favorite_is_top_scorer(self) -> None:
         activity = AllContributorActivity(
@@ -109,11 +111,11 @@ class TestBuildContributorUpdates:
             last_activity_by_user={"alice": self._recent(), "bob": self._recent()},
         )
         updates = build_contributor_updates(activity, self._now())
-        by_user = {u["github_username"]: u for u in updates}
+        by_user = {u.github_username: u for u in updates}
         # alice has 100 pts (top scorer, and >50)
-        assert by_user["alice"]["standing"] == ContributorStanding.FAVORITE
+        assert by_user["alice"].standing == ContributorStanding.FAVORITE
         # bob has 10 pts → neutral
-        assert by_user["bob"]["standing"] == ContributorStanding.NEUTRAL
+        assert by_user["bob"].standing == ContributorStanding.NEUTRAL
 
     def test_absent_contributor_not_in_list(self) -> None:
         """Contributors with no activity data in last 30 days are absent."""
@@ -128,8 +130,8 @@ class TestBuildContributorUpdates:
         updates = build_contributor_updates(activity, self._now())
         # alice has 0 score but is in the activity keys from commits_by_user
         # She will appear but be marked absent due to stale last_activity
-        by_user = {u["github_username"]: u for u in updates}
-        assert by_user["alice"]["standing"] == ContributorStanding.ABSENT
+        by_user = {u.github_username: u for u in updates}
+        assert by_user["alice"].standing == ContributorStanding.ABSENT
 
     def test_merged_prs_add_good_deeds(self) -> None:
         activity = AllContributorActivity(
@@ -139,8 +141,8 @@ class TestBuildContributorUpdates:
         )
         updates = build_contributor_updates(activity, self._now())
         bob = updates[0]
-        assert bob["score"] == 20  # 2 * 10
-        assert any("PR" in deed for deed in bob["good_deeds"])
+        assert bob.score == 20  # 2 * 10
+        assert any("PR" in deed for deed in bob.good_deeds)
 
     def test_no_favorite_when_all_zero_score(self) -> None:
         """When max score is 0, no one gets favorite standing."""
@@ -150,4 +152,4 @@ class TestBuildContributorUpdates:
             last_activity_by_user={"alice": self._recent()},
         )
         updates = build_contributor_updates(activity, self._now())
-        assert updates[0]["standing"] == ContributorStanding.NEUTRAL
+        assert updates[0].standing == ContributorStanding.NEUTRAL


### PR DESCRIPTION
## Summary
- Track each contributor's relationship with the pet via a new `ContributorRelationship` model
- Score is computed from 30-day activity (commits × 5, merged PRs × 10) on each poll cycle, with real-time adjustments from webhooks (push +5, PR merge +10, CI failure -20)
- Standing derived from score: **favorite** (top scorer), **good** (>50 pts), **neutral** (0–50), **doghouse** (<0), **absent** (no activity 30d)
- New **"Chippy's Humans"** section displayed on the pet profile page
- New public API endpoint `GET /api/v1/pets/{owner}/{repo}/contributors`

## Changes
- `ContributorRelationship` SQLAlchemy model + Alembic migration `020`
- `AllContributorActivity` dataclass + `get_all_contributor_activity()` on `GitHubService`
- `contributor_relationships` service: `calculate_score`, `calculate_standing`, `build_contributor_updates`
- CRUD: `get_contributors_for_pet`, `upsert_contributor_relationship`, `apply_score_delta`
- Poll loop integration: contributor relationships refreshed each cycle
- Webhook handlers updated: push, PR merged, CI failure apply score deltas
- Pet profile template: "{pet.name}'s Humans" section with standing emoji
- 23 new tests (unit + API)

## Testing
- [x] All 721 tests pass
- [x] Linter clean (`ruff check`)
- [x] 23 new tests covering score/standing logic and the contributors API endpoint
- [x] No breaking changes to existing endpoints

Closes #28