### PR TITLE
Closes #44: Add structured logging with context

### DIFF
--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -1,10 +1,10 @@
 """API routes for pet management."""
 
-import logging
 import math
 from datetime import UTC, datetime
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel, ConfigDict, Field
@@ -30,7 +30,7 @@ from github_tamagotchi.services.storage import StorageService
 from github_tamagotchi.services.token_encryption import decrypt_token
 from github_tamagotchi.services.webhook import EVENT_HANDLERS, verify_signature
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 router = APIRouter(prefix="/api/v1", tags=["pets"])
 
@@ -362,7 +362,7 @@ async def health_check(session: DbSession) -> HealthResponse:
         await session.execute(text("SELECT 1"))
         db_status = "connected"
     except Exception:
-        logger.exception("Database health check failed")
+        logger.exception("health_check_db_error")
         db_status = "disconnected"
 
     return HealthResponse(status="healthy", version=__version__, database=db_status)
@@ -435,6 +435,12 @@ async def create_pet(
         pet_name,
         user_id=user.id if user else None,
         style=pet_data.style,
+    )
+    logger.info(
+        "pet_created",
+        pet_id=pet.id,
+        pet_name=pet.name,
+        repo=f"{pet_data.repo_owner}/{pet_data.repo_name}",
     )
     # Enqueue egg stage image generation if a provider is configured
     try:

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import sentry_sdk
 import structlog
@@ -58,6 +58,37 @@ from github_tamagotchi.services.pet_logic import (
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def configure_logging(debug: bool = False) -> None:
+    """Configure structlog for JSON structured logging to stdout."""
+    shared_processors: list[Any] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+    ]
+
+    if debug:
+        processors: list[Any] = [
+            *shared_processors,
+            structlog.dev.ConsoleRenderer(),
+        ]
+    else:
+        processors = [
+            *shared_processors,
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ]
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+configure_logging(debug=bool(os.getenv("DEBUG")))
 logger = structlog.get_logger()
 
 scheduler = AsyncIOScheduler()
@@ -116,6 +147,9 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
 
                     # Fetch health metrics from GitHub
                     health = await github_service.get_repo_health(pet.repo_owner, pet.repo_name)
+
+                    old_health = pet.health
+                    old_mood = pet.mood
 
                     # Calculate state changes
                     health_delta = calculate_health_delta(health)
@@ -232,6 +266,16 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                         )
 
                     updated_count += 1
+
+                    logger.info(
+                        "pet_polled",
+                        pet_id=pet.id,
+                        pet_name=pet.name,
+                        repo=f"{pet.repo_owner}/{pet.repo_name}",
+                        health_before=old_health,
+                        health_after=new_health,
+                        mood_changed=(old_mood != new_mood.value),
+                    )
 
                     logger.debug(
                         "pet_updated",

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -146,6 +146,10 @@ class GitHubService:
                 reset_time = None
                 if reset_timestamp:
                     reset_time = datetime.fromtimestamp(int(reset_timestamp), tz=UTC)
+                logger.warning(
+                    "github_rate_limited",
+                    reset_time=reset_time.isoformat() if reset_time else None,
+                )
                 raise RateLimitError(
                     "GitHub API rate limit exceeded",
                     reset_time=reset_time,
@@ -219,7 +223,7 @@ class GitHubService:
         except RateLimitError:
             raise
         except Exception as e:
-            logger.warning("Failed to get last commit", error=str(e))
+            logger.warning("github_error", endpoint="commits", error=str(e))
         return None
 
     async def _get_open_prs(
@@ -239,7 +243,7 @@ class GitHubService:
         except RateLimitError:
             raise
         except Exception as e:
-            logger.warning("Failed to get open PRs", error=str(e))
+            logger.warning("github_error", endpoint="pulls", error=str(e))
         return []
 
     async def _get_open_issues(
@@ -260,7 +264,7 @@ class GitHubService:
         except RateLimitError:
             raise
         except Exception as e:
-            logger.warning("Failed to get open issues", error=str(e))
+            logger.warning("github_error", endpoint="issues", error=str(e))
         return []
 
     async def _get_ci_status(self, client: httpx.AsyncClient, owner: str, repo: str) -> bool | None:
@@ -288,7 +292,7 @@ class GitHubService:
         except RateLimitError:
             raise
         except Exception as e:
-            logger.warning("Failed to get CI status", error=str(e))
+            logger.warning("github_error", endpoint="check_status", error=str(e))
         return None
 
     async def _get_security_alerts(


### PR DESCRIPTION
## Summary

- Configures structlog with JSON output for production (stdout → cluster logging) and ConsoleRenderer for debug mode
- Adds `pet_polled` event per poll cycle (health_before/after, mood_changed)
- Adds `pet_created` event on registration
- Adds `github_rate_limited` with reset_time context when hitting API limits
- Replaces generic warning strings in github.py with structured `github_error` events keyed by endpoint
- Switches `api/routes.py` from standard `logging` to `structlog`

## Changes

- `main.py`: `configure_logging()` function called at startup; `pet_polled` log after each successful pet poll
- `api/routes.py`: use `structlog`, `pet_created` log in `create_pet`
- `services/github.py`: `github_rate_limited` in `_check_rate_limit`; `github_error` with endpoint context in all `except` handlers

## Testing

- [x] All 197 tests pass
- [x] Ruff lint passes
- [x] JSON log output visible in test stdout captures

Closes #44