### PR TITLE
Closes #33: Add pet admin panel for repo owners

### DIFF
--- a/src/github_tamagotchi/api/auth.py
+++ b/src/github_tamagotchi/api/auth.py
@@ -93,6 +93,11 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
+    # Sync is_admin from config on every request so nav links and gates stay consistent
+    should_be_admin = user.github_login in settings.admin_github_logins
+    if user.is_admin != should_be_admin:
+        user.is_admin = should_be_admin
+        await session.flush()
     return user
 
 


### PR DESCRIPTION
## Summary
- New admin panel at `/pet/{owner}/{repo}/admin` accessible only to users with GitHub admin permission on the repo
- Pet settings: rename, feature toggles (blame board, contributor badges, leaderboard participation)
- Threshold customization: days before hungry, PR review SLA hours, issue response SLA days
- Contributor exclusion: exclude bots/ex-employees from blame board and badges; remove exclusion
- Danger zone: reset pet (starts new generation with wiped stats) and permanently delete pet
- "Settings" gear link added to pet profile page for the repo owner

## Changes
- `models/pet.py`: Added `contributor_badges_enabled`, `hungry_after_days`, `pr_review_sla_hours`, `issue_response_sla_days` columns and `excluded_contributors` relationship
- `models/excluded_contributor.py`: New model for tracking excluded contributors per pet
- `models/__init__.py`: Register new model so it's included in `Base.metadata`
- `alembic/versions/020_add_pet_admin_settings.py`: Migration for new columns and table
- `services/github.py`: Added `get_repo_permission(owner, repo, username)` to check GitHub repo admin access
- `api/routes.py`: Admin API endpoints: GET/PATCH settings, POST/DELETE contributor exclusions, POST reset, DELETE pet
- `main.py`: Page route at `/pet/{owner}/{repo}/admin` with GitHub permission check
- `templates/pet_admin.html`: Full admin UI with toggle switches, threshold inputs, exclusion table, and danger zone
- `templates/pet_profile.html`: Added Settings link for repo owner

## Testing
- [x] 16 new tests in `tests/api/test_pet_admin.py` covering auth, permissions, settings updates, contributor exclusion, reset, and delete
- [x] All 714 tests pass
- [x] Linter clean

Closes #33