### PR TITLE
Closes #160: Prerender animated GIFs for logged-in users; show static fallback while loading

### DIFF
--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -133,6 +133,13 @@
             window.location.href = '/';
         });
 
+        // Warm GIF cache for live pets in the background so profile visits are instant
+        window.addEventListener('load', function () {
+            {% for pet in pets %}{% if not pet.is_dead %}
+            fetch('/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ pet.stage }}/animated', { priority: 'low' }).catch(function(){});
+            {% endif %}{% endfor %}
+        });
+
         async function deletePet(owner, repo, cardId) {
             if (!confirm(`Delete pet for ${owner}/${repo}? This cannot be undone.`)) return;
             const resp = await fetch(`/api/v1/pets/${owner}/${repo}`, { method: 'DELETE' });

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -70,11 +70,12 @@
                     <div class="pet-emoji-fallback" style="display:flex; font-size: 4rem;">&#129680;</div>
                     {% else %}
                     <img
-                        src="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}/animated"
+                        src="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}"
+                        data-animated="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}/animated"
                         alt="{{ pet.name }}"
                         class="profile-sprite"
                         id="profile-pet"
-                        onerror="this.src='/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}'; this.onerror=function(){this.style.display='none'; document.getElementById('pet-emoji-fallback').style.display='flex';};"
+                        onerror="this.style.display='none'; document.getElementById('pet-emoji-fallback').style.display='flex'; this.onerror=null;"
                     >
                     <div id="pet-emoji-fallback" class="pet-emoji-fallback" style="display:none;">&#128049;</div>
                     <div class="pet-shadow"></div>
@@ -389,6 +390,13 @@
                 setTimeout(animatePet, 3000 + Math.random() * 2000);
             }
             animatePet();
+
+            // Lazy-swap to animated GIF once loaded; static image is already shown
+            if (pet.dataset.animated) {
+                const animImg = new Image();
+                animImg.onload = function () { pet.src = animImg.src; };
+                animImg.src = pet.dataset.animated;
+            }
         }
 
         // Copy link


### PR DESCRIPTION
## Summary

- **Pet profile**: static image shown immediately on load; animated GIF is fetched in the background and swapped in once ready (no more blank space while the GIF loads)
- **Dashboard**: on page load, background `fetch()` calls warm the GIF cache for all live pets so the next profile visit renders the animated version instantly

## Changes

- `pet_profile.html`: `src` set to static image, animated URL stored in `data-animated`; JS `Image()` preload swaps src once ready
- `dashboard.html`: `window.load` listener fires low-priority fetches to the animated endpoint for each live pet

## Testing

- All 902 tests pass
- Linter clean

Closes #160