### PR TITLE
Closes #43: Add comprehensive health checks

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -134,7 +134,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /api/v1/health/ready
               port: 8000
             periodSeconds: 5
             failureThreshold: 3
@@ -275,7 +275,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /api/v1/health/ready
               port: 8000
             periodSeconds: 5
             failureThreshold: 3

--- a/src/github_tamagotchi/api/health.py
+++ b/src/github_tamagotchi/api/health.py
@@ -1,0 +1,286 @@
+"""Health check endpoints for k8s probes and monitoring."""
+
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, Any
+
+import httpx
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi import __version__
+from github_tamagotchi.api.auth import get_admin_user
+from github_tamagotchi.core.config import settings
+from github_tamagotchi.core.database import get_session
+from github_tamagotchi.core.scheduler import get_uptime_seconds, scheduler
+from github_tamagotchi.models.job_run import JobRun
+from github_tamagotchi.models.pet import Pet
+from github_tamagotchi.models.user import User
+from github_tamagotchi.models.webhook_event import WebhookEvent
+
+logger = structlog.get_logger()
+
+health_router = APIRouter(prefix="/api/v1/health", tags=["health"])
+
+DbSession = Annotated[AsyncSession, Depends(get_session)]
+AdminUser = Annotated[User, Depends(get_admin_user)]
+
+
+class LivenessResponse(BaseModel):
+    """Simple liveness response."""
+
+    status: str
+
+
+class CheckResult(BaseModel):
+    """Result of a single dependency check."""
+
+    status: str
+    latency_ms: float | None = None
+    rate_limit_remaining: int | None = None
+    next_poll_in: str | None = None
+    error: str | None = None
+
+
+class ReadinessResponse(BaseModel):
+    """Readiness check response with dependency statuses."""
+
+    status: str
+    checks: dict[str, CheckResult]
+
+
+class PetStats(BaseModel):
+    """Pet statistics."""
+
+    total_pets: int
+    active_pets: int
+    dead_pets: int
+
+
+class ActivityStats(BaseModel):
+    """Activity statistics for the last hour."""
+
+    polls_last_hour: int
+    webhooks_last_hour: int
+    errors_last_hour: int
+
+
+class DetailedResponse(BaseModel):
+    """Full system status for admin monitoring."""
+
+    status: str
+    version: str
+    uptime: str
+    checks: dict[str, CheckResult]
+    stats: dict[str, Any]
+
+
+def _format_uptime(seconds: float) -> str:
+    """Format seconds into a human-readable uptime string."""
+    td = timedelta(seconds=int(seconds))
+    days = td.days
+    hours, remainder = divmod(td.seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if days:
+        return f"{days}d {hours}h {minutes}m"
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    return f"{minutes}m {secs}s"
+
+
+async def _check_database(session: AsyncSession) -> CheckResult:
+    """Check database connectivity and measure latency."""
+    start = time.monotonic()
+    try:
+        await session.execute(text("SELECT 1"))
+        latency_ms = (time.monotonic() - start) * 1000
+        if latency_ms > 1000:
+            return CheckResult(status="degraded", latency_ms=round(latency_ms, 2))
+        return CheckResult(status="ok", latency_ms=round(latency_ms, 2))
+    except Exception as exc:
+        logger.warning("Database health check failed", error=str(exc))
+        return CheckResult(status="error", error=str(exc))
+
+
+async def _check_github_api() -> CheckResult:
+    """Check GitHub API availability via rate limit endpoint."""
+    try:
+        headers: dict[str, str] = {"Accept": "application/vnd.github.v3+json"}
+        if settings.github_token:
+            headers["Authorization"] = f"Bearer {settings.github_token}"
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            start = time.monotonic()
+            resp = await client.get("https://api.github.com/rate_limit", headers=headers)
+            latency_ms = (time.monotonic() - start) * 1000
+        if resp.status_code != 200:
+            return CheckResult(
+                status="error",
+                latency_ms=round(latency_ms, 2),
+                error=f"HTTP {resp.status_code}",
+            )
+        data = resp.json()
+        remaining = data.get("rate", {}).get("remaining", 0)
+        if remaining < 100:
+            return CheckResult(
+                status="degraded",
+                latency_ms=round(latency_ms, 2),
+                rate_limit_remaining=remaining,
+            )
+        return CheckResult(
+            status="ok",
+            latency_ms=round(latency_ms, 2),
+            rate_limit_remaining=remaining,
+        )
+    except Exception as exc:
+        logger.warning("GitHub API health check failed", error=str(exc))
+        return CheckResult(status="error", error=str(exc))
+
+
+def _check_scheduler() -> CheckResult:
+    """Check if the poll_repositories job is scheduled and running."""
+    try:
+        job = scheduler.get_job("poll_repositories")
+        if job is None:
+            return CheckResult(status="error", error="Job not found")
+        next_run = job.next_run_time
+        if next_run is None:
+            return CheckResult(status="error", error="Job has no next run time")
+        now = datetime.now(UTC)
+        seconds_until = (next_run - now).total_seconds()
+        interval_seconds = settings.github_poll_interval_minutes * 60
+        # Consider degraded if next run is more than 2x the interval overdue
+        if seconds_until < -(interval_seconds * 2):
+            return CheckResult(
+                status="degraded",
+                next_poll_in=f"{int(-seconds_until)}s overdue",
+            )
+        if seconds_until < 0:
+            next_poll_str = "running"
+        else:
+            minutes, secs = divmod(int(seconds_until), 60)
+            next_poll_str = f"{minutes}m{secs}s" if minutes else f"{secs}s"
+        return CheckResult(status="ok", next_poll_in=next_poll_str)
+    except Exception as exc:
+        logger.warning("Scheduler health check failed", error=str(exc))
+        return CheckResult(status="error", error=str(exc))
+
+
+@health_router.get("", response_model=LivenessResponse)
+async def liveness() -> LivenessResponse:
+    """Liveness probe — returns 200 if the process is alive."""
+    return LivenessResponse(status="ok")
+
+
+@health_router.get("/ready", response_model=ReadinessResponse)
+async def readiness(session: DbSession) -> ReadinessResponse:
+    """Readiness probe — checks all critical dependencies."""
+    db_check = await _check_database(session)
+    github_check = await _check_github_api()
+    scheduler_check = _check_scheduler()
+
+    checks = {
+        "database": db_check,
+        "github_api": github_check,
+        "scheduler": scheduler_check,
+    }
+
+    all_ok = all(c.status == "ok" for c in checks.values())
+    any_error = any(c.status == "error" for c in checks.values())
+
+    if any_error:
+        overall = "unhealthy"
+    elif not all_ok:
+        overall = "degraded"
+    else:
+        overall = "healthy"
+
+    if any_error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=ReadinessResponse(status=overall, checks=checks).model_dump(),
+        )
+
+    return ReadinessResponse(status=overall, checks=checks)
+
+
+@health_router.get("/detailed", response_model=DetailedResponse)
+async def detailed(
+    session: DbSession,
+    _admin: AdminUser,
+) -> DetailedResponse:
+    """Full system status — requires admin authentication."""
+    db_check = await _check_database(session)
+    github_check = await _check_github_api()
+    scheduler_check = _check_scheduler()
+
+    checks = {
+        "database": db_check,
+        "github_api": github_check,
+        "scheduler": scheduler_check,
+    }
+
+    all_ok = all(c.status == "ok" for c in checks.values())
+    any_error = any(c.status == "error" for c in checks.values())
+
+    if any_error:
+        overall = "unhealthy"
+    elif not all_ok:
+        overall = "degraded"
+    else:
+        overall = "healthy"
+
+    # Pet stats
+    total_pets = (await session.execute(select(func.count()).select_from(Pet))).scalar() or 0
+    dead_pets = (
+        await session.execute(select(func.count()).select_from(Pet).where(Pet.is_dead.is_(True)))
+    ).scalar() or 0
+    active_pets = total_pets - dead_pets
+
+    # Activity stats (last hour)
+    one_hour_ago = datetime.now(UTC) - timedelta(hours=1)
+
+    polls_last_hour = (
+        await session.execute(
+            select(func.count())
+            .select_from(JobRun)
+            .where(JobRun.job_name == "poll_repositories")
+            .where(JobRun.started_at >= one_hour_ago)
+        )
+    ).scalar() or 0
+
+    webhooks_last_hour = (
+        await session.execute(
+            select(func.count())
+            .select_from(WebhookEvent)
+            .where(WebhookEvent.created_at >= one_hour_ago)
+        )
+    ).scalar() or 0
+
+    errors_last_hour = (
+        await session.execute(
+            select(func.sum(JobRun.errors_count))
+            .select_from(JobRun)
+            .where(JobRun.started_at >= one_hour_ago)
+        )
+    ).scalar() or 0
+
+    uptime_seconds = get_uptime_seconds()
+    uptime_str = _format_uptime(uptime_seconds) if uptime_seconds is not None else "unknown"
+
+    return DetailedResponse(
+        status=overall,
+        version=__version__,
+        uptime=uptime_str,
+        checks=checks,
+        stats={
+            "total_pets": total_pets,
+            "active_pets": active_pets,
+            "dead_pets": dead_pets,
+            "polls_last_hour": polls_last_hour,
+            "webhooks_last_hour": webhooks_last_hour,
+            "errors_last_hour": int(errors_last_hour),
+        },
+    )

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -8,7 +8,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import text, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
@@ -168,14 +168,6 @@ class SkinSelectResponse(BaseModel):
 
     message: str
     pet: PetResponse
-
-class HealthResponse(BaseModel):
-    """Health check response."""
-
-    status: str
-    version: str
-    database: str
-
 
 class ImageProviderHealthResponse(BaseModel):
     """Image provider health check response."""
@@ -351,21 +343,6 @@ class LeaderboardResponse(BaseModel):
 
     categories: list[LeaderboardCategory]
     cached_at: datetime
-
-
-@router.get("/health", response_model=HealthResponse)
-async def health_check(session: DbSession) -> HealthResponse:
-    """Health check endpoint."""
-    from github_tamagotchi import __version__
-
-    try:
-        await session.execute(text("SELECT 1"))
-        db_status = "connected"
-    except Exception:
-        logger.exception("health_check_db_error")
-        db_status = "disconnected"
-
-    return HealthResponse(status="healthy", version=__version__, database=db_status)
 
 
 @router.get("/health/image-provider", response_model=ImageProviderHealthResponse)

--- a/src/github_tamagotchi/core/scheduler.py
+++ b/src/github_tamagotchi/core/scheduler.py
@@ -1,0 +1,23 @@
+"""Shared scheduler instance for background jobs."""
+
+from datetime import UTC, datetime
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+scheduler = AsyncIOScheduler()
+
+# Set during application startup
+app_start_time: datetime | None = None
+
+
+def set_start_time() -> None:
+    """Record the application startup time."""
+    global app_start_time
+    app_start_time = datetime.now(UTC)
+
+
+def get_uptime_seconds() -> float | None:
+    """Return seconds since startup, or None if not started."""
+    if app_start_time is None:
+        return None
+    return (datetime.now(UTC) - app_start_time).total_seconds()

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -13,7 +13,6 @@ from typing import Annotated, Any
 
 import sentry_sdk
 import structlog
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -27,9 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from github_tamagotchi import __version__
 from github_tamagotchi.api.alerts import alert_router
 from github_tamagotchi.api.auth import auth_router, get_admin_user, get_optional_user
+from github_tamagotchi.api.health import health_router
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.config import settings
 from github_tamagotchi.core.database import async_session_factory, close_database, get_session
+from github_tamagotchi.core.scheduler import scheduler, set_start_time
 from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.crud.contributor_relationship import upsert_contributor_relationship
 from github_tamagotchi.crud.milestone import create_milestone
@@ -90,8 +91,6 @@ def configure_logging(debug: bool = False) -> None:
 
 configure_logging(debug=bool(os.getenv("DEBUG")))
 logger = structlog.get_logger()
-
-scheduler = AsyncIOScheduler()
 
 # Track consecutive poll failures for alerting
 _consecutive_poll_failures = 0
@@ -418,6 +417,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
         logger.info("Sentry initialized")
 
+    set_start_time()
+
     # Start scheduler for periodic polling
     scheduler.add_job(
         poll_repositories,
@@ -467,6 +468,7 @@ app = FastAPI(
 app.include_router(router)
 app.include_router(alert_router)
 app.include_router(auth_router)
+app.include_router(health_router)
 
 # Mount the MCP server at /mcp
 app.mount("/mcp", mcp_app)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -16,26 +16,13 @@ async def test_root_endpoint(async_client: AsyncClient) -> None:
     assert data["docs"] == "/docs"
 
 
-async def test_health_check_returns_database_status(async_client: AsyncClient) -> None:
-    """Test health check includes database connectivity status."""
+async def test_liveness_returns_ok(async_client: AsyncClient) -> None:
+    """Liveness check returns 200 with status ok."""
     response = await async_client.get("/api/v1/health")
     assert response.status_code == 200
 
     data = response.json()
-    assert data["status"] == "healthy"
-    assert data["version"] == __version__
-    assert data["database"] == "connected"
-
-
-async def test_health_check_response_schema(async_client: AsyncClient) -> None:
-    """Test health check response matches expected schema."""
-    response = await async_client.get("/api/v1/health")
-    assert response.status_code == 200
-
-    data = response.json()
-    assert "status" in data
-    assert "version" in data
-    assert "database" in data
+    assert data["status"] == "ok"
 
 
 async def test_create_pet_validates_request_body(async_client: AsyncClient) -> None:

--- a/tests/api/test_api_routes.py
+++ b/tests/api/test_api_routes.py
@@ -5,9 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
-from github_tamagotchi import __version__
-
-
 class TestHealthEndpoint:
     """Tests for the health check endpoint."""
 
@@ -16,17 +13,11 @@ class TestHealthEndpoint:
         response = client.get("/api/v1/health")
         assert response.status_code == 200
 
-    def test_health_returns_healthy_status(self, client: TestClient) -> None:
-        """Health endpoint should return healthy status."""
+    def test_health_returns_ok_status(self, client: TestClient) -> None:
+        """Health endpoint should return ok status for liveness."""
         response = client.get("/api/v1/health")
         data = response.json()
-        assert data["status"] == "healthy"
-
-    def test_health_returns_version(self, client: TestClient) -> None:
-        """Health endpoint should return current version."""
-        response = client.get("/api/v1/health")
-        data = response.json()
-        assert data["version"] == __version__
+        assert data["status"] == "ok"
 
 
 class TestPetsEndpointsAsync:

--- a/tests/api/test_api_routes.py
+++ b/tests/api/test_api_routes.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
+
 class TestHealthEndpoint:
     """Tests for the health check endpoint."""
 

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -9,11 +9,11 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from github_tamagotchi import __version__
-from github_tamagotchi.api.health import CheckResult, health_router
 from github_tamagotchi.api.auth import get_admin_user
+from github_tamagotchi.api.health import CheckResult, health_router
 from github_tamagotchi.core.database import get_session
-from tests.conftest import get_test_session, test_engine
 from github_tamagotchi.models.pet import Base
+from tests.conftest import get_test_session, test_engine
 
 
 class TestLivenessEndpoint:

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,216 @@
+"""Tests for comprehensive health check endpoints."""
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+
+from github_tamagotchi import __version__
+from github_tamagotchi.api.health import CheckResult, health_router
+from github_tamagotchi.api.auth import get_admin_user
+from github_tamagotchi.core.database import get_session
+from tests.conftest import get_test_session, test_engine
+from github_tamagotchi.models.pet import Base
+
+
+class TestLivenessEndpoint:
+    """Tests for GET /api/v1/health (liveness probe)."""
+
+    def test_liveness_returns_200(self, client: TestClient) -> None:
+        """Liveness endpoint returns 200 OK."""
+        response = client.get("/api/v1/health")
+        assert response.status_code == 200
+
+    def test_liveness_returns_ok_status(self, client: TestClient) -> None:
+        """Liveness endpoint returns ok status (no dependency checks)."""
+        response = client.get("/api/v1/health")
+        data = response.json()
+        assert data["status"] == "ok"
+
+    def test_liveness_has_no_dependency_fields(self, client: TestClient) -> None:
+        """Liveness endpoint does not expose database or other check fields."""
+        response = client.get("/api/v1/health")
+        data = response.json()
+        assert "database" not in data
+        assert "checks" not in data
+
+
+class TestReadinessEndpoint:
+    """Tests for GET /api/v1/health/ready (readiness probe)."""
+
+    async def test_readiness_healthy_when_all_checks_pass(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Readiness returns 200 when all dependency checks pass."""
+        github_ok = CheckResult(status="ok", latency_ms=50.0, rate_limit_remaining=4500)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="28m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await async_client.get("/api/v1/health/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "database" in data["checks"]
+        assert "github_api" in data["checks"]
+        assert "scheduler" in data["checks"]
+        assert data["checks"]["database"]["status"] == "ok"
+        assert data["checks"]["github_api"]["status"] == "ok"
+        assert data["checks"]["scheduler"]["status"] == "ok"
+
+    async def test_readiness_503_when_critical_check_fails(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Readiness returns 503 when any critical check fails."""
+        db_error = CheckResult(status="error", error="Connection refused")
+        github_ok = CheckResult(status="ok", latency_ms=45.0, rate_limit_remaining=4000)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="10m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_database",
+                new_callable=AsyncMock,
+                return_value=db_error,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await async_client.get("/api/v1/health/ready")
+
+        assert response.status_code == 503
+
+    async def test_readiness_degraded_when_github_rate_limit_low(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Readiness returns 200 with degraded when GitHub rate limit is low."""
+        github_degraded = CheckResult(status="degraded", latency_ms=40.0, rate_limit_remaining=50)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="5m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_degraded,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await async_client.get("/api/v1/health/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "degraded"
+
+    async def test_readiness_includes_check_details(self, async_client: AsyncClient) -> None:
+        """Readiness response includes latency and rate limit info."""
+        github_ok = CheckResult(status="ok", latency_ms=55.3, rate_limit_remaining=4800)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="14m30s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await async_client.get("/api/v1/health/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["checks"]["database"]["latency_ms"] is not None
+        assert data["checks"]["github_api"]["rate_limit_remaining"] == 4800
+        assert data["checks"]["scheduler"]["next_poll_in"] == "14m30s"
+
+
+@pytest.fixture
+async def admin_health_client() -> AsyncIterator[AsyncClient]:
+    """Async client with admin dependency overridden for health endpoint tests."""
+    mock_admin_user = MagicMock()
+    mock_admin_user.is_admin = True
+
+    app = FastAPI(title="Health Admin Test")
+    app.include_router(health_router)
+    app.dependency_overrides[get_session] = get_test_session
+    app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+class TestDetailedEndpoint:
+    """Tests for GET /api/v1/health/detailed (admin endpoint)."""
+
+    async def test_detailed_requires_auth(self, async_client: AsyncClient) -> None:
+        """Detailed endpoint returns 401 without authentication."""
+        response = await async_client.get("/api/v1/health/detailed")
+        # FastAPI returns 401 or 403 depending on auth setup
+        assert response.status_code in (401, 403)
+
+    async def test_detailed_returns_full_stats_for_admin(
+        self, admin_health_client: AsyncClient
+    ) -> None:
+        """Detailed endpoint returns version, uptime, checks, and pet stats."""
+        github_ok = CheckResult(status="ok", latency_ms=60.0, rate_limit_remaining=4700)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="20m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await admin_health_client.get("/api/v1/health/detailed")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["version"] == __version__
+        assert "uptime" in data
+        assert "checks" in data
+        assert "stats" in data
+        stats = data["stats"]
+        assert "total_pets" in stats
+        assert "active_pets" in stats
+        assert "dead_pets" in stats
+        assert "polls_last_hour" in stats
+        assert "webhooks_last_hour" in stats
+        assert "errors_last_hour" in stats

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from github_tamagotchi import __version__
+from github_tamagotchi.api.health import health_router
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 
@@ -53,8 +54,9 @@ def create_api_test_app() -> FastAPI:
     """Create a test FastAPI app for API testing (no templates/static)."""
     test_app = FastAPI(title="GitHub Tamagotchi Test")
 
-    # Include the production API router
+    # Include the production API routers
     test_app.include_router(router)
+    test_app.include_router(health_router)
 
     # Override the database session dependency
     test_app.dependency_overrides[get_session] = get_test_session
@@ -148,7 +150,7 @@ def client() -> Iterator[TestClient]:
     github_tamagotchi.services.image_queue.run_worker = mock_run_worker
 
     # Patch the scheduler
-    with patch("github_tamagotchi.main.scheduler") as mock_scheduler:
+    with patch("github_tamagotchi.core.scheduler.scheduler") as mock_scheduler:
         mock_scheduler.start = lambda: None
         mock_scheduler.shutdown = lambda: None
         mock_scheduler.add_job = lambda *args, **kwargs: None

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from github_tamagotchi.api.health import health_router
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.models.pet import Base, Pet, PetMood, PetStage
@@ -38,6 +39,7 @@ def create_e2e_app() -> FastAPI:
     """Create E2E test app with DB but no external services."""
     app = FastAPI(title="GitHub Tamagotchi E2E", lifespan=e2e_lifespan)
     app.include_router(router)
+    app.include_router(health_router)
     app.dependency_overrides[get_session] = get_e2e_session
     return app
 

--- a/tests/e2e/test_pet_lifecycle.py
+++ b/tests/e2e/test_pet_lifecycle.py
@@ -10,13 +10,12 @@ from github_tamagotchi.models.pet import PetMood, PetStage
 class TestPetLifecycle:
     """Full pet lifecycle through the API."""
 
-    async def test_health_endpoint_with_db(self, e2e_client: AsyncClient) -> None:
-        """Health endpoint reports connected database."""
+    async def test_liveness_endpoint(self, e2e_client: AsyncClient) -> None:
+        """Liveness endpoint returns ok."""
         resp = await e2e_client.get("/api/v1/health")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] == "healthy"
-        assert data["database"] == "connected"
+        assert data["status"] == "ok"
 
     async def test_create_pet_via_api(self, e2e_client: AsyncClient) -> None:
         """Create a pet through the API and verify response."""


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/health` as a pure liveness probe returning `{"status": "ok"}`
- Adds `GET /api/v1/health/ready` as a readiness probe checking database latency, GitHub API rate limits, and scheduler state — returns 503 if any critical check fails
- Adds `GET /api/v1/health/detailed` as an admin-only endpoint with full system status: version, uptime, dependency checks, and pet/activity stats (total pets, dead pets, polls/webhooks/errors in the last hour)
- Updates k8s readiness probe to use `/api/v1/health/ready` (liveness and startup stay on `/api/v1/health`)
- Extracts `APScheduler` instance to `core/scheduler.py` to share it between `main.py` and `health.py` without circular imports

## Changes
- `src/github_tamagotchi/core/scheduler.py` — shared scheduler instance with startup time tracking
- `src/github_tamagotchi/api/health.py` — three health check endpoints
- `src/github_tamagotchi/main.py` — import scheduler from core, call `set_start_time()` on startup, register `health_router`
- `src/github_tamagotchi/api/routes.py` — remove old `/api/v1/health` (replaced by health router)
- `k8s/deployment.yaml` — readiness probe updated to `/api/v1/health/ready`
- Tests updated for new liveness response and new health endpoints added

## Testing
- [x] All 850 tests pass
- [x] Ruff lint passes
- [x] 9 new tests covering liveness, readiness (200/503/degraded), and detailed admin endpoint

Closes #43