### PR TITLE
fix: remove magenta chroma-key background and border trim from sprite frames

### DIFF
--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -137,20 +137,46 @@ def build_sprite_sheet_prompt(
     return prompt, negative
 
 
+def _remove_chroma_key(img: Image.Image, tolerance: int = 60) -> Image.Image:
+    """Replace magenta (#FF00FF) chroma-key pixels with transparency.
+
+    Args:
+        img: RGBA PIL Image
+        tolerance: Per-channel distance tolerance for matching magenta (default 60)
+
+    Returns:
+        RGBA image with chroma-key pixels made transparent
+    """
+    pixels = list(img.getdata())
+    thresh = tolerance * tolerance * 3
+    result: list[tuple[int, int, int, int]] = [
+        (r, g, b, 0)
+        if (r - 255) ** 2 + g**2 + (b - 255) ** 2 < thresh
+        else (r, g, b, a)
+        for r, g, b, a in pixels
+    ]
+    out = img.copy()
+    out.putdata(result)
+    return out
+
+
 def extract_frames(
     sprite_sheet_bytes: bytes,
     cols: int = SPRITE_COLS,
     rows: int = SPRITE_ROWS,
+    border_trim: int = 2,
 ) -> list[bytes]:
     """Extract individual frames from a sprite sheet.
 
     Slices the sprite sheet grid into individual frame images using equal-width
-    columns and equal-height rows.
+    columns and equal-height rows. Removes magenta chroma-key background and
+    trims separator-line borders.
 
     Args:
         sprite_sheet_bytes: Raw sprite sheet image bytes (PNG)
         cols: Number of columns in the grid
         rows: Number of rows in the grid
+        border_trim: Pixels to trim from each edge to remove cell separator lines
 
     Returns:
         List of PNG frame bytes in reading order (left-to-right, top-to-bottom)
@@ -166,6 +192,17 @@ def extract_frames(
             x = col * frame_w
             y = row * frame_h
             frame = img.crop((x, y, x + frame_w, y + frame_h))
+            # Trim separator borders
+            if border_trim > 0:
+                fw, fh = frame.size
+                frame = frame.crop((
+                    border_trim,
+                    border_trim,
+                    fw - border_trim,
+                    fh - border_trim,
+                ))
+            # Remove chroma-key background
+            frame = _remove_chroma_key(frame)
             out = io.BytesIO()
             frame.save(out, format="PNG")
             frames.append(out.getvalue())

--- a/tests/test_sprite_sheet.py
+++ b/tests/test_sprite_sheet.py
@@ -8,6 +8,7 @@ from PIL import Image
 from github_tamagotchi.services.sprite_sheet import (
     SPRITE_COLS,
     SPRITE_ROWS,
+    _remove_chroma_key,
     build_sprite_sheet_prompt,
     compose_animated_gif,
     extract_frames,
@@ -117,10 +118,21 @@ class TestExtractFrames:
             img = Image.open(io.BytesIO(frame))
             assert img.format == "PNG"
 
-    def test_frame_dimensions_are_equal(self) -> None:
+    def test_frame_dimensions_account_for_border_trim(self) -> None:
+        cell_size = 48
+        border_trim = 2
+        sheet = _make_sprite_sheet(cell_size=cell_size)
+        frames = extract_frames(sheet, border_trim=border_trim)
+        expected = cell_size - border_trim * 2
+        for frame in frames:
+            img = Image.open(io.BytesIO(frame))
+            assert img.width == expected
+            assert img.height == expected
+
+    def test_no_border_trim_preserves_dimensions(self) -> None:
         cell_size = 48
         sheet = _make_sprite_sheet(cell_size=cell_size)
-        frames = extract_frames(sheet)
+        frames = extract_frames(sheet, border_trim=0)
         for frame in frames:
             img = Image.open(io.BytesIO(frame))
             assert img.width == cell_size
@@ -137,6 +149,46 @@ class TestExtractFrames:
         for frame in frames:
             img = Image.open(io.BytesIO(frame)).convert("RGBA")
             assert img.mode == "RGBA"
+
+    def test_chroma_key_pixels_become_transparent(self) -> None:
+        """Magenta (#FF00FF) pixels in the sprite sheet are made transparent."""
+        # Build a sheet that is pure magenta
+        cell_size = 32
+        cols, rows = 2, 2
+        width = cols * cell_size
+        height = rows * cell_size
+        img = Image.new("RGBA", (width, height), color=(255, 0, 255, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        sheet = buf.getvalue()
+
+        frames = extract_frames(sheet, cols=cols, rows=rows, border_trim=0)
+        for frame in frames:
+            frame_img = Image.open(io.BytesIO(frame)).convert("RGBA")
+            pixels = list(frame_img.getdata())
+            # All pixels should be fully transparent (alpha == 0)
+            assert all(a == 0 for _, _, _, a in pixels), "Magenta pixels should be transparent"
+
+
+class TestRemoveChromaKey:
+    def test_pure_magenta_becomes_transparent(self) -> None:
+        img = Image.new("RGBA", (4, 4), color=(255, 0, 255, 255))
+        result = _remove_chroma_key(img)
+        pixels = list(result.getdata())
+        assert all(a == 0 for _, _, _, a in pixels)
+
+    def test_non_magenta_pixels_preserved(self) -> None:
+        img = Image.new("RGBA", (4, 4), color=(100, 150, 200, 255))
+        result = _remove_chroma_key(img)
+        pixels = list(result.getdata())
+        assert all(a == 255 for _, _, _, a in pixels)
+
+    def test_tolerance_catches_near_magenta(self) -> None:
+        # Near-magenta (240, 20, 240) should be caught with default tolerance
+        img = Image.new("RGBA", (2, 2), color=(240, 20, 240, 255))
+        result = _remove_chroma_key(img, tolerance=60)
+        pixels = list(result.getdata())
+        assert all(a == 0 for _, _, _, a in pixels)
 
 
 class TestComposeAnimatedGif:


### PR DESCRIPTION
## Problem

Animated GIFs were showing hotpink with a visible border instead of the pet character.

**Root cause:** `build_sprite_sheet_prompt` asks the model for a `#FF00FF` (magenta) background as a chroma key so frames can be isolated — but `extract_frames` was just cropping and saving without removing it. The white cell separator lines from the grid also bled into each frame edge.

## Fix

- Add `_remove_chroma_key()` in `sprite_sheet.py` — pure Pillow, no numpy. Replaces magenta pixels (within tolerance=60) with alpha=0 per frame.
- Add `border_trim=2` default to `extract_frames` — crops 2px from each edge to remove cell separator lines.
- New tests covering chroma-key removal and border trim behaviour.

## Test

All existing + new tests pass locally.