### PR TITLE
Closes #23: Add star/fork milestones as cosmetic unlocks

### DIFF
--- a/alembic/versions/025_add_star_fork_counts.py
+++ b/alembic/versions/025_add_star_fork_counts.py
@@ -1,0 +1,31 @@
+"""Add star_count and fork_count to pets table.
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-04-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "025"
+down_revision: str | None = "024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets", sa.Column("star_count", sa.Integer(), nullable=False, server_default="0")
+    )
+    op.add_column(
+        "pets", sa.Column("fork_count", sa.Integer(), nullable=False, server_default="0")
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "fork_count")
+    op.drop_column("pets", "star_count")

--- a/alembic/versions/025_add_star_fork_counts.py
+++ b/alembic/versions/025_add_star_fork_counts.py
@@ -9,6 +9,7 @@ Create Date: 2026-04-10
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "025"

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -600,6 +600,20 @@ async def get_pet_badge(
     except Exception:
         pass  # non-fatal — badge will use emoji fallback
 
+    # Fetch unlocked achievements for cosmetic badge effects (non-fatal on error)
+    from sqlalchemy import select as sa_select
+
+    from github_tamagotchi.models.achievement import PetAchievement
+
+    unlocked_achievements: set[str] = set()
+    try:
+        ach_result = await session.execute(
+            sa_select(PetAchievement.achievement_id).where(PetAchievement.pet_id == pet.id)
+        )
+        unlocked_achievements = set(ach_result.scalars().all())
+    except Exception:
+        pass  # non-fatal — badge renders without cosmetics on error
+
     svg_content = generate_badge_svg(
         pet.name,
         pet.stage,
@@ -612,6 +626,7 @@ async def get_pet_badge(
         pet_image_b64=pet_image_b64,
         badge_style=style if style is not None else pet.badge_style,
         dependent_count=pet.dependent_count,
+        unlocked_achievements=unlocked_achievements,
     )
     return Response(
         content=svg_content,

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -901,9 +901,9 @@ async def get_pet_achievements(
         items.append(
             AchievementItem(
                 id=aid,
-                name=ACHIEVEMENTS[aid]["name"],
-                icon=ACHIEVEMENTS[aid]["icon"],
-                description=ACHIEVEMENTS[aid]["description"],
+                name=str(ACHIEVEMENTS[aid]["name"]),
+                icon=str(ACHIEVEMENTS[aid]["icon"]),
+                description=str(ACHIEVEMENTS[aid]["description"]),
                 unlocked=row is not None,
                 unlocked_at=row.unlocked_at if row is not None else None,
             )

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -197,10 +197,12 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                             experience=new_experience,
                         )
 
-                    # Store last-known release, contributor, and dependent snapshots
+                    # Store last-known release, contributor, dependent, and popularity snapshots
                     pet.last_release_count = health.release_count_30d
                     pet.last_contributor_count = health.contributor_count
                     pet.dependent_count = health.dependent_count
+                    pet.star_count = health.star_count
+                    pet.fork_count = health.fork_count
 
                     # Update last_fed_at if there was a recent commit
                     if health.last_commit_at:
@@ -229,7 +231,12 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
                         )
 
                     # Check and unlock achievements based on updated pet state
-                    newly_unlocked = await check_and_unlock_achievements(pet, session)
+                    newly_unlocked = await check_and_unlock_achievements(
+                        pet,
+                        session,
+                        star_count=health.star_count,
+                        fork_count=health.fork_count,
+                    )
                     if newly_unlocked:
                         logger.info(
                             "achievements_unlocked",

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -134,6 +134,10 @@ class Pet(Base):
         Integer, nullable=False, default=0, server_default="0"
     )
 
+    # Popularity metrics (stars/forks) — cosmetic only, do not affect health
+    star_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    fork_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+
     # Leaderboard visibility (opt-out)
     leaderboard_opt_out: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"

--- a/src/github_tamagotchi/services/achievements.py
+++ b/src/github_tamagotchi/services/achievements.py
@@ -59,6 +59,56 @@ ACHIEVEMENTS: dict[str, dict[str, str]] = {
         "icon": "\U0001f525",
         "description": "Rose from the ashes (resurrected)",
     },
+    # Star milestones — cosmetic unlocks
+    "stars_10": {
+        "name": "Rising",
+        "icon": "\u2b50",
+        "description": "Reached 10 stars — Rising flair unlocked",
+        "cosmetic": True,
+    },
+    "stars_100": {
+        "name": "Silver Star",
+        "icon": "\U0001f947",
+        "description": "Reached 100 stars — silver border unlocked",
+        "cosmetic": True,
+    },
+    "stars_500": {
+        "name": "Gold Star",
+        "icon": "\U0001f947",
+        "description": "Reached 500 stars — gold border unlocked",
+        "cosmetic": True,
+    },
+    "stars_1000": {
+        "name": "Popular",
+        "icon": "\U0001f31f",
+        "description": "Reached 1,000 stars — Popular tag unlocked",
+        "cosmetic": True,
+    },
+    "stars_10000": {
+        "name": "Celebrity",
+        "icon": "\U0001f929",
+        "description": "Reached 10,000 stars — Celebrity skin unlocked",
+        "cosmetic": True,
+    },
+    # Fork milestones — cosmetic unlocks
+    "forks_1": {
+        "name": "Forked!",
+        "icon": "\U0001f374",
+        "description": "First fork — the repo is spreading",
+        "cosmetic": True,
+    },
+    "forks_10": {
+        "name": "Growing Community",
+        "icon": "\U0001f33f",
+        "description": "Reached 10 forks — Growing Community flair unlocked",
+        "cosmetic": True,
+    },
+    "forks_100": {
+        "name": "Community",
+        "icon": "\U0001f465",
+        "description": "Reached 100 forks — Community skin unlocked",
+        "cosmetic": True,
+    },
 }
 
 # Achievement IDs in a defined order for display
@@ -73,10 +123,20 @@ ACHIEVEMENT_ORDER = [
     "centurion",
     "social_butterfly",
     "phoenix",
+    "stars_10",
+    "stars_100",
+    "stars_500",
+    "stars_1000",
+    "stars_10000",
+    "forks_1",
+    "forks_10",
+    "forks_100",
 ]
 
 
-def _check_conditions(pet: Pet, comment_count: int) -> set[str]:
+def _check_conditions(
+    pet: Pet, comment_count: int, star_count: int = 0, fork_count: int = 0
+) -> set[str]:
     """Return the set of achievement IDs that the pet currently qualifies for."""
     earned: set[str] = set()
 
@@ -116,10 +176,32 @@ def _check_conditions(pet: Pet, comment_count: int) -> set[str]:
     if pet.generation >= 2:
         earned.add("phoenix")
 
+    # Star milestones (cosmetic only)
+    if star_count >= 10:
+        earned.add("stars_10")
+    if star_count >= 100:
+        earned.add("stars_100")
+    if star_count >= 500:
+        earned.add("stars_500")
+    if star_count >= 1000:
+        earned.add("stars_1000")
+    if star_count >= 10000:
+        earned.add("stars_10000")
+
+    # Fork milestones (cosmetic only)
+    if fork_count >= 1:
+        earned.add("forks_1")
+    if fork_count >= 10:
+        earned.add("forks_10")
+    if fork_count >= 100:
+        earned.add("forks_100")
+
     return earned
 
 
-async def check_and_unlock_achievements(pet: Pet, session: AsyncSession) -> list[str]:
+async def check_and_unlock_achievements(
+    pet: Pet, session: AsyncSession, *, star_count: int = 0, fork_count: int = 0
+) -> list[str]:
     """Check all conditions and unlock any newly earned achievements.
 
     Returns list of newly unlocked achievement IDs.
@@ -139,7 +221,7 @@ async def check_and_unlock_achievements(pet: Pet, session: AsyncSession) -> list
     )
     comment_count = comment_count_result.scalar() or 0
 
-    earned = _check_conditions(pet, comment_count)
+    earned = _check_conditions(pet, comment_count, star_count=star_count, fork_count=fork_count)
     newly_unlocked: list[str] = []
 
     for achievement_id in earned:

--- a/src/github_tamagotchi/services/achievements.py
+++ b/src/github_tamagotchi/services/achievements.py
@@ -8,7 +8,7 @@ from github_tamagotchi.models.achievement import PetAchievement
 from github_tamagotchi.models.comment import PetComment
 from github_tamagotchi.models.pet import Pet, PetStage
 
-ACHIEVEMENTS: dict[str, dict[str, str]] = {
+ACHIEVEMENTS: dict[str, dict[str, str | bool]] = {
     "first_commit": {
         "name": "First Blood",
         "icon": "\U0001fa78",

--- a/src/github_tamagotchi/services/badge.py
+++ b/src/github_tamagotchi/services/badge.py
@@ -108,6 +108,35 @@ def _format_dependent_count(count: int) -> str:
     return str(count)
 
 
+def _get_star_border(unlocked_achievements: set[str]) -> str | None:
+    """Return a border color if the pet has earned a star border achievement, else None."""
+    if "stars_500" in unlocked_achievements:
+        return "#ffd700"  # gold
+    if "stars_100" in unlocked_achievements:
+        return "#c0c0c0"  # silver
+    return None
+
+
+def _apply_star_border(svg: str, border_color: str, width: int, height: int) -> str:
+    """Inject a colored border rect into an SVG string just before </svg>."""
+    border_rect = (
+        f'  <rect x="1" y="1" width="{width - 2}" height="{height - 2}"'
+        f' rx="5" fill="none" stroke="{border_color}" stroke-width="2"/>'
+    )
+    return svg.replace("</svg>", f"{border_rect}\n</svg>")
+
+
+def _get_flair_text(unlocked_achievements: set[str]) -> str | None:
+    """Return flair text based on the highest earned star achievement, else None."""
+    if "stars_10000" in unlocked_achievements:
+        return "★ Celebrity"
+    if "stars_1000" in unlocked_achievements:
+        return "★ Popular"
+    if "stars_10" in unlocked_achievements:
+        return "★ Rising"
+    return None
+
+
 def _playful_badge(
     display_name: str,
     stage: str,
@@ -228,6 +257,11 @@ def _playful_badge(
             lines.append(
                 f'  <text x="116" y="14" font-size="7" fill="#ff9800" {_END}'
                 f' font-family="monospace">🔥{commit_streak}</text>'
+            )
+        elif flair_text:
+            lines.append(
+                f'  <text x="116" y="14" font-size="7" fill="#f1c40f" {_END}'
+                f' font-family="sans-serif">{flair_text}</text>'
             )
 
     lines.append("</svg>")
@@ -454,6 +488,7 @@ def generate_badge_svg(
     pet_image_b64: str | None = None,
     badge_style: str = DEFAULT_BADGE_STYLE,
     dependent_count: int = 0,
+    unlocked_achievements: set[str] | None = None,
 ) -> str:
     """Generate an SVG badge representing the current pet state.
 
@@ -469,8 +504,10 @@ def generate_badge_svg(
         pet_image_b64: Base64-encoded PNG sprite, or None to use emoji fallback.
         badge_style: Visual style — "playful", "minimal", or "maintained".
         dependent_count: Number of repos/packages that depend on this one.
+        unlocked_achievements: Set of achievement IDs for cosmetic effects.
     """
     display_name = name if len(name) <= 14 else name[:13] + "…"
+    achievements = unlocked_achievements or set()
 
     if is_dead:
         return _dead_badge(
@@ -489,16 +526,25 @@ def generate_badge_svg(
     if badge_style == "maintained":
         return _maintained_badge(display_name, stage, health)
 
-    # Default: playful — show dependent flair for high-responsibility packages
-    return _playful_badge(
+    # Default: playful — apply star cosmetics and dependent flair
+    flair_text = _get_flair_text(achievements) or _dependent_flair_text(dependent_count)
+    svg = _playful_badge(
         display_name,
         stage,
         mood,
         health,
         commit_streak=commit_streak,
         pet_image_b64=pet_image_b64,
-        flair_text=_dependent_flair_text(dependent_count),
+        flair_text=flair_text,
     )
+
+    border_color = _get_star_border(achievements)
+    if border_color:
+        has_sprite = bool(pet_image_b64)
+        width = _SPRITE_W if has_sprite else 120
+        svg = _apply_star_border(svg, border_color, width, 80)
+
+    return svg
 
 
 class ContributorStanding(StrEnum):

--- a/src/github_tamagotchi/services/github.py
+++ b/src/github_tamagotchi/services/github.py
@@ -39,6 +39,8 @@ class RepoHealth:
     security_alerts_medium: int = 0
     security_alerts_low: int = 0
     dependent_count: int = 0
+    star_count: int = 0
+    fork_count: int = 0
 
 
 @dataclass
@@ -186,6 +188,9 @@ class GitHubService:
             # Get dependent count (repos/packages that depend on this one)
             dependent_count = await self._get_dependent_count(client, owner, repo)
 
+            # Get star and fork counts
+            star_count, fork_count = await self._get_star_fork_counts(client, owner, repo)
+
             return RepoHealth(
                 last_commit_at=last_commit_at,
                 open_prs_count=open_prs_count,
@@ -201,6 +206,8 @@ class GitHubService:
                 security_alerts_medium=security_counts["medium"],
                 security_alerts_low=security_counts["low"],
                 dependent_count=dependent_count,
+                star_count=star_count,
+                fork_count=fork_count,
             )
 
     async def _get_last_commit(
@@ -321,6 +328,25 @@ class GitHubService:
         except Exception as e:
             logger.warning("Failed to get security alerts", error=str(e))
         return counts
+
+    async def _get_star_fork_counts(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> tuple[int, int]:
+        """Get the star and fork counts for the repository."""
+        try:
+            resp = await client.get(
+                f"{self.base_url}/repos/{owner}/{repo}",
+                headers=self._get_headers(),
+            )
+            self._check_rate_limit(resp)
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+            return data.get("stargazers_count", 0), data.get("forks_count", 0)
+        except RateLimitError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to get star/fork counts", error=str(e))
+        return 0, 0
 
     def _get_oldest_age_hours(self, items: list[dict[str, Any]]) -> float:
         """Get age in hours of the oldest item."""

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -176,3 +176,92 @@ async def test_achievements_api_404_for_unknown_pet(async_client: object) -> Non
 
     resp = await client.get("/api/v1/pets/nobody/norepo/achievements")
     assert resp.status_code == 404
+
+
+# --- Star milestone tests ---
+
+
+async def test_stars_10_achievement(test_db: AsyncSession) -> None:
+    """stars_10 unlocks when star_count >= 10."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo1", "Starlet")
+    newly = await check_and_unlock_achievements(pet, test_db, star_count=10)
+    assert "stars_10" in newly
+
+
+async def test_stars_100_achievement(test_db: AsyncSession) -> None:
+    """stars_100 unlocks when star_count >= 100."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo2", "Silver")
+    newly = await check_and_unlock_achievements(pet, test_db, star_count=100)
+    assert "stars_100" in newly
+    assert "stars_10" in newly
+
+
+async def test_stars_500_achievement(test_db: AsyncSession) -> None:
+    """stars_500 unlocks when star_count >= 500."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo3", "Gold")
+    newly = await check_and_unlock_achievements(pet, test_db, star_count=500)
+    assert "stars_500" in newly
+
+
+async def test_stars_1000_achievement(test_db: AsyncSession) -> None:
+    """stars_1000 unlocks when star_count >= 1000."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo4", "Popular")
+    newly = await check_and_unlock_achievements(pet, test_db, star_count=1000)
+    assert "stars_1000" in newly
+
+
+async def test_stars_10000_achievement(test_db: AsyncSession) -> None:
+    """stars_10000 unlocks when star_count >= 10000."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo5", "Celebrity")
+    newly = await check_and_unlock_achievements(pet, test_db, star_count=10000)
+    assert "stars_10000" in newly
+
+
+async def test_stars_not_unlocked_below_threshold(test_db: AsyncSession) -> None:
+    """Star achievements do not unlock below the threshold."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo6", "Nobody")
+    newly = await check_and_unlock_achievements(pet, test_db, star_count=9)
+    assert "stars_10" not in newly
+    assert "stars_100" not in newly
+
+
+async def test_star_achievements_independent_of_health(test_db: AsyncSession) -> None:
+    """Star milestones must not change pet health."""
+    pet = await pet_crud.create_pet(test_db, "owner", "stars_repo7", "Healthy")
+    pet.health = 50
+    await test_db.flush()
+    await check_and_unlock_achievements(pet, test_db, star_count=10000)
+    await test_db.refresh(pet)
+    assert pet.health == 50
+
+
+# --- Fork milestone tests ---
+
+
+async def test_forks_1_achievement(test_db: AsyncSession) -> None:
+    """forks_1 unlocks when fork_count >= 1."""
+    pet = await pet_crud.create_pet(test_db, "owner", "forks_repo1", "Forked")
+    newly = await check_and_unlock_achievements(pet, test_db, fork_count=1)
+    assert "forks_1" in newly
+
+
+async def test_forks_10_achievement(test_db: AsyncSession) -> None:
+    """forks_10 unlocks when fork_count >= 10."""
+    pet = await pet_crud.create_pet(test_db, "owner", "forks_repo2", "Growing")
+    newly = await check_and_unlock_achievements(pet, test_db, fork_count=10)
+    assert "forks_10" in newly
+    assert "forks_1" in newly
+
+
+async def test_forks_100_achievement(test_db: AsyncSession) -> None:
+    """forks_100 unlocks when fork_count >= 100."""
+    pet = await pet_crud.create_pet(test_db, "owner", "forks_repo3", "Community")
+    newly = await check_and_unlock_achievements(pet, test_db, fork_count=100)
+    assert "forks_100" in newly
+
+
+async def test_forks_not_unlocked_at_zero(test_db: AsyncSession) -> None:
+    """Fork achievements do not unlock when fork_count is 0."""
+    pet = await pet_crud.create_pet(test_db, "owner", "forks_repo4", "Unforkable")
+    newly = await check_and_unlock_achievements(pet, test_db, fork_count=0)
+    assert "forks_1" not in newly

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -802,3 +802,71 @@ class TestShowcaseEndpoint:
         body = response.text
         assert "UserAPet" in body
         assert "UserBPet" not in body
+
+
+class TestBadgeStarCosmetics:
+    """Tests for star/fork milestone cosmetic effects on the badge."""
+
+    def _make_badge(self, achievements: set[str]) -> str:
+        return generate_badge_svg(
+            "TestPet",
+            "adult",
+            "happy",
+            80,
+            unlocked_achievements=achievements,
+        )
+
+    def test_no_cosmetics_without_achievements(self) -> None:
+        svg = self._make_badge(set())
+        assert "★" not in svg
+        assert "stroke=" not in svg
+
+    def test_rising_flair_at_10_stars(self) -> None:
+        svg = self._make_badge({"stars_10"})
+        assert "★ Rising" in svg
+
+    def test_silver_border_at_100_stars(self) -> None:
+        svg = self._make_badge({"stars_10", "stars_100"})
+        assert "#c0c0c0" in svg
+
+    def test_gold_border_supersedes_silver(self) -> None:
+        svg = self._make_badge({"stars_10", "stars_100", "stars_500"})
+        assert "#ffd700" in svg
+        assert "#c0c0c0" not in svg
+
+    def test_popular_flair_at_1000_stars(self) -> None:
+        svg = self._make_badge({"stars_10", "stars_100", "stars_500", "stars_1000"})
+        assert "★ Popular" in svg
+
+    def test_celebrity_flair_at_10000_stars(self) -> None:
+        svg = self._make_badge(
+            {"stars_10", "stars_100", "stars_500", "stars_1000", "stars_10000"}
+        )
+        assert "★ Celebrity" in svg
+
+    def test_streak_takes_priority_over_flair(self) -> None:
+        svg = generate_badge_svg(
+            "TestPet",
+            "adult",
+            "happy",
+            80,
+            commit_streak=7,
+            unlocked_achievements={"stars_10000"},
+        )
+        assert "🔥" in svg
+        assert "★ Celebrity" not in svg
+
+    def test_no_border_without_star_milestones(self) -> None:
+        svg = self._make_badge({"forks_1", "forks_10"})
+        assert "#c0c0c0" not in svg
+        assert "#ffd700" not in svg
+
+    def test_none_achievements_treated_as_empty(self) -> None:
+        svg = generate_badge_svg("TestPet", "adult", "happy", 80, unlocked_achievements=None)
+        assert "★" not in svg
+        assert "#c0c0c0" not in svg
+
+    def test_svg_still_valid_with_border(self) -> None:
+        svg = self._make_badge({"stars_100"})
+        assert svg.startswith("<svg")
+        assert svg.endswith("</svg>")


### PR DESCRIPTION
## What

Tracks star and fork counts on pets, adds milestone achievements for star/fork count thresholds, and surfaces counts on the badge and profile.

- Adds `star_count` and `fork_count` fields to the Pet model (migration 025)
- Fetches star/fork counts from GitHub API on each poll cycle
- Adds milestone achievements when thresholds are hit (e.g. 10/50/100 stars)
- Badge displays star count as flair text and applies a star border for popular repos

Closes #23