### PR TITLE
Closes #24: Add dependents responsibility mechanic

### DIFF
--- a/alembic/versions/023_add_dependent_count.py
+++ b/alembic/versions/023_add_dependent_count.py
@@ -1,0 +1,30 @@
+"""Add dependent_count to pets
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-04-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "023"
+down_revision: str | None = "022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column("dependent_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "dependent_count")

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -107,6 +107,7 @@ class PetResponse(BaseModel):
     updated_at: datetime
     last_fed_at: datetime | None
     last_checked_at: datetime | None
+    dependent_count: int
 
 
 class PetListResponse(BaseModel):
@@ -589,6 +590,7 @@ async def get_pet_badge(
         commit_streak=pet.commit_streak,
         pet_image_b64=pet_image_b64,
         badge_style=style if style is not None else pet.badge_style,
+        dependent_count=pet.dependent_count,
     )
     return Response(
         content=svg_content,

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -163,9 +163,10 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             experience=new_experience,
                         )
 
-                    # Store last-known release and contributor snapshots
+                    # Store last-known release, contributor, and dependent snapshots
                     pet.last_release_count = health.release_count_30d
                     pet.last_contributor_count = health.contributor_count
+                    pet.dependent_count = health.dependent_count
 
                     # Update last_fed_at if there was a recent commit
                     if health.last_commit_at:

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -149,6 +149,11 @@ class Pet(Base):
         Integer, nullable=False, default=7, server_default="7"
     )
 
+    # Dependent count — repos/packages that depend on this one (responsibility indicator)
+    dependent_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/services/badge.py
+++ b/src/github_tamagotchi/services/badge.py
@@ -100,6 +100,14 @@ def _sprite_image_element(b64: str, anim_name: str | None, anim_timing: str | No
     return [img_elem]
 
 
+def _format_dependent_count(count: int) -> str:
+    """Format a dependent count for compact display (e.g. 1200 -> '1.2k')."""
+    if count >= 1000:
+        formatted = f"{count / 1000:.1f}k"
+        return formatted.replace(".0k", "k")
+    return str(count)
+
+
 def _playful_badge(
     display_name: str,
     stage: str,
@@ -108,6 +116,7 @@ def _playful_badge(
     *,
     commit_streak: int = 0,
     pet_image_b64: str | None = None,
+    flair_text: str | None = None,
 ) -> str:
     """Dark gradient badge with emoji sprites (original style)."""
     stage_sprite = STAGE_EMOJI.get(stage, "🥚")
@@ -175,6 +184,11 @@ def _playful_badge(
             lines.append(
                 f'  <text x="{_TEXT_RIGHT}" y="14" font-size="7" fill="#ff9800" {_END}'
                 f' font-family="monospace">🔥{commit_streak}</text>'
+            )
+        elif flair_text:
+            lines.append(
+                f'  <text x="{_TEXT_RIGHT}" y="14" font-size="7" fill="#f1c40f" {_END}'
+                f' font-family="sans-serif">{flair_text}</text>'
             )
     else:
         # 120px wide layout with emoji (original)
@@ -420,6 +434,13 @@ def _dead_badge(
     return "\n".join(lines)
 
 
+def _dependent_flair_text(dependent_count: int) -> str | None:
+    """Return flair text for the badge when the repo has many dependents."""
+    if dependent_count >= 100:
+        return f"\u2699 {_format_dependent_count(dependent_count)} deps"
+    return None
+
+
 def generate_badge_svg(
     name: str,
     stage: str,
@@ -432,6 +453,7 @@ def generate_badge_svg(
     commit_streak: int = 0,
     pet_image_b64: str | None = None,
     badge_style: str = DEFAULT_BADGE_STYLE,
+    dependent_count: int = 0,
 ) -> str:
     """Generate an SVG badge representing the current pet state.
 
@@ -446,6 +468,7 @@ def generate_badge_svg(
         commit_streak: Current commit streak count.
         pet_image_b64: Base64-encoded PNG sprite, or None to use emoji fallback.
         badge_style: Visual style — "playful", "minimal", or "maintained".
+        dependent_count: Number of repos/packages that depend on this one.
     """
     display_name = name if len(name) <= 14 else name[:13] + "…"
 
@@ -466,9 +489,15 @@ def generate_badge_svg(
     if badge_style == "maintained":
         return _maintained_badge(display_name, stage, health)
 
-    # Default: playful
+    # Default: playful — show dependent flair for high-responsibility packages
     return _playful_badge(
-        display_name, stage, mood, health, commit_streak=commit_streak, pet_image_b64=pet_image_b64
+        display_name,
+        stage,
+        mood,
+        health,
+        commit_streak=commit_streak,
+        pet_image_b64=pet_image_b64,
+        flair_text=_dependent_flair_text(dependent_count),
     )
 
 

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -1,5 +1,6 @@
 """GitHub API service for repository health metrics."""
 
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -37,6 +38,7 @@ class RepoHealth:
     security_alerts_high: int = 0
     security_alerts_medium: int = 0
     security_alerts_low: int = 0
+    dependent_count: int = 0
 
 
 @dataclass
@@ -177,6 +179,9 @@ class GitHubService:
             # Get security alerts
             security_counts = await self._get_security_alerts(client, owner, repo)
 
+            # Get dependent count (repos/packages that depend on this one)
+            dependent_count = await self._get_dependent_count(client, owner, repo)
+
             return RepoHealth(
                 last_commit_at=last_commit_at,
                 open_prs_count=open_prs_count,
@@ -191,6 +196,7 @@ class GitHubService:
                 security_alerts_high=security_counts["high"],
                 security_alerts_medium=security_counts["medium"],
                 security_alerts_low=security_counts["low"],
+                dependent_count=dependent_count,
             )
 
     async def _get_last_commit(
@@ -375,6 +381,31 @@ class GitHubService:
             raise
         except Exception as e:
             logger.warning("Failed to get contributor count", error=str(e))
+        return 0
+
+    async def _get_dependent_count(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> int:
+        """Get the number of repositories that depend on this repo.
+
+        Scrapes the GitHub network/dependents page since there is no REST API.
+        Returns 0 on any error or when the page is unavailable.
+        """
+        try:
+            resp = await client.get(
+                f"https://github.com/{owner}/{repo}/network/dependents",
+                headers={"Accept": "text/html"},
+                follow_redirects=True,
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                return 0
+            # Parse "N Repositories" or "N,NNN Repositories" from the page
+            match = re.search(r"([\d,]+)\s+Repositor", resp.text)
+            if match:
+                return int(match.group(1).replace(",", ""))
+        except Exception as e:
+            logger.warning("Failed to get dependent count", error=str(e))
         return 0
 
     async def get_contributor_stats(self, owner: str, repo: str, username: str) -> ContributorStats:

--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -97,14 +97,20 @@ def calculate_health_delta(health: RepoHealth) -> int:
         delta -= 5
 
     # Security alert penalties (capped per severity to avoid instant death)
+    # High-dependent packages carry more responsibility: security issues hurt more
+    sec_mult = 2 if health.dependent_count >= 100 else 1
     if health.security_alerts_critical > 0:
-        delta -= min(health.security_alerts_critical * SECURITY_HEALTH_PENALTY["critical"], 40)
+        cap = SECURITY_HEALTH_PENALTY["critical"] * health.security_alerts_critical * sec_mult
+        delta -= min(cap, 40 * sec_mult)
     if health.security_alerts_high > 0:
-        delta -= min(health.security_alerts_high * SECURITY_HEALTH_PENALTY["high"], 20)
+        cap = SECURITY_HEALTH_PENALTY["high"] * health.security_alerts_high * sec_mult
+        delta -= min(cap, 20 * sec_mult)
     if health.security_alerts_medium > 0:
-        delta -= min(health.security_alerts_medium * SECURITY_HEALTH_PENALTY["medium"], 10)
+        cap = SECURITY_HEALTH_PENALTY["medium"] * health.security_alerts_medium * sec_mult
+        delta -= min(cap, 10 * sec_mult)
     if health.security_alerts_low > 0:
-        delta -= min(health.security_alerts_low * SECURITY_HEALTH_PENALTY["low"], 4)
+        cap = SECURITY_HEALTH_PENALTY["low"] * health.security_alerts_low * sec_mult
+        delta -= min(cap, 4 * sec_mult)
 
     return delta
 

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -708,3 +708,66 @@ class TestGetContributorCount90d:
             result = await service._get_contributor_count_90d(client, "owner", "repo")
 
         assert result == 1
+
+
+class TestGetDependentCount:
+    """Tests for _get_dependent_count method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_count_from_html(self) -> None:
+        """Should parse dependent count from GitHub network/dependents page."""
+        html = (
+            "<html><body>"
+            '<a href="/owner/repo/network/dependents?dependent_type=REPOSITORY">'
+            "1,234 Repositories"
+            "</a></body></html>"
+        )
+        respx.get("https://github.com/owner/repo/network/dependents").mock(
+            return_value=httpx.Response(200, text=html)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_dependent_count(client, "owner", "repo")
+
+        assert result == 1234
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_count_without_comma(self) -> None:
+        """Should handle counts without comma separators."""
+        html = "<html><body>42 Repositories</body></html>"
+        respx.get("https://github.com/owner/repo/network/dependents").mock(
+            return_value=httpx.Response(200, text=html)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_dependent_count(client, "owner", "repo")
+
+        assert result == 42
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_404(self) -> None:
+        """Should return 0 when page is not found."""
+        respx.get("https://github.com/owner/repo/network/dependents").mock(
+            return_value=httpx.Response(404)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_dependent_count(client, "owner", "repo")
+
+        assert result == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_match(self) -> None:
+        """Should return 0 when page has no recognisable count."""
+        respx.get("https://github.com/owner/repo/network/dependents").mock(
+            return_value=httpx.Response(200, text="<html><body>No dependents</body></html>")
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_dependent_count(client, "owner", "repo")
+
+        assert result == 0

--- a/tests/unit/test_pet_logic.py
+++ b/tests/unit/test_pet_logic.py
@@ -603,3 +603,81 @@ class TestGetNextStage:
     def test_evolution_boundary_cases(self, stage: PetStage, exp: int, expected: PetStage) -> None:
         """Test evolution at exact threshold boundaries."""
         assert get_next_stage(stage, exp) == expected
+
+
+class TestDependentsResponsibilityMechanic:
+    """Tests for the dependents responsibility mechanic."""
+
+    def test_security_penalty_normal_without_dependents(self) -> None:
+        """Standard security penalty when no dependents."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_critical=1,
+            dependent_count=0,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["critical"]
+
+    def test_security_penalty_normal_below_threshold(self) -> None:
+        """Standard security penalty when dependents below 100."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_critical=1,
+            dependent_count=99,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["critical"]
+
+    def test_security_penalty_doubled_with_many_dependents(self) -> None:
+        """Security penalty is doubled when dependent_count >= 100."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_critical=1,
+            dependent_count=100,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["critical"] * 2
+
+    def test_security_penalty_doubled_for_large_dependent_count(self) -> None:
+        """Double penalty applies regardless of how many dependents above threshold."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            security_alerts_high=1,
+            dependent_count=10000,
+        )
+        assert calculate_health_delta(health) == -SECURITY_HEALTH_PENALTY["high"] * 2
+
+    def test_no_penalty_without_security_alerts_with_many_dependents(self) -> None:
+        """High dependent count alone does not affect health when no security alerts."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            dependent_count=5000,
+        )
+        assert calculate_health_delta(health) == 0


### PR DESCRIPTION
## Summary

- Fetch dependent count for each repo by scraping GitHub's `/network/dependents` page (no official API exists)
- Store `dependent_count` on the `Pet` model (migration `023`)
- Display a gear badge flair (`⚙ 1.2k deps`) in the SVG badge when a repo has 100+ dependents
- Security alert health penalties are doubled for high-dependent packages (100+ dependents), reflecting the increased responsibility of widely-used maintainers
- Expose `dependent_count` in `PetResponse` API

## Changes

- `services/github.py` — add `dependent_count` to `RepoHealth`, add `_get_dependent_count` HTML scraper
- `models/pet.py` — add `dependent_count` column
- `alembic/versions/023_add_dependent_count.py` — migration
- `api/routes.py` — expose `dependent_count` in `PetResponse`, pass to badge endpoint
- `main.py` — persist `dependent_count` each poll cycle
- `services/badge.py` — show `⚙ N deps` flair for high-dependent repos
- `services/pet_logic.py` — double security penalty multiplier when `dependent_count >= 100`

## Testing

- [x] All 822 tests pass
- [x] Lint clean
- [x] New unit tests for `_get_dependent_count` (HTML parse, 404, no match)
- [x] New unit tests for the responsibility health mechanic (multiplier applied / not applied)

Closes #24