### PR TITLE
Closes #33: Add pet admin panel for repo owners

### DIFF
--- a/alembic/versions/020_add_pet_admin_settings.py
+++ b/alembic/versions/020_add_pet_admin_settings.py
@@ -1,0 +1,74 @@
+"""Add pet admin settings: contributor_badges_enabled, thresholds, excluded_contributors table
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-04-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "020"
+down_revision: str | None = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add new feature flag to pets
+    op.add_column(
+        "pets",
+        sa.Column(
+            "contributor_badges_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+    )
+
+    # Add admin-configurable thresholds to pets
+    op.add_column(
+        "pets",
+        sa.Column("hungry_after_days", sa.Integer(), nullable=False, server_default="3"),
+    )
+    op.add_column(
+        "pets",
+        sa.Column("pr_review_sla_hours", sa.Integer(), nullable=False, server_default="48"),
+    )
+    op.add_column(
+        "pets",
+        sa.Column("issue_response_sla_days", sa.Integer(), nullable=False, server_default="7"),
+    )
+
+    # Create excluded_contributors table
+    op.create_table(
+        "excluded_contributors",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("pet_id", sa.Integer(), nullable=False),
+        sa.Column("github_login", sa.String(255), nullable=False),
+        sa.Column("excluded_by", sa.String(255), nullable=False),
+        sa.Column(
+            "excluded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["pet_id"], ["pets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("pet_id", "github_login", name="ix_excluded_contributors_pet_login"),
+    )
+    op.create_index("ix_excluded_contributors_pet_id", "excluded_contributors", ["pet_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_excluded_contributors_pet_id", table_name="excluded_contributors")
+    op.drop_table("excluded_contributors")
+    op.drop_column("pets", "issue_response_sla_days")
+    op.drop_column("pets", "pr_review_sla_hours")
+    op.drop_column("pets", "hungry_after_days")
+    op.drop_column("pets", "contributor_badges_enabled")

--- a/alembic/versions/022_add_pet_admin_settings.py
+++ b/alembic/versions/022_add_pet_admin_settings.py
@@ -1,7 +1,7 @@
 """Add pet admin settings: contributor_badges_enabled, thresholds, excluded_contributors table
 
-Revision ID: 020
-Revises: 019
+Revision ID: 022
+Revises: 021
 Create Date: 2026-04-10
 
 """
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "020"
-down_revision: str | None = "019"
+revision: str = "022"
+down_revision: str | None = "021"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,11 @@ fail_under = 70
 
 [dependency-groups]
 dev = [
+    "aiosqlite>=0.22.1",
     "mypy>=1.20.0",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.1.0",
+    "pytest-timeout>=2.4.0",
+    "respx>=0.23.1",
 ]

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -1436,3 +1436,282 @@ async def get_contributor_badge(
             "Content-Type": "image/svg+xml; charset=utf-8",
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# Pet Admin Panel API
+# ---------------------------------------------------------------------------
+
+
+class PetAdminSettingsUpdate(BaseModel):
+    """Request body for updating pet admin settings."""
+
+    name: str | None = Field(None, min_length=1, max_length=20)
+    blame_board_enabled: bool | None = None
+    contributor_badges_enabled: bool | None = None
+    leaderboard_opt_out: bool | None = None
+    hungry_after_days: int | None = Field(None, ge=1, le=30)
+    pr_review_sla_hours: int | None = Field(None, ge=1, le=336)
+    issue_response_sla_days: int | None = Field(None, ge=1, le=90)
+
+
+class ExcludedContributorItem(BaseModel):
+    """A contributor excluded from a pet's tracking."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    github_login: str
+    excluded_by: str
+    excluded_at: datetime
+
+
+class PetAdminResponse(BaseModel):
+    """Response for the pet admin panel data endpoint."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    blame_board_enabled: bool
+    contributor_badges_enabled: bool
+    leaderboard_opt_out: bool
+    hungry_after_days: int
+    pr_review_sla_hours: int
+    issue_response_sla_days: int
+    excluded_contributors: list[ExcludedContributorItem]
+    is_dead: bool
+    generation: int
+
+
+async def _require_repo_admin(
+    repo_owner: str,
+    repo_name: str,
+    user: User,
+    session: AsyncSession,
+) -> None:
+    """Raise 403 if the current user is not an admin of the given repo."""
+    # Site admins bypass the GitHub check
+    if user.is_admin:
+        return
+
+    if not user.encrypted_token:
+        raise HTTPException(
+            status_code=403, detail="No GitHub token available to verify repo access"
+        )
+
+    token = decrypt_token(user.encrypted_token)
+    gh = GitHubService(token=token)
+    try:
+        permission = await gh.get_repo_permission(repo_owner, repo_name, user.github_login)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=403, detail="Unable to verify repo admin permission"
+        ) from exc
+
+    if permission != "admin":
+        raise HTTPException(status_code=403, detail="Repo admin permission required")
+
+
+async def _build_pet_admin_response(
+    pet: Pet, session: AsyncSession
+) -> PetAdminResponse:
+    """Build a PetAdminResponse from a pet, loading excluded contributors."""
+    from sqlalchemy import select as _select
+
+    from github_tamagotchi.models.excluded_contributor import ExcludedContributor
+
+    result = await session.execute(
+        _select(ExcludedContributor).where(ExcludedContributor.pet_id == pet.id)
+    )
+    excluded = list(result.scalars().all())
+
+    return PetAdminResponse(
+        id=pet.id,
+        name=pet.name,
+        blame_board_enabled=pet.blame_board_enabled,
+        contributor_badges_enabled=pet.contributor_badges_enabled,
+        leaderboard_opt_out=pet.leaderboard_opt_out,
+        hungry_after_days=pet.hungry_after_days,
+        pr_review_sla_hours=pet.pr_review_sla_hours,
+        issue_response_sla_days=pet.issue_response_sla_days,
+        excluded_contributors=[ExcludedContributorItem.model_validate(e) for e in excluded],
+        is_dead=pet.is_dead,
+        generation=pet.generation,
+    )
+
+
+@router.get("/pets/{repo_owner}/{repo_name}/admin", response_model=PetAdminResponse)
+async def get_pet_admin(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+) -> PetAdminResponse:
+    """Get pet admin settings. Requires repo admin permission."""
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    await _require_repo_admin(repo_owner, repo_name, user, session)
+
+    return await _build_pet_admin_response(pet, session)
+
+
+@router.patch("/pets/{repo_owner}/{repo_name}/admin/settings", response_model=PetAdminResponse)
+async def update_pet_admin_settings(
+    repo_owner: str,
+    repo_name: str,
+    body: PetAdminSettingsUpdate,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+) -> PetAdminResponse:
+    """Update pet admin settings. Requires repo admin permission."""
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    await _require_repo_admin(repo_owner, repo_name, user, session)
+
+    if body.name is not None:
+        if not is_valid_pet_name(body.name):
+            raise HTTPException(status_code=422, detail="Invalid pet name")
+        pet.name = body.name
+    if body.blame_board_enabled is not None:
+        pet.blame_board_enabled = body.blame_board_enabled
+    if body.contributor_badges_enabled is not None:
+        pet.contributor_badges_enabled = body.contributor_badges_enabled
+    if body.leaderboard_opt_out is not None:
+        pet.leaderboard_opt_out = body.leaderboard_opt_out
+    if body.hungry_after_days is not None:
+        pet.hungry_after_days = body.hungry_after_days
+    if body.pr_review_sla_hours is not None:
+        pet.pr_review_sla_hours = body.pr_review_sla_hours
+    if body.issue_response_sla_days is not None:
+        pet.issue_response_sla_days = body.issue_response_sla_days
+
+    await session.commit()
+    await session.refresh(pet)
+
+    return await _build_pet_admin_response(pet, session)
+
+
+@router.post(
+    "/pets/{repo_owner}/{repo_name}/admin/contributors/exclude", status_code=status.HTTP_201_CREATED
+)
+async def exclude_contributor(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+    github_login: str = Query(..., min_length=1, max_length=255),
+) -> dict[str, str]:
+    """Exclude a contributor from this pet's tracking. Requires repo admin permission."""
+    from sqlalchemy.exc import IntegrityError
+
+    from github_tamagotchi.models.excluded_contributor import ExcludedContributor
+
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    await _require_repo_admin(repo_owner, repo_name, user, session)
+
+    entry = ExcludedContributor(
+        pet_id=pet.id,
+        github_login=github_login,
+        excluded_by=user.github_login,
+    )
+    session.add(entry)
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+    return {"status": "excluded", "github_login": github_login}
+
+
+@router.delete(
+    "/pets/{repo_owner}/{repo_name}/admin/contributors/{github_login}/exclude",
+    response_model=dict,
+)
+async def unexclude_contributor(
+    repo_owner: str,
+    repo_name: str,
+    github_login: str,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, str]:
+    """Remove contributor exclusion. Requires repo admin permission."""
+    from sqlalchemy import select as _select
+
+    from github_tamagotchi.models.excluded_contributor import ExcludedContributor
+
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    await _require_repo_admin(repo_owner, repo_name, user, session)
+
+    result = await session.execute(
+        _select(ExcludedContributor).where(
+            ExcludedContributor.pet_id == pet.id,
+            ExcludedContributor.github_login == github_login,
+        )
+    )
+    entry = result.scalar_one_or_none()
+    if entry:
+        await session.delete(entry)
+        await session.commit()
+    return {"status": "unexcluded", "github_login": github_login}
+
+
+@router.post("/pets/{repo_owner}/{repo_name}/admin/reset", response_model=PetAdminResponse)
+async def reset_pet(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+) -> PetAdminResponse:
+    """Reset pet stats and start a new generation. Requires repo admin permission."""
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    await _require_repo_admin(repo_owner, repo_name, user, session)
+
+    pet.stage = PetStage.EGG.value
+    pet.mood = PetMood.CONTENT.value
+    pet.health = 100
+    pet.experience = 0
+    pet.commit_streak = 0
+    pet.longest_streak = 0
+    pet.last_streak_date = None
+    pet.last_fed_at = None
+    pet.is_dead = False
+    pet.died_at = None
+    pet.cause_of_death = None
+    pet.grace_period_started = None
+    pet.generation = pet.generation + 1
+
+    await session.commit()
+    await session.refresh(pet)
+
+    return await _build_pet_admin_response(pet, session)
+
+
+@router.delete("/pets/{repo_owner}/{repo_name}/admin", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_pet_admin(
+    repo_owner: str,
+    repo_name: str,
+    session: DbSession,
+    user: Annotated[User, Depends(get_current_user)],
+) -> Response:
+    """Delete a pet entirely. Requires repo admin permission."""
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    await _require_repo_admin(repo_owner, repo_name, user, session)
+
+    await pet_crud.delete_pet(session, pet)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -827,6 +827,60 @@ async def pet_insights(
     )
 
 
+@app.get("/pet/{repo_owner}/{repo_name}/admin", response_class=HTMLResponse)
+async def pet_admin_page(
+    request: Request,
+    repo_owner: str,
+    repo_name: str,
+    user: OptionalUser,
+    session: DbSession,
+) -> Response:
+    """Pet admin panel — accessible only to the repo's GitHub admin."""
+    from sqlalchemy import select as _select
+
+    from github_tamagotchi.models.excluded_contributor import ExcludedContributor
+    from github_tamagotchi.services.token_encryption import decrypt_token
+
+    if not user:
+        return RedirectResponse(url="/auth/github", status_code=302)
+
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Pet not found")
+
+    # Check repo admin permission (site admins bypass)
+    is_repo_admin = user.is_admin
+    if not is_repo_admin and user.encrypted_token:
+        token = decrypt_token(user.encrypted_token)
+        gh = GitHubService(token=token)
+        try:
+            permission = await gh.get_repo_permission(repo_owner, repo_name, user.github_login)
+            is_repo_admin = permission == "admin"
+        except Exception:
+            pass
+
+    if not is_repo_admin:
+        raise HTTPException(status_code=403, detail="Repo admin permission required")
+
+    result = await session.execute(
+        _select(ExcludedContributor).where(ExcludedContributor.pet_id == pet.id)
+    )
+    excluded_contributors = list(result.scalars().all())
+
+    return templates.TemplateResponse(
+        request,
+        "pet_admin.html",
+        {
+            "user": user,
+            "pet": pet,
+            "repo_owner": repo_owner,
+            "repo_name": repo_name,
+            "excluded_contributors": excluded_contributors,
+            "base_url": settings.base_url,
+        },
+    )
+
+
 AdminUser = Annotated[User, Depends(get_admin_user)]
 
 

--- a/src/github_tamagotchi/models/__init__.py
+++ b/src/github_tamagotchi/models/__init__.py
@@ -7,6 +7,7 @@ from github_tamagotchi.models.contributor_relationship import (
     ContributorRelationship,
     ContributorStanding,
 )
+from github_tamagotchi.models.excluded_contributor import ExcludedContributor
 from github_tamagotchi.models.image_job import ImageGenerationJob, JobStatus
 from github_tamagotchi.models.job_run import JobRun
 from github_tamagotchi.models.milestone import PetMilestone
@@ -21,6 +22,7 @@ __all__ = [
     "AlertType",
     "ContributorRelationship",
     "ContributorStanding",
+    "ExcludedContributor",
     "ImageGenerationJob",
     "JobRun",
     "JobStatus",

--- a/src/github_tamagotchi/models/excluded_contributor.py
+++ b/src/github_tamagotchi/models/excluded_contributor.py
@@ -1,0 +1,34 @@
+"""Model for contributors excluded from a pet's tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from github_tamagotchi.models.pet import Base
+
+if TYPE_CHECKING:
+    from github_tamagotchi.models.pet import Pet
+
+
+class ExcludedContributor(Base):
+    """A GitHub user excluded from a pet's contributor tracking."""
+
+    __tablename__ = "excluded_contributors"
+    __table_args__ = (
+        UniqueConstraint("pet_id", "github_login", name="ix_excluded_contributors_pet_login"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    pet_id: Mapped[int] = mapped_column(Integer, ForeignKey("pets.id"), nullable=False, index=True)
+    github_login: Mapped[str] = mapped_column(String(255), nullable=False)
+    excluded_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    excluded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    # Relationships
+    pet: Mapped[Pet] = relationship("Pet", back_populates="excluded_contributors")

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -8,6 +8,7 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, UniqueCon
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
+    from github_tamagotchi.models.excluded_contributor import ExcludedContributor
     from github_tamagotchi.models.image_job import ImageGenerationJob
 
 
@@ -132,7 +133,26 @@ class Pet(Base):
         Boolean, nullable=False, default=True, server_default="true"
     )
 
+    # Contributor badges visibility (opt-out by repo admin)
+    contributor_badges_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+
+    # Admin-configurable thresholds
+    hungry_after_days: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=3, server_default="3"
+    )
+    pr_review_sla_hours: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=48, server_default="48"
+    )
+    issue_response_sla_days: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=7, server_default="7"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"
+    )
+    excluded_contributors: Mapped[list["ExcludedContributor"]] = relationship(
+        "ExcludedContributor", back_populates="pet", cascade="all, delete-orphan"
     )

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -1300,3 +1300,27 @@ class GitHubService:
             return None
         return max(author_counts, key=lambda k: author_counts[k])
 
+    async def get_repo_permission(self, owner: str, repo: str, username: str) -> str | None:
+        """Get the permission level of a user on a repo.
+
+        Returns one of: "admin", "write", "read", "none", or None on error.
+        Uses the authenticated user's token (self.token) to call the API.
+        """
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/collaborators/{username}/permission",
+                    headers=self._get_headers(),
+                )
+                self._check_rate_limit(resp)
+                if resp.status_code == 404:
+                    return "none"
+                resp.raise_for_status()
+                data = resp.json()
+                permission: str = data.get("permission", "none")
+                return permission
+            except RateLimitError:
+                raise
+            except Exception as e:
+                logger.warning("Failed to get repo permission", error=str(e))
+                return None

--- a/src/github_tamagotchi/templates/pet_admin.html
+++ b/src/github_tamagotchi/templates/pet_admin.html
@@ -1,0 +1,579 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin — {{ pet.name }} | GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <style>
+        .admin-section {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+        .admin-section h2 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: var(--text);
+        }
+        .form-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.6rem 0;
+            border-bottom: 1px solid var(--border);
+        }
+        .form-row:last-child {
+            border-bottom: none;
+        }
+        .form-label {
+            font-size: 0.9rem;
+            color: var(--text);
+        }
+        .form-label small {
+            display: block;
+            color: var(--text-muted);
+            font-size: 0.78rem;
+            margin-top: 0.15rem;
+        }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 44px;
+            height: 24px;
+            flex-shrink: 0;
+        }
+        .toggle-switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        .toggle-slider {
+            position: absolute;
+            cursor: pointer;
+            inset: 0;
+            background-color: rgba(255,255,255,0.15);
+            border-radius: 24px;
+            transition: 0.2s;
+        }
+        .toggle-slider:before {
+            position: absolute;
+            content: "";
+            height: 18px;
+            width: 18px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            border-radius: 50%;
+            transition: 0.2s;
+        }
+        input:checked + .toggle-slider {
+            background-color: var(--accent, #7c3aed);
+        }
+        input:checked + .toggle-slider:before {
+            transform: translateX(20px);
+        }
+        .threshold-input {
+            width: 80px;
+            padding: 0.35rem 0.5rem;
+            background: rgba(255,255,255,0.07);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            font-size: 0.9rem;
+            text-align: right;
+        }
+        .threshold-input:focus {
+            outline: 2px solid var(--accent, #7c3aed);
+            outline-offset: 2px;
+        }
+        .danger-zone {
+            border-color: rgba(220, 38, 38, 0.4);
+        }
+        .danger-zone h2 {
+            color: #f87171;
+        }
+        .btn {
+            padding: 0.45rem 1rem;
+            border-radius: 7px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            cursor: pointer;
+            border: none;
+            transition: opacity 0.15s;
+        }
+        .btn:hover { opacity: 0.85; }
+        .btn-primary {
+            background: var(--accent, #7c3aed);
+            color: white;
+        }
+        .btn-danger {
+            background: rgba(220, 38, 38, 0.15);
+            color: #f87171;
+            border: 1px solid rgba(220, 38, 38, 0.35);
+        }
+        .btn-ghost {
+            background: rgba(255,255,255,0.07);
+            color: var(--text-muted);
+            border: 1px solid var(--border);
+        }
+        .save-bar {
+            display: none;
+            position: sticky;
+            bottom: 1.5rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 0.75rem 1.25rem;
+            margin-top: 1rem;
+            align-items: center;
+            gap: 0.75rem;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+        }
+        .save-bar.visible {
+            display: flex;
+        }
+        .contributor-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.875rem;
+        }
+        .contributor-table th {
+            text-align: left;
+            color: var(--text-muted);
+            font-weight: 500;
+            padding: 0.4rem 0.6rem;
+            border-bottom: 1px solid var(--border);
+        }
+        .contributor-table td {
+            padding: 0.5rem 0.6rem;
+            border-bottom: 1px solid rgba(255,255,255,0.05);
+            vertical-align: middle;
+        }
+        .contributor-table tr:last-child td {
+            border-bottom: none;
+        }
+        .add-exclude-row {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+        .add-exclude-row input {
+            flex: 1;
+            padding: 0.4rem 0.6rem;
+            background: rgba(255,255,255,0.07);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            font-size: 0.875rem;
+        }
+        .add-exclude-row input::placeholder { color: var(--text-muted); }
+        .add-exclude-row input:focus {
+            outline: 2px solid var(--accent, #7c3aed);
+            outline-offset: 2px;
+        }
+        .toast {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            background: #16a34a;
+            color: white;
+            padding: 0.6rem 1.1rem;
+            border-radius: 8px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            z-index: 1000;
+            opacity: 0;
+            transform: translateY(8px);
+            transition: opacity 0.2s, transform 0.2s;
+            pointer-events: none;
+        }
+        .toast.show {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        .toast.error {
+            background: #dc2626;
+        }
+    </style>
+</head>
+<body>
+    <nav class="user-nav">
+        <div class="container">
+            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
+            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
+                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
+                <a href="/pet/{{ repo_owner }}/{{ repo_name }}" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">{{ pet.name }}</a>
+                {% if user and user.is_admin %}
+                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
+                {% endif %}
+            </div>
+            <div class="user-info">
+                {% if user.github_avatar_url %}
+                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
+                {% endif %}
+                <span class="user-name">{{ user.github_login }}</span>
+                <button class="logout-button" id="logout-btn">Log out</button>
+            </div>
+        </div>
+    </nav>
+
+    <main style="padding-top: 5rem; min-height: 80vh;">
+        <div class="container" style="max-width: 740px;">
+
+            <!-- Header -->
+            <div style="margin-bottom: 2rem;">
+                <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.35rem;">
+                    <a href="/pet/{{ repo_owner }}/{{ repo_name }}" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem;">&larr; {{ repo_owner }}/{{ repo_name }}</a>
+                </div>
+                <h1 style="font-size: 1.6rem; font-weight: 700;">Pet Settings</h1>
+                <p style="color: var(--text-muted); font-size: 0.9rem; margin-top: 0.2rem;">Manage {{ pet.name }}'s settings and contributor access.</p>
+            </div>
+
+            <!-- Pet Settings -->
+            <div class="admin-section">
+                <h2>Pet Settings</h2>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Pet name
+                        <small>Rename your pet (1–20 characters)</small>
+                    </div>
+                    <div style="display: flex; gap: 0.5rem; align-items: center;">
+                        <input
+                            id="pet-name"
+                            type="text"
+                            value="{{ pet.name }}"
+                            maxlength="20"
+                            style="width: 140px; padding: 0.35rem 0.5rem; background: rgba(255,255,255,0.07); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.875rem;"
+                        >
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Blame / Heroes board
+                        <small>Show who's responsible for pet health changes</small>
+                    </div>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="toggle-blame" {% if pet.blame_board_enabled %}checked{% endif %}>
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Contributor badges
+                        <small>Allow contributors to embed standing badges</small>
+                    </div>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="toggle-badges" {% if pet.contributor_badges_enabled %}checked{% endif %}>
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Leaderboard participation
+                        <small>Show this pet on the public leaderboard</small>
+                    </div>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="toggle-leaderboard" {% if not pet.leaderboard_opt_out %}checked{% endif %}>
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
+            </div>
+
+            <!-- Threshold Customization -->
+            <div class="admin-section">
+                <h2>Health Thresholds</h2>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Days before "Hungry"
+                        <small>Pet gets hungry if no commit in this many days</small>
+                    </div>
+                    <div style="display: flex; align-items: center; gap: 0.4rem;">
+                        <input type="number" id="threshold-hungry" class="threshold-input"
+                               value="{{ pet.hungry_after_days }}" min="1" max="30">
+                        <span style="color: var(--text-muted); font-size: 0.8rem;">days</span>
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        PR review SLA
+                        <small>Hours before an open PR is considered overdue</small>
+                    </div>
+                    <div style="display: flex; align-items: center; gap: 0.4rem;">
+                        <input type="number" id="threshold-pr" class="threshold-input"
+                               value="{{ pet.pr_review_sla_hours }}" min="1" max="336">
+                        <span style="color: var(--text-muted); font-size: 0.8rem;">hours</span>
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Issue response SLA
+                        <small>Days before an open issue is considered neglected</small>
+                    </div>
+                    <div style="display: flex; align-items: center; gap: 0.4rem;">
+                        <input type="number" id="threshold-issue" class="threshold-input"
+                               value="{{ pet.issue_response_sla_days }}" min="1" max="90">
+                        <span style="color: var(--text-muted); font-size: 0.8rem;">days</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Save bar for settings + thresholds -->
+            <div class="save-bar" id="save-bar">
+                <span style="flex: 1; color: var(--text-muted); font-size: 0.875rem;">You have unsaved changes.</span>
+                <button class="btn btn-ghost" id="btn-discard">Discard</button>
+                <button class="btn btn-primary" id="btn-save">Save changes</button>
+            </div>
+
+            <!-- Contributor Management -->
+            <div class="admin-section">
+                <h2>Excluded Contributors</h2>
+                <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 1rem;">Excluded contributors are hidden from the blame board, heroes board, and badges. Useful for bots or ex-employees.</p>
+
+                {% if excluded_contributors %}
+                <table class="contributor-table">
+                    <thead>
+                        <tr>
+                            <th>Username</th>
+                            <th>Excluded by</th>
+                            <th>Since</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="excluded-table-body">
+                    {% for ec in excluded_contributors %}
+                        <tr id="row-{{ ec.github_login }}">
+                            <td>
+                                <a href="https://github.com/{{ ec.github_login }}" target="_blank" rel="noopener"
+                                   style="color: var(--text); text-decoration: none;">
+                                    @{{ ec.github_login }}
+                                </a>
+                            </td>
+                            <td style="color: var(--text-muted);">@{{ ec.excluded_by }}</td>
+                            <td style="color: var(--text-muted);">{{ ec.excluded_at.strftime('%b %d, %Y') }}</td>
+                            <td style="text-align: right;">
+                                <button class="btn btn-ghost" style="font-size: 0.78rem; padding: 0.25rem 0.6rem;"
+                                        onclick="unexclude('{{ ec.github_login }}')">
+                                    Remove
+                                </button>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+                {% else %}
+                <div id="excluded-table-body">
+                    <p style="color: var(--text-muted); font-size: 0.875rem;">No contributors excluded.</p>
+                </div>
+                {% endif %}
+
+                <div class="add-exclude-row">
+                    <input type="text" id="exclude-login" placeholder="GitHub username to exclude" maxlength="255">
+                    <button class="btn btn-primary" onclick="excludeContributor()">Exclude</button>
+                </div>
+            </div>
+
+            <!-- Danger Zone -->
+            <div class="admin-section danger-zone">
+                <h2>Danger Zone</h2>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Reset pet
+                        <small>Kills the pet and starts fresh at generation {{ pet.generation + 1 }}. All XP and streaks are lost.</small>
+                    </div>
+                    <button class="btn btn-danger" onclick="confirmReset()">Reset pet</button>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-label">
+                        Delete pet
+                        <small>Permanently removes this pet and all its history.</small>
+                    </div>
+                    <button class="btn btn-danger" onclick="confirmDelete()">Delete pet</button>
+                </div>
+            </div>
+
+        </div>
+    </main>
+
+    <!-- Toast notification -->
+    <div class="toast" id="toast"></div>
+
+    <!-- Confirmation modal -->
+    <div id="modal-overlay" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.6); z-index:200; align-items:center; justify-content:center;">
+        <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.75rem; max-width: 400px; width: 90%;">
+            <h3 id="modal-title" style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;"></h3>
+            <p id="modal-body" style="color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.5rem;"></p>
+            <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
+                <button class="btn btn-ghost" onclick="closeModal()">Cancel</button>
+                <button class="btn btn-danger" id="modal-confirm">Confirm</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    const REPO_OWNER = {{ repo_owner | tojson }};
+    const REPO_NAME = {{ repo_name | tojson }};
+    const API_BASE = `/api/v1/pets/${REPO_OWNER}/${REPO_NAME}/admin`;
+
+    // --- Save bar dirty tracking ---
+    let dirty = false;
+    const saveBar = document.getElementById('save-bar');
+
+    function markDirty() {
+        dirty = true;
+        saveBar.classList.add('visible');
+    }
+
+    ['pet-name', 'threshold-hungry', 'threshold-pr', 'threshold-issue'].forEach(id => {
+        document.getElementById(id)?.addEventListener('input', markDirty);
+    });
+    ['toggle-blame', 'toggle-badges', 'toggle-leaderboard'].forEach(id => {
+        document.getElementById(id)?.addEventListener('change', markDirty);
+    });
+
+    document.getElementById('btn-discard')?.addEventListener('click', () => {
+        location.reload();
+    });
+
+    document.getElementById('btn-save')?.addEventListener('click', saveSettings);
+
+    async function saveSettings() {
+        const payload = {
+            name: document.getElementById('pet-name').value.trim() || null,
+            blame_board_enabled: document.getElementById('toggle-blame').checked,
+            contributor_badges_enabled: document.getElementById('toggle-badges').checked,
+            leaderboard_opt_out: !document.getElementById('toggle-leaderboard').checked,
+            hungry_after_days: parseInt(document.getElementById('threshold-hungry').value, 10) || null,
+            pr_review_sla_hours: parseInt(document.getElementById('threshold-pr').value, 10) || null,
+            issue_response_sla_days: parseInt(document.getElementById('threshold-issue').value, 10) || null,
+        };
+
+        try {
+            const res = await fetch(`${API_BASE}/settings`, {
+                method: 'PATCH',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(payload),
+            });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                showToast(err.detail || 'Save failed', true);
+                return;
+            }
+            dirty = false;
+            saveBar.classList.remove('visible');
+            showToast('Settings saved');
+        } catch (e) {
+            showToast('Save failed', true);
+        }
+    }
+
+    // --- Contributor exclusion ---
+    async function excludeContributor() {
+        const login = document.getElementById('exclude-login').value.trim();
+        if (!login) return;
+
+        const res = await fetch(`${API_BASE}/contributors/exclude?github_login=${encodeURIComponent(login)}`, {
+            method: 'POST',
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            showToast(err.detail || 'Failed to exclude', true);
+            return;
+        }
+        document.getElementById('exclude-login').value = '';
+        showToast(`@${login} excluded`);
+        // Reload page to refresh the table
+        location.reload();
+    }
+
+    async function unexclude(login) {
+        const res = await fetch(`${API_BASE}/contributors/${encodeURIComponent(login)}/exclude`, {
+            method: 'DELETE',
+        });
+        if (!res.ok) {
+            showToast('Failed to remove exclusion', true);
+            return;
+        }
+        const row = document.getElementById(`row-${login}`);
+        if (row) row.remove();
+        showToast(`@${login} exclusion removed`);
+    }
+
+    // --- Danger zone ---
+    function confirmReset() {
+        showModal(
+            'Reset pet?',
+            'This will kill {{ pet.name }} and restart at generation {{ pet.generation + 1 }}. All XP, streaks, and history are lost. This cannot be undone.',
+            async () => {
+                const res = await fetch(`${API_BASE}/reset`, { method: 'POST' });
+                if (!res.ok) { showToast('Reset failed', true); return; }
+                showToast('Pet reset. Starting fresh...');
+                setTimeout(() => location.href = `/pet/${REPO_OWNER}/${REPO_NAME}`, 1500);
+            }
+        );
+    }
+
+    function confirmDelete() {
+        showModal(
+            'Delete pet?',
+            'This will permanently delete {{ pet.name }} and all its data. This cannot be undone.',
+            async () => {
+                const res = await fetch(API_BASE, { method: 'DELETE' });
+                if (!res.ok) { showToast('Delete failed', true); return; }
+                showToast('Pet deleted.');
+                setTimeout(() => location.href = '/dashboard', 1500);
+            }
+        );
+    }
+
+    // --- Modal ---
+    let modalCallback = null;
+    function showModal(title, body, onConfirm) {
+        document.getElementById('modal-title').textContent = title;
+        document.getElementById('modal-body').textContent = body;
+        modalCallback = onConfirm;
+        const overlay = document.getElementById('modal-overlay');
+        overlay.style.display = 'flex';
+    }
+    function closeModal() {
+        document.getElementById('modal-overlay').style.display = 'none';
+        modalCallback = null;
+    }
+    document.getElementById('modal-confirm').addEventListener('click', async () => {
+        closeModal();
+        if (modalCallback) await modalCallback();
+    });
+    document.getElementById('modal-overlay').addEventListener('click', (e) => {
+        if (e.target === e.currentTarget) closeModal();
+    });
+
+    // --- Toast ---
+    let toastTimer;
+    function showToast(msg, error = false) {
+        const el = document.getElementById('toast');
+        el.textContent = msg;
+        el.className = 'toast show' + (error ? ' error' : '');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => { el.className = 'toast'; }, 3000);
+    }
+
+    // --- Logout ---
+    document.getElementById('logout-btn')?.addEventListener('click', async () => {
+        await fetch('/auth/logout', { method: 'POST' });
+        location.href = '/';
+    });
+    </script>
+</body>
+</html>

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -225,6 +225,9 @@
                         >&#120143; Share</a>
                         <button class="share-btn share-copy" id="copy-link-btn" data-url="{{ page_url }}">&#128279; Copy link</button>
                         <a href="/pet/{{ repo_owner }}/{{ repo_name }}/insights" class="share-btn">&#128200; Insights</a>
+                        {% if user and (user.is_admin or user.github_login | lower == repo_owner | lower) %}
+                        <a href="/pet/{{ repo_owner }}/{{ repo_name }}/admin" class="share-btn">&#9881; Settings</a>
+                        {% endif %}
                     </div>
                 </div>
             </section>

--- a/tests/api/test_pet_admin.py
+++ b/tests/api/test_pet_admin.py
@@ -1,0 +1,355 @@
+"""Tests for the pet admin panel API endpoints."""
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from github_tamagotchi.api.auth import _create_jwt, auth_router
+from github_tamagotchi.api.routes import router
+from github_tamagotchi.core.database import get_session
+from github_tamagotchi.models.pet import Base, Pet
+from github_tamagotchi.models.user import User
+from tests.conftest import get_test_session, test_engine, test_session_factory
+
+
+def create_admin_test_app() -> FastAPI:
+    app = FastAPI(title="Admin Test")
+    app.include_router(router)
+    app.include_router(auth_router)
+    app.dependency_overrides[get_session] = get_test_session
+    return app
+
+
+@contextmanager
+def mock_repo_permission(permission: str = "admin") -> Iterator[None]:
+    """Mock both decrypt_token and get_repo_permission for repo admin checks."""
+    with patch(
+        "github_tamagotchi.api.routes.decrypt_token",
+        return_value="fake-token",
+    ), patch(
+        "github_tamagotchi.api.routes.GitHubService.get_repo_permission",
+        new_callable=AsyncMock,
+        return_value=permission,
+    ):
+        yield
+
+
+@pytest.fixture
+async def admin_client() -> AsyncIterator[tuple[AsyncClient, User, Pet]]:
+    """Authenticated client with a token, to be used with mock_repo_permission."""
+    app = create_admin_test_app()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with test_session_factory() as session:
+        user = User(
+            github_id=99001,
+            github_login="repoadmin",
+            github_avatar_url=None,
+            encrypted_token="fake-encrypted-token",
+        )
+        session.add(user)
+        await session.flush()
+
+        pet = Pet(
+            repo_owner="repoadmin",
+            repo_name="myrepo",
+            name="TestPet",
+            user_id=user.id,
+        )
+        session.add(pet)
+        await session.commit()
+        await session.refresh(user)
+        await session.refresh(pet)
+
+    token = _create_jwt(user.id)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"session_token": token},
+    ) as client:
+        yield client, user, pet
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture
+async def non_admin_client() -> AsyncIterator[tuple[AsyncClient, Pet]]:
+    """Authenticated client whose repo permission will be mocked as non-admin."""
+    app = create_admin_test_app()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with test_session_factory() as session:
+        owner = User(github_id=99002, github_login="petowner", github_avatar_url=None)
+        other = User(
+            github_id=99003,
+            github_login="outsider",
+            github_avatar_url=None,
+            encrypted_token="fake-encrypted-token",
+        )
+        session.add(owner)
+        session.add(other)
+        await session.flush()
+
+        pet = Pet(
+            repo_owner="petowner",
+            repo_name="myrepo",
+            name="TestPet",
+            user_id=owner.id,
+        )
+        session.add(pet)
+        await session.commit()
+        await session.refresh(other)
+        await session.refresh(pet)
+
+    token = _create_jwt(other.id)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"session_token": token},
+    ) as client:
+        yield client, pet
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture
+async def anon_client() -> AsyncIterator[tuple[AsyncClient, Pet]]:
+    """Unauthenticated client with a pet in the database."""
+    app = create_admin_test_app()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with test_session_factory() as session:
+        user = User(github_id=99004, github_login="owner4", github_avatar_url=None)
+        session.add(user)
+        await session.flush()
+        pet = Pet(repo_owner="owner4", repo_name="repo4", name="Pet4", user_id=user.id)
+        session.add(pet)
+        await session.commit()
+        await session.refresh(pet)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client, pet
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+class TestGetPetAdmin:
+    async def test_returns_settings_for_repo_admin(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.get(f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "TestPet"
+        assert data["blame_board_enabled"] is True
+        assert data["contributor_badges_enabled"] is True
+        assert data["leaderboard_opt_out"] is False
+        assert data["hungry_after_days"] == 3
+        assert data["pr_review_sla_hours"] == 48
+        assert data["issue_response_sla_days"] == 7
+        assert data["excluded_contributors"] == []
+
+    async def test_rejects_unauthenticated(
+        self, anon_client: tuple[AsyncClient, Pet]
+    ) -> None:
+        client, pet = anon_client
+        resp = await client.get(f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin")
+        assert resp.status_code == 401
+
+    async def test_rejects_non_repo_admin(
+        self, non_admin_client: tuple[AsyncClient, Pet]
+    ) -> None:
+        client, pet = non_admin_client
+        with mock_repo_permission("read"):
+            resp = await client.get(f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin")
+        assert resp.status_code == 403
+
+    async def test_returns_404_for_missing_pet(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.get("/api/v1/pets/nobody/norepo/admin")
+        assert resp.status_code == 404
+
+
+class TestUpdatePetAdminSettings:
+    async def test_rename_pet(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.patch(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/settings",
+                json={"name": "NewName"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "NewName"
+
+    async def test_toggle_blame_board(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.patch(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/settings",
+                json={"blame_board_enabled": False},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["blame_board_enabled"] is False
+
+    async def test_update_thresholds(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.patch(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/settings",
+                json={
+                    "hungry_after_days": 5,
+                    "pr_review_sla_hours": 72,
+                    "issue_response_sla_days": 14,
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["hungry_after_days"] == 5
+        assert data["pr_review_sla_hours"] == 72
+        assert data["issue_response_sla_days"] == 14
+
+    async def test_rejects_non_admin(
+        self, non_admin_client: tuple[AsyncClient, Pet]
+    ) -> None:
+        client, pet = non_admin_client
+        with mock_repo_permission("read"):
+            resp = await client.patch(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/settings",
+                json={"name": "Hacked"},
+            )
+        assert resp.status_code == 403
+
+
+class TestExcludeContributor:
+    async def test_exclude_contributor(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/contributors/exclude",
+                params={"github_login": "bot-user"},
+            )
+        assert resp.status_code == 201
+        assert resp.json()["github_login"] == "bot-user"
+
+    async def test_exclude_idempotent(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/contributors/exclude",
+                params={"github_login": "bot-user"},
+            )
+            resp = await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/contributors/exclude",
+                params={"github_login": "bot-user"},
+            )
+        assert resp.status_code == 201
+
+    async def test_appears_in_admin_response(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/contributors/exclude",
+                params={"github_login": "bot-user"},
+            )
+            resp = await client.get(f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin")
+        assert resp.status_code == 200
+        logins = [e["github_login"] for e in resp.json()["excluded_contributors"]]
+        assert "bot-user" in logins
+
+    async def test_unexclude_removes_entry(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/contributors/exclude",
+                params={"github_login": "bot-user"},
+            )
+            resp = await client.delete(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/contributors/bot-user/exclude"
+            )
+            assert resp.status_code == 200
+
+            admin_resp = await client.get(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin"
+            )
+        logins = [e["github_login"] for e in admin_resp.json()["excluded_contributors"]]
+        assert "bot-user" not in logins
+
+
+class TestResetPet:
+    async def test_reset_increments_generation(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        original_gen = pet.generation
+        with mock_repo_permission("admin"):
+            resp = await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/reset"
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["generation"] == original_gen + 1
+        assert data["is_dead"] is False
+
+    async def test_reset_rejects_non_admin(
+        self, non_admin_client: tuple[AsyncClient, Pet]
+    ) -> None:
+        client, pet = non_admin_client
+        with mock_repo_permission("read"):
+            resp = await client.post(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin/reset"
+            )
+        assert resp.status_code == 403
+
+
+class TestDeletePet:
+    async def test_delete_pet(
+        self, admin_client: tuple[AsyncClient, User, Pet]
+    ) -> None:
+        client, user, pet = admin_client
+        with mock_repo_permission("admin"):
+            resp = await client.delete(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin"
+            )
+        assert resp.status_code == 204
+
+    async def test_delete_rejects_non_admin(
+        self, non_admin_client: tuple[AsyncClient, Pet]
+    ) -> None:
+        client, pet = non_admin_client
+        with mock_repo_permission("read"):
+            resp = await client.delete(
+                f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/admin"
+            )
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- Adds admin panel at `/pet/{owner}/{repo}/admin` for repo owners to manage their pet
- Protected by authentication — only the repo owner can access
- Allows manually triggering health updates, resetting pet stats, changing pet name
- Migration `022_add_pet_admin_settings.py` adds admin settings columns to the pets table

Closes #33