### PR TITLE
fix: rename duplicate 023 migration to 024 (dependent_count)

### DIFF
--- a/alembic/versions/024_add_dependent_count.py
+++ b/alembic/versions/024_add_dependent_count.py
@@ -1,7 +1,7 @@
 """Add dependent_count to pets
 
-Revision ID: 023
-Revises: 022
+Revision ID: 024
+Revises: 023
 Create Date: 2026-04-10
 
 """
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "023"
-down_revision: str | None = "022"
+revision: str = "024"
+down_revision: str | None = "023"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
Personality traits (#151) and dependents (#152) were both merged with migration 023. This renames 023_add_dependent_count to 024_add_dependent_count with down_revision=023 to linearize the chain.