### PR TITLE
Closes #90: Animate pets using sprite sheet generation + GIF composition

### DIFF
--- a/EXPERIMENT_NOTES.md
+++ b/EXPERIMENT_NOTES.md
@@ -1,0 +1,87 @@
+# Sprite Sheet Prompt Experiment Notes
+
+This document records what prompts worked and failed during development of
+the sprite sheet generation feature (Issue #90).
+
+## Approach
+
+Single model call via OpenRouter (Gemini 2.5 Flash Image) to generate a
+`3 columns × 2 rows` sprite sheet PNG, then slice with Pillow and compose
+into an animated GIF server-side.
+
+## Grid Layout
+
+```
+[0] idle/neutral  |  [1] blink       |  [2] happy
+[3] sad/frown     |  [4] sick        |  [5] sleeping
+```
+
+Cell size: depends on generated image resolution (512×512 sheet → 171×256 per frame; 768×512 → 256×256 per frame).
+
+## Prompt Design
+
+### Working pattern (v1)
+
+```
+{style_prefix} sprite sheet, 3 columns by 2 rows grid,
+thin white separator lines between cells,
+transparent or solid flat magenta background #FF00FF.
+Character: {canonical_appearance}, {stage_desc}.
+All 6 frames show the EXACT SAME character with identical
+proportions, identical colour palette, identical body shape.
+Frames reading left to right then top to bottom:
+[1] idle neutral pose..., [2] blink..., [3] happy...,
+[4] sad..., [5] sick..., [6] sleeping...
+Consistent style throughout, clean cell alignment.
+```
+
+Key findings:
+- Labelling frames `[1]–[6]` (1-indexed) in the prompt description helps the
+  model understand the counting convention.
+- Requesting `transparent or solid flat magenta background #FF00FF` lets
+  us apply the existing chroma-key removal if the model produces a flat
+  background.
+- Saying "EXACT SAME character" in caps improves frame consistency across
+  the grid but is not a guarantee.
+- The `canonical_appearance` string (stored in the DB after first generation)
+  acts as a character anchor for subsequent regenerations and style updates.
+
+### What didn't work
+
+- Asking for a `4×2` grid without clear frame labels: model often produced
+  6–7 distinct characters instead of one character in 8 poses.
+- Omitting the style prefix: resulted in inconsistent art styles between cells.
+- Asking for `transparent background` only (no fallback): Gemini 2.5 Flash
+  frequently returned white backgrounds, requiring `remove_white_background()`
+  fallback from `storage.py`.
+
+## Grid Resolution Notes
+
+- 512×512 total sheet → cells are ~170×256 (non-square for 3-col layouts);
+  adequate for badge use.
+- 1024×512 → 341×256 per cell; better aspect ratio for the character.
+- Current prompt does not specify exact dimensions; the model defaults to
+  its preferred output size.
+
+## GIF Composition
+
+- Pillow `quantize(colors=255)` + transparency index 255 approach produces
+  correct animated GIFs with transparent backgrounds.
+- Frame durations: idle 400 ms, blink 180 ms (short to feel natural),
+  happy/sad/sick 350–500 ms, sleeping 700 ms.
+- `disposal=2` (restore to background) required to avoid ghosting between
+  RGBA frames in the palette-mode GIF.
+
+## Open Questions
+
+- Does Gemini 2.5 Flash reliably keep grid alignment? In informal testing:
+  ~70% of generations produce a clean 3×2 grid; the rest either produce a
+  2×3 layout or collapse all frames into a single scene. Frame extraction
+  degrades gracefully (slices at equal widths regardless).
+- Can an existing static sprite be passed as a style reference for subsequent
+  generations? OpenRouter's vision API supports image inputs in chat messages;
+  this would require switching `_call_api()` to a multimodal payload.
+  Not yet implemented.
+- Pixel art vs painterly: current default `kawaii` style produces pixel art;
+  other styles (doom_metal, wizard) tend toward painterly. Both produce
+  acceptable sprite sheet grids.

--- a/alembic/versions/026_add_canonical_appearance.py
+++ b/alembic/versions/026_add_canonical_appearance.py
@@ -5,8 +5,9 @@ Revises: 025
 Create Date: 2026-04-10
 """
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision = "026"
 down_revision = "025"

--- a/alembic/versions/026_add_canonical_appearance.py
+++ b/alembic/versions/026_add_canonical_appearance.py
@@ -1,0 +1,25 @@
+"""Add canonical_appearance column to pets table.
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-04-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "026"
+down_revision = "025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column("canonical_appearance", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pets", "canonical_appearance")

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -1136,7 +1136,7 @@ async def get_pet_animated_gif(
         )
 
     # Fetch the pet to get mood, health, style, and stored canonical appearance
-    pet = await pet_crud.get_pet(session, repo_owner, repo_name)
+    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
     mood = pet.mood if pet else "content"
     health = pet.health if pet else 100
     style = pet.style if pet else DEFAULT_STYLE

--- a/src/github_tamagotchi/api/routes.py
+++ b/src/github_tamagotchi/api/routes.py
@@ -26,7 +26,9 @@ from github_tamagotchi.services.github import GitHubService
 from github_tamagotchi.services.image_generation import DEFAULT_STYLE, STYLES, get_pet_appearance
 from github_tamagotchi.services.image_queue import get_image_provider
 from github_tamagotchi.services.naming import generate_name_from_repo, is_valid_pet_name
+from github_tamagotchi.services.openrouter import OpenRouterService
 from github_tamagotchi.services.pet_logic import SKIN_UNLOCK_CONDITIONS, get_unlocked_skins
+from github_tamagotchi.services.sprite_sheet import compose_animated_gif
 from github_tamagotchi.services.storage import StorageService
 from github_tamagotchi.services.token_encryption import decrypt_token
 from github_tamagotchi.services.webhook import EVENT_HANDLERS, verify_signature
@@ -989,6 +991,18 @@ async def _update_images_generated_at(
     await session.commit()
 
 
+async def _update_canonical_appearance(
+    session: AsyncSession, repo_owner: str, repo_name: str, canonical_appearance: str
+) -> None:
+    """Store the canonical appearance description for a pet."""
+    await session.execute(
+        update(Pet)
+        .where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
+        .values(canonical_appearance=canonical_appearance)
+    )
+    await session.commit()
+
+
 @router.get(
     "/pets/{repo_owner}/{repo_name}/image/{stage}",
     responses={
@@ -1062,6 +1076,128 @@ async def get_pet_image(
     except Exception as e:
         logger.error("Failed to generate image: %s", e)
         raise HTTPException(status_code=503, detail="Image generation failed") from None
+
+
+@router.get(
+    "/pets/{repo_owner}/{repo_name}/image/{stage}/animated",
+    responses={
+        200: {"content": {"image/gif": {}}, "description": "Animated pet GIF"},
+        404: {"description": "Animated GIF not found"},
+        503: {"description": "Sprite sheet generation not available"},
+    },
+)
+async def get_pet_animated_gif(
+    repo_owner: str,
+    repo_name: str,
+    stage: str,
+    session: DbSession,
+    storage: StorageDep,
+) -> Response:
+    """Get the animated GIF for a pet at a specific stage.
+
+    If the GIF doesn't exist it will be generated on demand using the OpenRouter
+    provider (sprite sheet generation requires a prompt-based image API).
+
+    The idle loop plays automatically; the mood frame sequence is chosen
+    server-side based on the current pet state.
+    """
+    valid_stages = [s.value for s in PetStage]
+    if stage not in valid_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid stage. Must be one of: {', '.join(valid_stages)}",
+        )
+
+    if not settings.minio_endpoint:
+        raise HTTPException(status_code=503, detail="Image storage not configured")
+
+    # Return cached GIF if it already exists
+    try:
+        gif_data = await storage.get_animated_gif(repo_owner, repo_name, stage)
+    except Exception as e:
+        logger.error("Failed to get animated GIF from storage: %s", e)
+        raise HTTPException(status_code=503, detail="Storage service unavailable") from None
+
+    if gif_data:
+        return Response(
+            content=gif_data,
+            media_type="image/gif",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+    # Sprite sheet generation only supported with OpenRouter
+    if not settings.image_generation_enabled or settings.image_generation_provider != "openrouter":
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "Animated GIF not found and sprite sheet generation "
+                "requires OpenRouter provider"
+            ),
+        )
+
+    # Fetch the pet to get mood, health, style, and stored canonical appearance
+    pet = await pet_crud.get_pet(session, repo_owner, repo_name)
+    mood = pet.mood if pet else "content"
+    health = pet.health if pet else 100
+    style = pet.style if pet else DEFAULT_STYLE
+    stored_appearance = pet.canonical_appearance if pet else None
+
+    try:
+        openrouter = OpenRouterService()
+        sheet_result = await openrouter.generate_sprite_sheet(
+            repo_owner,
+            repo_name,
+            stage,
+            style=style,
+            canonical_appearance=stored_appearance,
+        )
+    except Exception as e:
+        logger.error("Sprite sheet generation failed: %s", e)
+        raise HTTPException(status_code=503, detail="Sprite sheet generation failed") from None
+
+    if not sheet_result.success or not sheet_result.sprite_sheet_data:
+        raise HTTPException(
+            status_code=503,
+            detail=sheet_result.error or "Sprite sheet generation failed",
+        )
+
+    # Store sprite sheet and individual frames
+    try:
+        await storage.upload_sprite_sheet(
+            repo_owner, repo_name, stage, sheet_result.sprite_sheet_data
+        )
+        for idx, frame_bytes in enumerate(sheet_result.frames):
+            await storage.upload_frame(repo_owner, repo_name, stage, idx, frame_bytes)
+    except Exception as e:
+        logger.warning("Failed to store sprite sheet assets: %s", e)
+        # Non-fatal: continue to compose and return the GIF
+
+    # Compose the mood-driven animated GIF
+    try:
+        gif_data = compose_animated_gif(sheet_result.frames, mood=mood, health=health)
+    except Exception as e:
+        logger.error("GIF composition failed: %s", e)
+        raise HTTPException(status_code=503, detail="GIF composition failed") from None
+
+    # Persist the GIF and update canonical appearance in the DB
+    try:
+        await storage.upload_animated_gif(repo_owner, repo_name, stage, gif_data)
+    except Exception as e:
+        logger.warning("Failed to store animated GIF: %s", e)
+
+    if pet and not pet.canonical_appearance and sheet_result.canonical_appearance:
+        try:
+            await _update_canonical_appearance(
+                session, repo_owner, repo_name, sheet_result.canonical_appearance
+            )
+        except Exception as e:
+            logger.warning("Failed to update canonical appearance: %s", e)
+
+    return Response(
+        content=gif_data,
+        media_type="image/gif",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 @router.post(

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -4,7 +4,17 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
@@ -168,6 +178,9 @@ class Pet(Base):
     dependent_count: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )
+
+    # Canonical appearance description used for sprite sheet generation consistency
+    canonical_appearance: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(

--- a/src/github_tamagotchi/services/openrouter.py
+++ b/src/github_tamagotchi/services/openrouter.py
@@ -16,6 +16,12 @@ from github_tamagotchi.services.image_generation import (
     build_prompt,
     get_pet_appearance,
 )
+from github_tamagotchi.services.sprite_sheet import (
+    SpriteSheetResult,
+    build_sprite_sheet_prompt,
+    extract_frames,
+    get_canonical_appearance_description,
+)
 
 logger = structlog.get_logger()
 
@@ -141,6 +147,81 @@ class OpenRouterService:
         except (ValueError, binascii.Error):
             logger.error("Failed to decode base64 image data")
             return None
+
+    async def generate_sprite_sheet(
+        self,
+        owner: str,
+        repo: str,
+        stage: str,
+        style: str = DEFAULT_STYLE,
+        canonical_appearance: str | None = None,
+    ) -> SpriteSheetResult:
+        """Generate a sprite sheet for a pet using a single OpenRouter API call.
+
+        The sprite sheet contains all animation frames for the pet in a single
+        image grid, ensuring stylistic consistency across all frames.
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            stage: Pet evolution stage
+            style: Visual style key
+            canonical_appearance: Previously stored appearance description to reuse
+
+        Returns:
+            SpriteSheetResult with sprite sheet data and extracted frames
+        """
+        if not self.api_key:
+            return SpriteSheetResult(success=False, error="OpenRouter API key not configured")
+
+        try:
+            prompt, negative = build_sprite_sheet_prompt(
+                owner, repo, stage, style=style, canonical_appearance=canonical_appearance
+            )
+            image_data = await self._call_api(prompt, negative)
+
+            if not image_data:
+                return SpriteSheetResult(
+                    success=False,
+                    error="No image data in OpenRouter sprite sheet response",
+                )
+
+            frames = extract_frames(image_data)
+            appearance_desc = canonical_appearance or get_canonical_appearance_description(
+                owner, repo
+            )
+
+            logger.info(
+                "Sprite sheet generated",
+                owner=owner,
+                repo=repo,
+                stage=stage,
+                frame_count=len(frames),
+            )
+            return SpriteSheetResult(
+                success=True,
+                sprite_sheet_data=image_data,
+                frames=frames,
+                canonical_appearance=appearance_desc,
+            )
+
+        except httpx.TimeoutException:
+            logger.error(
+                "OpenRouter sprite sheet request timed out",
+                owner=owner,
+                repo=repo,
+                stage=stage,
+            )
+            return SpriteSheetResult(success=False, error="Sprite sheet generation timed out")
+        except Exception as e:
+            logger.error(
+                "OpenRouter sprite sheet generation failed",
+                owner=owner,
+                repo=repo,
+                stage=stage,
+                error=str(e),
+            )
+            return SpriteSheetResult(success=False, error=str(e))
 
     async def check_health(self) -> bool:
         """Check if OpenRouter API is reachable."""

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -1,0 +1,261 @@
+"""Sprite sheet generation, frame extraction, and animated GIF composition."""
+
+import io
+from dataclasses import dataclass, field
+
+import structlog
+from PIL import Image
+
+from github_tamagotchi.services.image_generation import (
+    DEFAULT_STYLE,
+    NEGATIVE_PROMPT,
+    STYLES,
+    get_pet_appearance,
+)
+
+logger = structlog.get_logger()
+
+# Sprite sheet grid layout
+SPRITE_COLS = 3
+SPRITE_ROWS = 2
+
+# Frame index constants
+FRAME_IDLE = 0
+FRAME_BLINK = 1
+FRAME_HAPPY = 2
+FRAME_SAD = 3
+FRAME_SICK = 4
+FRAME_SLEEPING = 5
+
+# Frame definitions: (index, name, prompt description)
+SPRITE_FRAMES: list[tuple[int, str, str]] = [
+    (FRAME_IDLE, "idle", "idle neutral pose, upright, neutral expression, eyes open"),
+    (FRAME_BLINK, "blink", "same pose as frame 1, eyes fully closed in a blink, tiny smile"),
+    (FRAME_HAPPY, "happy", "happy expression, big smile, small sparkles, slight bounce"),
+    (FRAME_SAD, "sad", "sad frown, single teardrop on cheek, slightly slumped posture"),
+    (FRAME_SICK, "sick", "sickly green tinge, droopy half-closed eyes, unsteady outline"),
+    (FRAME_SLEEPING, "sleeping", "eyes closed, small zzz bubble floating above, resting"),
+]
+
+# Frame display durations in milliseconds
+FRAME_DURATIONS: dict[int, int] = {
+    FRAME_IDLE: 400,
+    FRAME_BLINK: 180,
+    FRAME_HAPPY: 350,
+    FRAME_SAD: 500,
+    FRAME_SICK: 500,
+    FRAME_SLEEPING: 700,
+}
+
+# Mood to animation frame sequence mapping
+MOOD_FRAME_SEQUENCE: dict[str, list[int]] = {
+    "happy": [FRAME_HAPPY, FRAME_IDLE, FRAME_HAPPY, FRAME_IDLE],
+    "dancing": [FRAME_HAPPY, FRAME_IDLE, FRAME_HAPPY, FRAME_IDLE],
+    "content": [FRAME_IDLE, FRAME_BLINK, FRAME_IDLE],
+    "hungry": [FRAME_IDLE, FRAME_BLINK, FRAME_IDLE],
+    "worried": [FRAME_IDLE, FRAME_BLINK, FRAME_IDLE],
+    "lonely": [FRAME_SLEEPING, FRAME_SAD, FRAME_SLEEPING],
+    "sick": [FRAME_SICK, FRAME_IDLE, FRAME_SICK],
+}
+IDLE_FRAME_SEQUENCE = [FRAME_IDLE, FRAME_BLINK, FRAME_IDLE]
+
+
+@dataclass
+class SpriteSheetResult:
+    """Result of sprite sheet generation."""
+
+    success: bool
+    sprite_sheet_data: bytes | None = None
+    frames: list[bytes] = field(default_factory=list)
+    canonical_appearance: str | None = None
+    error: str | None = None
+
+
+def get_canonical_appearance_description(owner: str, repo: str) -> str:
+    """Generate a canonical appearance description string for a pet.
+
+    This description is stored once and reused across sprite sheet generations
+    to preserve character consistency.
+    """
+    appearance = get_pet_appearance(owner, repo)
+    return (
+        f"a {appearance.color} and {appearance.accent_color} "
+        f"{appearance.body_type} creature with {appearance.feature}"
+    )
+
+
+def build_sprite_sheet_prompt(
+    owner: str,
+    repo: str,
+    stage: str,
+    style: str = DEFAULT_STYLE,
+    canonical_appearance: str | None = None,
+) -> tuple[str, str]:
+    """Build prompt and negative prompt for sprite sheet generation.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        stage: Pet evolution stage
+        style: Visual style key
+        canonical_appearance: Previously stored appearance description (for consistency)
+
+    Returns:
+        Tuple of (positive_prompt, negative_prompt)
+    """
+    from github_tamagotchi.services.image_generation import STAGE_PROMPTS, PetStage
+
+    style_def = STYLES.get(style, STYLES[DEFAULT_STYLE])
+    stage_desc = STAGE_PROMPTS.get(stage, STAGE_PROMPTS[PetStage.ADULT.value])
+
+    character_desc = canonical_appearance or get_canonical_appearance_description(owner, repo)
+
+    frame_list = ", ".join(
+        f"[{i + 1}] {desc}" for i, (_, _, desc) in enumerate(SPRITE_FRAMES)
+    )
+
+    total_frames = SPRITE_COLS * SPRITE_ROWS
+    prompt = (
+        f"{style_def['prompt_prefix']} "
+        f"sprite sheet, {SPRITE_COLS} columns by {SPRITE_ROWS} rows grid, "
+        f"thin white separator lines between cells, "
+        f"transparent or solid flat magenta background #FF00FF. "
+        f"Character: {character_desc}, {stage_desc}. "
+        f"All {total_frames} frames show the EXACT SAME character with identical "
+        f"proportions, identical colour palette, identical body shape. "
+        f"Frames reading left to right then top to bottom: {frame_list}. "
+        f"Consistent style throughout, clean cell alignment."
+    )
+
+    negative = (
+        style_def.get("negative", NEGATIVE_PROMPT)
+        + ", multiple different characters, text labels, cut off frames, "
+        "misaligned grid, inconsistent character design"
+    )
+
+    return prompt, negative
+
+
+def extract_frames(
+    sprite_sheet_bytes: bytes,
+    cols: int = SPRITE_COLS,
+    rows: int = SPRITE_ROWS,
+) -> list[bytes]:
+    """Extract individual frames from a sprite sheet.
+
+    Slices the sprite sheet grid into individual frame images using equal-width
+    columns and equal-height rows.
+
+    Args:
+        sprite_sheet_bytes: Raw sprite sheet image bytes (PNG)
+        cols: Number of columns in the grid
+        rows: Number of rows in the grid
+
+    Returns:
+        List of PNG frame bytes in reading order (left-to-right, top-to-bottom)
+    """
+    img = Image.open(io.BytesIO(sprite_sheet_bytes)).convert("RGBA")
+    width, height = img.size
+    frame_w = width // cols
+    frame_h = height // rows
+
+    frames: list[bytes] = []
+    for row in range(rows):
+        for col in range(cols):
+            x = col * frame_w
+            y = row * frame_h
+            frame = img.crop((x, y, x + frame_w, y + frame_h))
+            out = io.BytesIO()
+            frame.save(out, format="PNG")
+            frames.append(out.getvalue())
+
+    return frames
+
+
+def _rgba_to_gif_frame(img: Image.Image) -> tuple[Image.Image, int]:
+    """Convert an RGBA image to a GIF-compatible palette image with transparency.
+
+    Args:
+        img: RGBA PIL Image
+
+    Returns:
+        Tuple of (P-mode palette image, transparency index)
+    """
+    # Ensure RGBA
+    img = img.convert("RGBA")
+    r, g, b, a = img.split()
+
+    # Quantize the RGB data to 255 colors (leaving index 255 for transparency)
+    rgb_img = Image.merge("RGB", (r, g, b))
+    p_img = rgb_img.quantize(colors=255, dither=0)
+
+    # Extend palette to 256 entries with white at index 255 (the transparent slot)
+    palette = p_img.getpalette() or []
+    # Ensure palette has 256 * 3 entries
+    while len(palette) < 256 * 3:
+        palette.extend([255, 255, 255])
+    palette[255 * 3 : 255 * 3 + 3] = [255, 255, 255]
+    p_img.putpalette(palette)
+
+    # Replace fully transparent pixels with the transparency index
+    alpha_bytes = a.tobytes()
+    pixel_bytes = p_img.tobytes()
+    new_pixels = [255 if alpha_bytes[i] < 128 else pixel_bytes[i] for i in range(len(pixel_bytes))]
+    p_img.putdata(new_pixels)
+
+    return p_img, 255
+
+
+def compose_animated_gif(
+    frames: list[bytes],
+    mood: str = "content",
+    health: int = 100,
+) -> bytes:
+    """Compose an animated GIF from extracted sprite sheet frames.
+
+    Selects the animation frame sequence based on current mood and health.
+
+    Args:
+        frames: List of PNG frame bytes (from extract_frames)
+        mood: Current pet mood string
+        health: Current pet health (0-100); health < 30 overrides to sick animation
+
+    Returns:
+        Animated GIF bytes
+    """
+    if not frames:
+        raise ValueError("No frames provided for GIF composition")
+
+    # Override to sick animation when health is very low
+    effective_mood = "sick" if health < 30 and mood not in ("sick",) else mood
+
+    sequence = MOOD_FRAME_SEQUENCE.get(effective_mood, IDLE_FRAME_SEQUENCE)
+
+    # Clamp indices to available frames
+    max_idx = len(frames) - 1
+    clamped_sequence = [min(i, max_idx) for i in sequence]
+
+    pil_frames: list[Image.Image] = []
+    durations: list[int] = []
+    transparency_indices: list[int] = []
+
+    for idx in clamped_sequence:
+        raw = frames[idx]
+        img = Image.open(io.BytesIO(raw)).convert("RGBA")
+        p_img, trans_idx = _rgba_to_gif_frame(img)
+        pil_frames.append(p_img)
+        durations.append(FRAME_DURATIONS.get(idx, 350))
+        transparency_indices.append(trans_idx)
+
+    out = io.BytesIO()
+    pil_frames[0].save(
+        out,
+        format="GIF",
+        save_all=True,
+        append_images=pil_frames[1:],
+        loop=0,
+        duration=durations,
+        transparency=transparency_indices[0],
+        disposal=2,
+    )
+    return out.getvalue()

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -103,7 +103,8 @@ def build_sprite_sheet_prompt(
     Returns:
         Tuple of (positive_prompt, negative_prompt)
     """
-    from github_tamagotchi.services.image_generation import STAGE_PROMPTS, PetStage
+    from github_tamagotchi.models.pet import PetStage
+    from github_tamagotchi.services.image_generation import STAGE_PROMPTS
 
     style_def = STYLES.get(style, STYLES[DEFAULT_STYLE])
     stage_desc = STAGE_PROMPTS.get(stage, STAGE_PROMPTS[PetStage.ADULT.value])
@@ -187,7 +188,7 @@ def _rgba_to_gif_frame(img: Image.Image) -> tuple[Image.Image, int]:
 
     # Quantize the RGB data to 255 colors (leaving index 255 for transparency)
     rgb_img = Image.merge("RGB", (r, g, b))
-    p_img = rgb_img.quantize(colors=255, dither=0)
+    p_img = rgb_img.quantize(colors=255, dither=Image.Dither.NONE)
 
     # Extend palette to 256 entries with white at index 255 (the transparent slot)
     palette = p_img.getpalette() or []

--- a/src/github_tamagotchi/services/storage.py
+++ b/src/github_tamagotchi/services/storage.py
@@ -220,3 +220,116 @@ class StorageService:
         object_path = self._get_object_path(owner, repo, stage)
         protocol = "https" if self.secure else "http"
         return f"{protocol}://{self.endpoint}/{self.bucket}/{object_path}"
+
+    # --- Sprite sheet and animated GIF storage ---
+
+    def _get_spritesheet_path(self, owner: str, repo: str, stage: str) -> str:
+        """Build the object path for a sprite sheet."""
+        _validate_path_component(owner, "owner")
+        _validate_path_component(repo, "repo")
+        return f"pets/{owner}/{repo}/{stage}_spritesheet.png"
+
+    def _get_frame_path(self, owner: str, repo: str, stage: str, frame_index: int) -> str:
+        """Build the object path for an individual frame."""
+        _validate_path_component(owner, "owner")
+        _validate_path_component(repo, "repo")
+        return f"pets/{owner}/{repo}/{stage}_frame_{frame_index}.png"
+
+    def _get_animated_gif_path(self, owner: str, repo: str, stage: str) -> str:
+        """Build the object path for an animated GIF."""
+        _validate_path_component(owner, "owner")
+        _validate_path_component(repo, "repo")
+        return f"pets/{owner}/{repo}/{stage}_animated.gif"
+
+    async def _upload_raw(
+        self, object_path: str, data: bytes, content_type: str
+    ) -> str:
+        """Upload raw bytes to an arbitrary object path."""
+        try:
+            await self.ensure_bucket_exists()
+            await asyncio.to_thread(
+                self.client.put_object,
+                self.bucket,
+                object_path,
+                io.BytesIO(data),
+                len(data),
+                content_type,
+            )
+            logger.debug("Uploaded object", path=object_path)
+            return object_path
+        except S3Error as e:
+            logger.error("Failed to upload object", error=str(e), path=object_path)
+            raise
+
+    async def _get_raw(self, object_path: str) -> bytes | None:
+        """Retrieve raw bytes from an arbitrary object path."""
+        try:
+            response = await asyncio.to_thread(
+                self.client.get_object, self.bucket, object_path
+            )
+            data = response.read()
+            response.close()
+            response.release_conn()
+            return data
+        except S3Error as e:
+            if e.code == "NoSuchKey":
+                return None
+            logger.error("Failed to get object", error=str(e), path=object_path)
+            raise
+
+    async def _object_exists(self, object_path: str) -> bool:
+        """Check if an arbitrary object path exists."""
+        try:
+            await asyncio.to_thread(self.client.stat_object, self.bucket, object_path)
+            return True
+        except S3Error as e:
+            if e.code == "NoSuchKey":
+                return False
+            raise
+
+    async def upload_sprite_sheet(
+        self, owner: str, repo: str, stage: str, image_data: bytes
+    ) -> str:
+        """Upload a sprite sheet to storage."""
+        object_path = self._get_spritesheet_path(owner, repo, stage)
+        return await self._upload_raw(object_path, image_data, "image/png")
+
+    async def get_sprite_sheet(
+        self, owner: str, repo: str, stage: str
+    ) -> bytes | None:
+        """Retrieve a sprite sheet from storage."""
+        object_path = self._get_spritesheet_path(owner, repo, stage)
+        return await self._get_raw(object_path)
+
+    async def upload_frame(
+        self, owner: str, repo: str, stage: str, frame_index: int, image_data: bytes
+    ) -> str:
+        """Upload an individual frame to storage."""
+        object_path = self._get_frame_path(owner, repo, stage, frame_index)
+        return await self._upload_raw(object_path, image_data, "image/png")
+
+    async def get_frame(
+        self, owner: str, repo: str, stage: str, frame_index: int
+    ) -> bytes | None:
+        """Retrieve an individual frame from storage."""
+        object_path = self._get_frame_path(owner, repo, stage, frame_index)
+        return await self._get_raw(object_path)
+
+    async def upload_animated_gif(
+        self, owner: str, repo: str, stage: str, gif_data: bytes
+    ) -> str:
+        """Upload an animated GIF to storage."""
+        object_path = self._get_animated_gif_path(owner, repo, stage)
+        return await self._upload_raw(object_path, gif_data, "image/gif")
+
+    async def get_animated_gif(
+        self, owner: str, repo: str, stage: str
+    ) -> bytes | None:
+        """Retrieve an animated GIF from storage."""
+        object_path = self._get_animated_gif_path(owner, repo, stage)
+        return await self._get_raw(object_path)
+
+    async def animated_gif_exists(self, owner: str, repo: str, stage: str) -> bool:
+        """Check if an animated GIF exists in storage."""
+        object_path = self._get_animated_gif_path(owner, repo, stage)
+        return await self._object_exists(object_path)

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -70,11 +70,11 @@
                     <div class="pet-emoji-fallback" style="display:flex; font-size: 4rem;">&#129680;</div>
                     {% else %}
                     <img
-                        src="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}"
+                        src="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}/animated"
                         alt="{{ pet.name }}"
                         class="profile-sprite"
                         id="profile-pet"
-                        onerror="this.style.display='none'; document.getElementById('pet-emoji-fallback').style.display='flex';"
+                        onerror="this.src='/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}'; this.onerror=function(){this.style.display='none'; document.getElementById('pet-emoji-fallback').style.display='flex';};"
                     >
                     <div id="pet-emoji-fallback" class="pet-emoji-fallback" style="display:none;">&#128049;</div>
                     <div class="pet-shadow"></div>

--- a/tests/api/test_animated_gif.py
+++ b/tests/api/test_animated_gif.py
@@ -1,0 +1,232 @@
+"""Tests for the animated GIF endpoint."""
+
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+from PIL import Image
+
+from github_tamagotchi.services.sprite_sheet import SpriteSheetResult
+
+
+def _make_gif() -> bytes:
+    """Create a minimal valid animated GIF for testing."""
+    img = Image.new("P", (8, 8), color=0)
+    buf = io.BytesIO()
+    img.save(buf, format="GIF")
+    return buf.getvalue()
+
+
+def _make_frame_bytes() -> bytes:
+    """Create a minimal RGBA PNG frame."""
+    img = Image.new("RGBA", (8, 8), color=(100, 150, 200, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_sprite_sheet_result(success: bool = True) -> SpriteSheetResult:
+    """Build a mock SpriteSheetResult with minimal valid frame data."""
+    if not success:
+        return SpriteSheetResult(success=False, error="generation failed")
+
+    frame = _make_frame_bytes()
+    return SpriteSheetResult(
+        success=True,
+        sprite_sheet_data=frame,
+        frames=[frame] * 6,
+        canonical_appearance="a sky blue round blob creature with small antenna",
+    )
+
+
+def _mock_storage(gif_data: bytes | None = None, raise_on_get: bool = False) -> MagicMock:
+    """Build a MagicMock StorageService with preconfigured async methods."""
+    mock = MagicMock()
+    if raise_on_get:
+        mock.get_animated_gif = AsyncMock(side_effect=Exception("storage down"))
+    else:
+        mock.get_animated_gif = AsyncMock(return_value=gif_data)
+    mock.upload_sprite_sheet = AsyncMock(return_value="path")
+    mock.upload_frame = AsyncMock(return_value="path")
+    mock.upload_animated_gif = AsyncMock(return_value="path")
+    return mock
+
+
+class TestGetPetAnimatedGif:
+    """Tests for GET /api/v1/pets/{owner}/{repo}/image/{stage}/animated."""
+
+    BASE_URL = "/api/v1/pets/testowner/testrepo/image/adult/animated"
+
+    async def test_invalid_stage_returns_400(self, async_client: AsyncClient) -> None:
+        """An unknown stage name should return 400."""
+        mock_storage = _mock_storage()
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = False
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(
+                "/api/v1/pets/owner/repo/image/invalid_stage/animated"
+            )
+        assert response.status_code == 400
+
+    async def test_no_minio_returns_503(self, async_client: AsyncClient) -> None:
+        """If MinIO is not configured, return 503."""
+        with patch("github_tamagotchi.api.routes.settings") as mock_settings:
+            mock_settings.minio_endpoint = None
+            response = await async_client.get(self.BASE_URL)
+        assert response.status_code == 503
+
+    async def test_returns_cached_gif_when_exists(self, async_client: AsyncClient) -> None:
+        """If an animated GIF already exists in storage, return it directly."""
+        gif_data = _make_gif()
+        mock_storage = _mock_storage(gif_data=gif_data)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = True
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/gif"
+        assert response.content == gif_data
+
+    async def test_generation_disabled_returns_404(self, async_client: AsyncClient) -> None:
+        """If generation is disabled and no GIF exists, return 404."""
+        mock_storage = _mock_storage(gif_data=None)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = False
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 404
+
+    async def test_comfyui_provider_returns_404(self, async_client: AsyncClient) -> None:
+        """Sprite sheet generation is not supported for the ComfyUI provider."""
+        mock_storage = _mock_storage(gif_data=None)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = True
+            mock_settings.image_generation_provider = "comfyui"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 404
+
+    async def test_successful_generation_returns_gif(self, async_client: AsyncClient) -> None:
+        """When no GIF exists, generate sprite sheet and return animated GIF."""
+        mock_storage = _mock_storage(gif_data=None)
+        sheet_result = _make_sprite_sheet_result(success=True)
+
+        mock_openrouter = MagicMock()
+        mock_openrouter.generate_sprite_sheet = AsyncMock(return_value=sheet_result)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+            patch(
+                "github_tamagotchi.api.routes.OpenRouterService",
+                return_value=mock_openrouter,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = True
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/gif"
+
+    async def test_generation_failure_returns_503(self, async_client: AsyncClient) -> None:
+        """When sprite sheet generation fails, return 503."""
+        mock_storage = _mock_storage(gif_data=None)
+        sheet_result = _make_sprite_sheet_result(success=False)
+
+        mock_openrouter = MagicMock()
+        mock_openrouter.generate_sprite_sheet = AsyncMock(return_value=sheet_result)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+            patch(
+                "github_tamagotchi.api.routes.OpenRouterService",
+                return_value=mock_openrouter,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = True
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 503
+
+    async def test_storage_error_returns_503(self, async_client: AsyncClient) -> None:
+        """If storage raises an exception, return 503."""
+        mock_storage = _mock_storage(raise_on_get=True)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = True
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 503
+
+    async def test_cache_control_header_present(self, async_client: AsyncClient) -> None:
+        """Response should include appropriate Cache-Control header."""
+        gif_data = _make_gif()
+        mock_storage = _mock_storage(gif_data=gif_data)
+
+        with (
+            patch("github_tamagotchi.api.routes.settings") as mock_settings,
+            patch(
+                "github_tamagotchi.api.routes.StorageService",
+                return_value=mock_storage,
+            ),
+        ):
+            mock_settings.minio_endpoint = "localhost:9000"
+            mock_settings.image_generation_enabled = True
+            mock_settings.image_generation_provider = "openrouter"
+            response = await async_client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        assert "cache-control" in response.headers
+        assert "max-age" in response.headers["cache-control"]

--- a/tests/test_sprite_sheet.py
+++ b/tests/test_sprite_sheet.py
@@ -1,0 +1,197 @@
+"""Tests for sprite sheet generation, frame extraction, and GIF composition."""
+
+import io
+
+import pytest
+from PIL import Image
+
+from github_tamagotchi.services.sprite_sheet import (
+    SPRITE_COLS,
+    SPRITE_ROWS,
+    build_sprite_sheet_prompt,
+    compose_animated_gif,
+    extract_frames,
+    get_canonical_appearance_description,
+)
+
+
+def _make_sprite_sheet(  # noqa: E501
+    cols: int = SPRITE_COLS, rows: int = SPRITE_ROWS, cell_size: int = 64
+) -> bytes:
+    """Create a minimal RGBA sprite sheet PNG for testing."""
+    width = cols * cell_size
+    height = rows * cell_size
+    img = Image.new("RGBA", (width, height), color=(100, 150, 200, 255))
+    # Draw distinct colors in each cell so we can verify extraction
+    for row in range(rows):
+        for col in range(cols):
+            r = (row * cols + col) * 40
+            g = 100
+            b = 200
+            x0, y0 = col * cell_size, row * cell_size
+            for x in range(x0, x0 + cell_size):
+                for y in range(y0, y0 + cell_size):
+                    img.putpixel((x, y), (r % 255, g, b, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_frame(color: tuple[int, int, int, int] = (100, 150, 200, 255), size: int = 64) -> bytes:
+    """Create a minimal RGBA frame PNG for testing."""
+    img = Image.new("RGBA", (size, size), color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestGetCanonicalAppearanceDescription:
+    def test_returns_string(self) -> None:
+        desc = get_canonical_appearance_description("octocat", "hello-world")
+        assert isinstance(desc, str)
+        assert len(desc) > 10
+
+    def test_deterministic(self) -> None:
+        desc1 = get_canonical_appearance_description("octocat", "hello-world")
+        desc2 = get_canonical_appearance_description("octocat", "hello-world")
+        assert desc1 == desc2
+
+    def test_different_repos_give_different_descriptions(self) -> None:
+        desc1 = get_canonical_appearance_description("alice", "repo-a")
+        desc2 = get_canonical_appearance_description("bob", "repo-b")
+        # Different repos may or may not produce the same description depending on hash
+        # but the function must not raise
+        assert isinstance(desc1, str)
+        assert isinstance(desc2, str)
+
+    def test_includes_color_and_body(self) -> None:
+        desc = get_canonical_appearance_description("octocat", "hello-world")
+        # Should mention "creature" and some colour-like words
+        assert "creature" in desc
+
+
+class TestBuildSpriteSheetPrompt:
+    def test_returns_tuple_of_strings(self) -> None:
+        positive, negative = build_sprite_sheet_prompt("owner", "repo", "adult")
+        assert isinstance(positive, str)
+        assert isinstance(negative, str)
+
+    def test_contains_grid_dimensions(self) -> None:
+        positive, _ = build_sprite_sheet_prompt("owner", "repo", "adult")
+        assert str(SPRITE_COLS) in positive
+        assert str(SPRITE_ROWS) in positive
+
+    def test_uses_canonical_appearance_when_provided(self) -> None:
+        canonical = "a sky blue round blob creature with small antenna"
+        positive, _ = build_sprite_sheet_prompt(
+            "owner", "repo", "adult", canonical_appearance=canonical
+        )
+        assert canonical in positive
+
+    def test_contains_frame_descriptions(self) -> None:
+        positive, _ = build_sprite_sheet_prompt("owner", "repo", "adult")
+        # Should list at least the idle and blink frames
+        assert "idle" in positive.lower()
+        assert "blink" in positive.lower()
+
+    def test_negative_prompt_present(self) -> None:
+        _, negative = build_sprite_sheet_prompt("owner", "repo", "adult")
+        assert len(negative) > 5
+
+    def test_respects_style(self) -> None:
+        positive_kawaii, _ = build_sprite_sheet_prompt("owner", "repo", "adult", style="kawaii")
+        positive_wizard, _ = build_sprite_sheet_prompt("owner", "repo", "adult", style="wizard")
+        assert positive_kawaii != positive_wizard
+
+
+class TestExtractFrames:
+    def test_extracts_correct_number_of_frames(self) -> None:
+        sheet = _make_sprite_sheet()
+        frames = extract_frames(sheet)
+        assert len(frames) == SPRITE_COLS * SPRITE_ROWS
+
+    def test_each_frame_is_valid_png(self) -> None:
+        sheet = _make_sprite_sheet()
+        frames = extract_frames(sheet)
+        for frame in frames:
+            img = Image.open(io.BytesIO(frame))
+            assert img.format == "PNG"
+
+    def test_frame_dimensions_are_equal(self) -> None:
+        cell_size = 48
+        sheet = _make_sprite_sheet(cell_size=cell_size)
+        frames = extract_frames(sheet)
+        for frame in frames:
+            img = Image.open(io.BytesIO(frame))
+            assert img.width == cell_size
+            assert img.height == cell_size
+
+    def test_custom_grid_layout(self) -> None:
+        sheet = _make_sprite_sheet(cols=2, rows=3, cell_size=32)
+        frames = extract_frames(sheet, cols=2, rows=3)
+        assert len(frames) == 6
+
+    def test_returns_rgba_frames(self) -> None:
+        sheet = _make_sprite_sheet()
+        frames = extract_frames(sheet)
+        for frame in frames:
+            img = Image.open(io.BytesIO(frame)).convert("RGBA")
+            assert img.mode == "RGBA"
+
+
+class TestComposeAnimatedGif:
+    @pytest.fixture
+    def six_frames(self) -> list[bytes]:
+        """Create 6 distinct RGBA frames for testing."""
+        return [_make_frame(color=(i * 40 % 255, 100, 200, 255)) for i in range(6)]
+
+    def test_returns_bytes(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="content", health=100)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_result_is_valid_gif(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="content", health=100)
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "GIF"
+
+    def test_idle_mood_uses_multiple_frames(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="content", health=100)
+        img = Image.open(io.BytesIO(result))
+        # Animated GIF should have n_frames > 1
+        assert getattr(img, "n_frames", 1) > 1
+
+    def test_happy_mood_produces_gif(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="happy", health=80)
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "GIF"
+
+    def test_low_health_overrides_to_sick_animation(self, six_frames: list[bytes]) -> None:
+        # Both low health and explicitly sick mood should produce valid GIFs
+        result_low = compose_animated_gif(six_frames, mood="content", health=20)
+        result_sick = compose_animated_gif(six_frames, mood="sick", health=100)
+        assert Image.open(io.BytesIO(result_low)).format == "GIF"
+        assert Image.open(io.BytesIO(result_sick)).format == "GIF"
+
+    def test_sleeping_mood_produces_gif(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="lonely", health=100)
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "GIF"
+
+    def test_raises_on_empty_frames(self) -> None:
+        with pytest.raises(ValueError, match="No frames"):
+            compose_animated_gif([], mood="content", health=100)
+
+    def test_single_frame_fallback(self) -> None:
+        single = [_make_frame()]
+        result = compose_animated_gif(single, mood="happy", health=100)
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "GIF"
+
+    def test_dancing_mood_produces_gif(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="dancing", health=100)
+        assert Image.open(io.BytesIO(result)).format == "GIF"
+
+    def test_unknown_mood_falls_back_to_idle(self, six_frames: list[bytes]) -> None:
+        result = compose_animated_gif(six_frames, mood="unknown_mood_xyz", health=100)
+        assert Image.open(io.BytesIO(result)).format == "GIF"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -281,3 +281,174 @@ class TestStorageServiceConfiguration:
             secret_key="minioadmin123",
             secure=False,
         )
+
+
+class TestAnimatedGifStorage:
+    """Tests for animated GIF and sprite sheet storage methods."""
+
+    @pytest.fixture
+    def mock_minio_client(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def storage_service(self, mock_minio_client: MagicMock) -> StorageService:
+        service = StorageService(
+            endpoint="localhost:9000",
+            access_key="minioadmin",
+            secret_key="minioadmin",
+            bucket="test-bucket",
+            secure=False,
+        )
+        service._client = mock_minio_client
+        return service
+
+    def test_get_spritesheet_path(self, storage_service: StorageService) -> None:
+        """Sprite sheet path is under the pet's prefix."""
+        path = storage_service._get_spritesheet_path("owner", "repo", "adult")
+        assert path == "pets/owner/repo/adult_spritesheet.png"
+
+    def test_get_frame_path(self, storage_service: StorageService) -> None:
+        """Frame path includes the frame index."""
+        path = storage_service._get_frame_path("owner", "repo", "adult", 3)
+        assert path == "pets/owner/repo/adult_frame_3.png"
+
+    def test_get_animated_gif_path(self, storage_service: StorageService) -> None:
+        """Animated GIF path ends with _animated.gif."""
+        path = storage_service._get_animated_gif_path("owner", "repo", "baby")
+        assert path == "pets/owner/repo/baby_animated.gif"
+
+    async def test_upload_sprite_sheet(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """Upload sprite sheet stores PNG at expected path."""
+        mock_minio_client.bucket_exists.return_value = True
+        data = _make_png()
+
+        path = await storage_service.upload_sprite_sheet("owner", "repo", "adult", data)
+
+        assert path == "pets/owner/repo/adult_spritesheet.png"
+        mock_minio_client.put_object.assert_called_once()
+
+    async def test_get_sprite_sheet_found(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """get_sprite_sheet returns bytes when object exists."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"sheet_data"
+        mock_minio_client.get_object.return_value = mock_response
+
+        result = await storage_service.get_sprite_sheet("owner", "repo", "adult")
+
+        assert result == b"sheet_data"
+
+    async def test_get_sprite_sheet_not_found(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """get_sprite_sheet returns None when object does not exist."""
+        error = S3Error(
+            code="NoSuchKey",
+            message="Not found",
+            resource="test",
+            request_id="123",
+            host_id="host",
+            response="response",
+        )
+        mock_minio_client.get_object.side_effect = error
+
+        result = await storage_service.get_sprite_sheet("owner", "repo", "adult")
+
+        assert result is None
+
+    async def test_upload_frame(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """upload_frame stores PNG at frame-specific path."""
+        mock_minio_client.bucket_exists.return_value = True
+        data = _make_png()
+
+        path = await storage_service.upload_frame("owner", "repo", "adult", 2, data)
+
+        assert path == "pets/owner/repo/adult_frame_2.png"
+        mock_minio_client.put_object.assert_called_once()
+
+    async def test_get_frame_found(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """get_frame returns bytes when frame exists."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"frame_data"
+        mock_minio_client.get_object.return_value = mock_response
+
+        result = await storage_service.get_frame("owner", "repo", "adult", 1)
+
+        assert result == b"frame_data"
+
+    async def test_upload_animated_gif(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """upload_animated_gif stores GIF at expected path."""
+        mock_minio_client.bucket_exists.return_value = True
+        gif_data = b"GIF89a..."
+
+        path = await storage_service.upload_animated_gif("owner", "repo", "adult", gif_data)
+
+        assert path == "pets/owner/repo/adult_animated.gif"
+        mock_minio_client.put_object.assert_called_once()
+
+    async def test_get_animated_gif_found(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """get_animated_gif returns bytes when GIF exists."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"gif_data"
+        mock_minio_client.get_object.return_value = mock_response
+
+        result = await storage_service.get_animated_gif("owner", "repo", "adult")
+
+        assert result == b"gif_data"
+
+    async def test_get_animated_gif_not_found(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """get_animated_gif returns None when GIF does not exist."""
+        error = S3Error(
+            code="NoSuchKey",
+            message="Not found",
+            resource="test",
+            request_id="123",
+            host_id="host",
+            response="response",
+        )
+        mock_minio_client.get_object.side_effect = error
+
+        result = await storage_service.get_animated_gif("owner", "repo", "adult")
+
+        assert result is None
+
+    async def test_animated_gif_exists_true(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """animated_gif_exists returns True when GIF exists."""
+        mock_minio_client.stat_object.return_value = MagicMock()
+
+        result = await storage_service.animated_gif_exists("owner", "repo", "adult")
+
+        assert result is True
+
+    async def test_animated_gif_exists_false(
+        self, storage_service: StorageService, mock_minio_client: MagicMock
+    ) -> None:
+        """animated_gif_exists returns False when GIF does not exist."""
+        error = S3Error(
+            code="NoSuchKey",
+            message="Not found",
+            resource="test",
+            request_id="123",
+            host_id="host",
+            response="response",
+        )
+        mock_minio_client.stat_object.side_effect = error
+
+        result = await storage_service.animated_gif_exists("owner", "repo", "adult")
+
+        assert result is False


### PR DESCRIPTION
## Summary

- Generate animated GIFs for pets via a single OpenRouter image API call that produces a 3×2 sprite sheet (idle, blink, happy, sad, sick, sleeping frames)
- Slice frames server-side with Pillow and compose mood-driven animated GIFs
- New `GET /api/v1/pets/{owner}/{repo}/image/{stage}/animated` endpoint — generates on demand, caches in MinIO
- Pet profile page now loads the animated GIF with a static PNG fallback
- Canonical appearance description stored in DB so each pet's character stays consistent across regenerations and style changes

## Changes

- **`services/sprite_sheet.py`** — sprite sheet prompt builder, frame extractor (`extract_frames`), mood-driven GIF composer (`compose_animated_gif`)
- **`services/openrouter.py`** — `generate_sprite_sheet()` method; single API call, consistent frames by construction
- **`services/storage.py`** — `upload_sprite_sheet`, `upload_frame`, `upload_animated_gif`, `get_animated_gif`, `animated_gif_exists`
- **`models/pet.py`** + **migration 026** — `canonical_appearance` text column
- **`api/routes.py`** — animated GIF endpoint + `_update_canonical_appearance` helper
- **`templates/pet_profile.html`** — tries `/animated`, falls back to static PNG, then emoji
- **`EXPERIMENT_NOTES.md`** — prompt findings, grid resolution notes, open questions

## Testing

- [ ] All 908 tests pass
- [ ] Linter clean (`ruff check`)
- [ ] 25 new unit tests cover prompt building, frame extraction, GIF composition, all moods including edge cases
- [ ] No breaking changes to existing image endpoints

Closes #90