### PR TITLE
chore: raise test coverage from 70% to 81%, enforce 75% threshold in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run unit tests
-        run: pytest tests/ --ignore=tests/e2e --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=70 --timeout=60
+        run: pytest tests/ --ignore=tests/e2e --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=75 --timeout=60
         timeout-minutes: 5
 
   e2e:

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ htmlcov/
 .uv/
 uv.lock
 coverage.xml
+coverage.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 show_missing = true
-fail_under = 70
+fail_under = 75
 
 [dependency-groups]
 dev = [

--- a/tests/api/test_admin_pages.py
+++ b/tests/api/test_admin_pages.py
@@ -1,11 +1,10 @@
-"""Tests for admin HTML pages (/admin, /admin/pets, /admin/jobs, /admin/achievements, /admin/webhooks)."""
+"""Tests for admin HTML pages."""
 
 import asyncio
 from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from github_tamagotchi.api.auth import _create_jwt

--- a/tests/api/test_admin_pages.py
+++ b/tests/api/test_admin_pages.py
@@ -1,0 +1,171 @@
+"""Tests for admin HTML pages (/admin, /admin/pets, /admin/jobs, /admin/achievements, /admin/webhooks)."""
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from github_tamagotchi.api.auth import _create_jwt
+from github_tamagotchi.models.pet import Pet, PetMood, PetStage
+from github_tamagotchi.models.user import User
+from tests.conftest import test_session_factory
+
+
+@contextmanager
+def _as_admin(login: str) -> Iterator[None]:
+    """Patch settings so the given login is treated as admin."""
+    with patch(
+        "github_tamagotchi.api.auth.settings.admin_github_logins",
+        new=[login],
+    ), patch(
+        "github_tamagotchi.main.settings.admin_github_logins",
+        new=[login],
+    ):
+        yield
+
+
+def _create_user(user_id: int, github_login: str) -> str:
+    async def _setup() -> str:
+        async with test_session_factory() as session:
+            user = User(
+                id=user_id,
+                github_id=user_id * 1000,
+                github_login=github_login,
+                github_avatar_url=None,
+            )
+            session.add(user)
+            await session.commit()
+        return _create_jwt(user_id=user_id)
+
+    return asyncio.run(_setup())
+
+
+def _create_pet(
+    repo_owner: str = "adminorg",
+    repo_name: str = "adminrepo",
+    name: str = "AdminPet",
+    user_id: int | None = None,
+) -> None:
+    async def _setup() -> None:
+        async with test_session_factory() as session:
+            pet = Pet(
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                name=name,
+                stage=PetStage.BABY.value,
+                mood=PetMood.HAPPY.value,
+                health=80,
+                user_id=user_id,
+            )
+            session.add(pet)
+            await session.commit()
+
+    asyncio.run(_setup())
+
+
+class TestAdminOverviewPage:
+    """Tests for /admin HTML page."""
+
+    def test_unauthenticated_gets_401(self, client: TestClient) -> None:
+        response = client.get("/admin", follow_redirects=False)
+        assert response.status_code in (401, 302)
+
+    def test_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=351, github_login="notadmin351")
+        response = client.get("/admin", cookies={"session_token": token})
+        assert response.status_code == 403
+
+    def test_admin_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=300, github_login="adminlogin300")
+        with _as_admin("adminlogin300"):
+            response = client.get("/admin", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_admin_shows_overview_content(self, client: TestClient) -> None:
+        token = _create_user(user_id=301, github_login="adminlogin301")
+        with _as_admin("adminlogin301"):
+            response = client.get("/admin", cookies={"session_token": token})
+        assert "Admin" in response.text
+        assert "Users" in response.text
+        assert "Pets" in response.text
+
+
+class TestAdminPetsPage:
+    """Tests for /admin/pets HTML page."""
+
+    def test_admin_pets_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=310, github_login="adminlogin310")
+        with _as_admin("adminlogin310"):
+            response = client.get("/admin/pets", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=352, github_login="notadmin352")
+        response = client.get("/admin/pets", cookies={"session_token": token})
+        assert response.status_code == 403
+
+    def test_shows_pet_in_list(self, client: TestClient) -> None:
+        token = _create_user(user_id=311, github_login="adminlogin311")
+        _create_pet(repo_owner="adminpetowner", repo_name="adminpetrepo", name="AdminListedPet")
+        with _as_admin("adminlogin311"):
+            response = client.get("/admin/pets", cookies={"session_token": token})
+        assert "AdminListedPet" in response.text
+
+
+class TestAdminJobsPage:
+    """Tests for /admin/jobs HTML page."""
+
+    def test_admin_jobs_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=320, github_login="adminlogin320")
+        with _as_admin("adminlogin320"):
+            response = client.get("/admin/jobs", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=353, github_login="notadmin353")
+        response = client.get("/admin/jobs", cookies={"session_token": token})
+        assert response.status_code == 403
+
+
+class TestAdminAchievementsPage:
+    """Tests for /admin/achievements HTML page."""
+
+    def test_admin_achievements_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=330, github_login="adminlogin330")
+        with _as_admin("adminlogin330"):
+            response = client.get("/admin/achievements", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=354, github_login="notadmin354")
+        response = client.get("/admin/achievements", cookies={"session_token": token})
+        assert response.status_code == 403
+
+    def test_shows_achievements_content(self, client: TestClient) -> None:
+        token = _create_user(user_id=331, github_login="adminlogin331")
+        with _as_admin("adminlogin331"):
+            response = client.get("/admin/achievements", cookies={"session_token": token})
+        assert "Achievement" in response.text
+
+
+class TestAdminWebhooksPage:
+    """Tests for /admin/webhooks HTML page."""
+
+    def test_admin_webhooks_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=340, github_login="adminlogin340")
+        with _as_admin("adminlogin340"):
+            response = client.get("/admin/webhooks", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=355, github_login="notadmin355")
+        response = client.get("/admin/webhooks", cookies={"session_token": token})
+        assert response.status_code == 403

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -95,3 +95,57 @@ class TestDashboardAuthenticated:
         _create_pet_for_user(user_id=16, repo_owner="linkowner", repo_name="linkrepo")
         response = client.get("/dashboard", cookies={"session_token": token})
         assert "/pet/linkowner/linkrepo" in response.text
+
+
+class TestRegisterPage:
+    def test_unauthenticated_redirects_to_auth(self, client: TestClient) -> None:
+        response = client.get("/register", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/auth/github" in response.headers["location"]
+
+    def test_authenticated_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=20, github_login="reguser")
+        response = client.get("/register", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_authenticated_shows_register_form(self, client: TestClient) -> None:
+        token = _create_user(user_id=21, github_login="reguser2")
+        response = client.get("/register", cookies={"session_token": token})
+        assert "Register" in response.text
+
+
+class TestRegisterCompletePage:
+    def test_unauthenticated_redirects_to_auth(self, client: TestClient) -> None:
+        response = client.get(
+            "/register/complete?owner=myorg&repo=myrepo&pet_name=Gotchi",
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert "/auth/github" in response.headers["location"]
+
+    def test_authenticated_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=22, github_login="completeuser")
+        response = client.get(
+            "/register/complete?owner=myorg&repo=myrepo&pet_name=Gotchi",
+            cookies={"session_token": token},
+        )
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_shows_pet_name_on_complete_page(self, client: TestClient) -> None:
+        token = _create_user(user_id=23, github_login="completeuser2")
+        response = client.get(
+            "/register/complete?owner=myorg&repo=myrepo&pet_name=Sparky",
+            cookies={"session_token": token},
+        )
+        assert "Sparky" in response.text
+
+    def test_shows_embed_code_on_complete_page(self, client: TestClient) -> None:
+        token = _create_user(user_id=24, github_login="completeuser3")
+        response = client.get(
+            "/register/complete?owner=myorg&repo=myrepo&pet_name=Sparky",
+            cookies={"session_token": token},
+        )
+        assert "myorg/myrepo" in response.text
+        assert "badge.svg" in response.text

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -346,9 +346,6 @@ class TestCheckDatabase:
 
     async def test_degraded_when_slow(self, test_db: AsyncSession) -> None:
         """Returns degraded status when latency exceeds 1000ms."""
-        import time
-
-        original_monotonic = time.monotonic
         call_count = 0
 
         def mock_monotonic() -> float:

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -7,10 +7,18 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi import __version__
 from github_tamagotchi.api.auth import get_admin_user
-from github_tamagotchi.api.health import CheckResult, health_router
+from github_tamagotchi.api.health import (
+    CheckResult,
+    _check_database,
+    _check_github_api,
+    _check_scheduler,
+    _format_uptime,
+    health_router,
+)
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.models.pet import Base
 from tests.conftest import get_test_session, test_engine
@@ -214,3 +222,358 @@ class TestDetailedEndpoint:
         assert "polls_last_hour" in stats
         assert "webhooks_last_hour" in stats
         assert "errors_last_hour" in stats
+
+    async def test_detailed_unhealthy_when_db_error(
+        self, admin_health_client: AsyncClient
+    ) -> None:
+        """Detailed endpoint returns unhealthy status when a check has error."""
+        db_error = CheckResult(status="error", error="Connection refused")
+        github_ok = CheckResult(status="ok", latency_ms=60.0, rate_limit_remaining=4700)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="20m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_database",
+                new_callable=AsyncMock,
+                return_value=db_error,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await admin_health_client.get("/api/v1/health/detailed")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "unhealthy"
+
+    async def test_detailed_degraded_when_check_degraded(
+        self, admin_health_client: AsyncClient
+    ) -> None:
+        """Detailed endpoint returns degraded status when a check is degraded."""
+        github_degraded = CheckResult(
+            status="degraded", latency_ms=60.0, rate_limit_remaining=50
+        )
+        scheduler_ok = CheckResult(status="ok", next_poll_in="20m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_degraded,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+        ):
+            response = await admin_health_client.get("/api/v1/health/detailed")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "degraded"
+
+    async def test_detailed_uptime_unknown_when_none(
+        self, admin_health_client: AsyncClient
+    ) -> None:
+        """Detailed endpoint shows 'unknown' uptime when get_uptime_seconds returns None."""
+        github_ok = CheckResult(status="ok", latency_ms=60.0, rate_limit_remaining=4700)
+        scheduler_ok = CheckResult(status="ok", next_poll_in="20m0s")
+
+        with (
+            patch(
+                "github_tamagotchi.api.health._check_github_api",
+                new_callable=AsyncMock,
+                return_value=github_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health._check_scheduler",
+                return_value=scheduler_ok,
+            ),
+            patch(
+                "github_tamagotchi.api.health.get_uptime_seconds",
+                return_value=None,
+            ),
+        ):
+            response = await admin_health_client.get("/api/v1/health/detailed")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uptime"] == "unknown"
+
+
+class TestFormatUptime:
+    """Tests for _format_uptime helper."""
+
+    def test_seconds_only(self) -> None:
+        assert _format_uptime(45) == "0m 45s"
+
+    def test_minutes_and_seconds(self) -> None:
+        assert _format_uptime(125) == "2m 5s"
+
+    def test_hours_minutes_seconds(self) -> None:
+        result = _format_uptime(3661)
+        assert result == "1h 1m 1s"
+
+    def test_days(self) -> None:
+        result = _format_uptime(86400 + 3600)
+        assert result == "1d 1h 0m"
+
+
+class TestCheckDatabase:
+    """Tests for _check_database internal function."""
+
+    async def test_ok_when_query_succeeds(self, test_db: AsyncSession) -> None:
+        """Returns ok status when SELECT 1 succeeds."""
+        result = await _check_database(test_db)
+        assert result.status == "ok"
+        assert result.latency_ms is not None
+        assert result.latency_ms >= 0
+
+    async def test_error_when_exception(self) -> None:
+        """Returns error status when session raises an exception."""
+        mock_session = AsyncMock()
+        mock_session.execute.side_effect = Exception("Connection refused")
+        result = await _check_database(mock_session)
+        assert result.status == "error"
+        assert result.error == "Connection refused"
+
+    async def test_degraded_when_slow(self, test_db: AsyncSession) -> None:
+        """Returns degraded status when latency exceeds 1000ms."""
+        import time
+
+        original_monotonic = time.monotonic
+        call_count = 0
+
+        def mock_monotonic() -> float:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 0.0
+            return 1.1  # 1100ms latency
+
+        with patch("github_tamagotchi.api.health.time.monotonic", side_effect=mock_monotonic):
+            result = await _check_database(test_db)
+
+        assert result.status == "degraded"
+        assert result.latency_ms == 1100.0
+
+
+class TestCheckGithubApi:
+    """Tests for _check_github_api internal function."""
+
+    async def test_ok_when_rate_limit_ample(self) -> None:
+        """Returns ok when GitHub returns 200 and rate limit is above threshold."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"rate": {"remaining": 4500}}
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await _check_github_api()
+
+        assert result.status == "ok"
+        assert result.rate_limit_remaining == 4500
+
+    async def test_degraded_when_rate_limit_low(self) -> None:
+        """Returns degraded when rate limit is below 100."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"rate": {"remaining": 50}}
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await _check_github_api()
+
+        assert result.status == "degraded"
+        assert result.rate_limit_remaining == 50
+
+    async def test_error_when_non_200(self) -> None:
+        """Returns error when GitHub returns non-200 status."""
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await _check_github_api()
+
+        assert result.status == "error"
+        assert "503" in (result.error or "")
+
+    async def test_error_on_network_exception(self) -> None:
+        """Returns error when network request raises an exception."""
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=Exception("Connection timeout"))
+            mock_client_cls.return_value = mock_client
+
+            result = await _check_github_api()
+
+        assert result.status == "error"
+        assert "Connection timeout" in (result.error or "")
+
+    async def test_uses_token_when_configured(self) -> None:
+        """Sends Authorization header when github_token is configured."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"rate": {"remaining": 4500}}
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "github_tamagotchi.api.health.settings"
+            ) as mock_settings,
+        ):
+            mock_settings.github_token = "mytoken"
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await _check_github_api()
+
+        assert result.status == "ok"
+        call_kwargs = mock_client.get.call_args
+        headers = call_kwargs[1].get("headers") or call_kwargs[0][1]
+        assert "Authorization" in headers
+        assert headers["Authorization"] == "Bearer mytoken"
+
+
+class TestCheckScheduler:
+    """Tests for _check_scheduler internal function."""
+
+    def test_ok_when_job_running_soon(self) -> None:
+        """Returns ok when job has a future next_run_time."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_job = MagicMock()
+        mock_job.next_run_time = datetime.now(UTC) + timedelta(minutes=10)
+
+        with patch("github_tamagotchi.api.health.scheduler") as mock_scheduler:
+            mock_scheduler.get_job.return_value = mock_job
+            result = _check_scheduler()
+
+        assert result.status == "ok"
+        assert result.next_poll_in is not None
+
+    def test_ok_when_next_run_has_minutes(self) -> None:
+        """Returns ok with Xm Ys format for next run times over a minute away."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_job = MagicMock()
+        mock_job.next_run_time = datetime.now(UTC) + timedelta(seconds=125)
+
+        with patch("github_tamagotchi.api.health.scheduler") as mock_scheduler:
+            mock_scheduler.get_job.return_value = mock_job
+            result = _check_scheduler()
+
+        assert result.status == "ok"
+        assert "m" in (result.next_poll_in or "")
+
+    def test_ok_when_next_run_seconds_only(self) -> None:
+        """Returns ok with Xs format for next run times less than a minute away."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_job = MagicMock()
+        mock_job.next_run_time = datetime.now(UTC) + timedelta(seconds=30)
+
+        with patch("github_tamagotchi.api.health.scheduler") as mock_scheduler:
+            mock_scheduler.get_job.return_value = mock_job
+            result = _check_scheduler()
+
+        assert result.status == "ok"
+        # Result is "Xs" where X is close to 30 (timing may vary by 1-2s)
+        assert result.next_poll_in is not None
+        assert result.next_poll_in.endswith("s")
+        assert "m" not in result.next_poll_in
+
+    def test_ok_running_when_slightly_overdue(self) -> None:
+        """Returns ok with 'running' when job is slightly overdue but within threshold."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_job = MagicMock()
+        mock_job.next_run_time = datetime.now(UTC) - timedelta(seconds=30)
+
+        with (
+            patch("github_tamagotchi.api.health.scheduler") as mock_scheduler,
+            patch("github_tamagotchi.api.health.settings") as mock_settings,
+        ):
+            mock_settings.github_poll_interval_minutes = 30
+            mock_scheduler.get_job.return_value = mock_job
+            result = _check_scheduler()
+
+        assert result.status == "ok"
+        assert result.next_poll_in == "running"
+
+    def test_degraded_when_overdue(self) -> None:
+        """Returns degraded when job is more than 2x interval overdue."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_job = MagicMock()
+        # More than 2 * 30 minutes = 60 minutes overdue
+        mock_job.next_run_time = datetime.now(UTC) - timedelta(hours=2)
+
+        with (
+            patch("github_tamagotchi.api.health.scheduler") as mock_scheduler,
+            patch("github_tamagotchi.api.health.settings") as mock_settings,
+        ):
+            mock_settings.github_poll_interval_minutes = 30
+            mock_scheduler.get_job.return_value = mock_job
+            result = _check_scheduler()
+
+        assert result.status == "degraded"
+        assert "overdue" in (result.next_poll_in or "")
+
+    def test_error_when_job_not_found(self) -> None:
+        """Returns error when poll_repositories job is not found."""
+        with patch("github_tamagotchi.api.health.scheduler") as mock_scheduler:
+            mock_scheduler.get_job.return_value = None
+            result = _check_scheduler()
+
+        assert result.status == "error"
+        assert result.error == "Job not found"
+
+    def test_error_when_no_next_run_time(self) -> None:
+        """Returns error when job has no next_run_time."""
+        mock_job = MagicMock()
+        mock_job.next_run_time = None
+
+        with patch("github_tamagotchi.api.health.scheduler") as mock_scheduler:
+            mock_scheduler.get_job.return_value = mock_job
+            result = _check_scheduler()
+
+        assert result.status == "error"
+        assert result.error == "Job has no next run time"
+
+    def test_error_on_exception(self) -> None:
+        """Returns error when scheduler raises an exception."""
+        with patch("github_tamagotchi.api.health.scheduler") as mock_scheduler:
+            mock_scheduler.get_job.side_effect = Exception("Scheduler crash")
+            result = _check_scheduler()
+
+        assert result.status == "error"
+        assert "Scheduler crash" in (result.error or "")

--- a/tests/api/test_leaderboard.py
+++ b/tests/api/test_leaderboard.py
@@ -1,9 +1,13 @@
-"""Tests for the leaderboard API endpoint."""
+"""Tests for the leaderboard API endpoint and HTML page."""
 
+import asyncio
+
+from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
 from github_tamagotchi.crud.pet import _leaderboard_cache
 from github_tamagotchi.models.pet import Pet
+from tests.conftest import test_session_factory
 
 
 class TestLeaderboardEndpoint:
@@ -166,3 +170,60 @@ class TestLeaderboardEndpoint:
         response = await async_client.get("/api/v1/leaderboard")
         data = response.json()
         assert "cached_at" in data
+
+
+def _create_pet_for_leaderboard(
+    repo_owner: str = "lbowner",
+    repo_name: str = "lbrepo",
+    name: str = "LBPet",
+    experience: int = 500,
+) -> None:
+    async def _setup() -> None:
+        async with test_session_factory() as session:
+            pet = Pet(
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                name=name,
+                experience=experience,
+            )
+            session.add(pet)
+            await session.commit()
+
+    asyncio.run(_setup())
+
+
+class TestLeaderboardHTMLPage:
+    """Tests for the /leaderboard HTML page."""
+
+    def test_returns_html(self, client: TestClient) -> None:
+        response = client.get("/leaderboard")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_contains_leaderboard_title(self, client: TestClient) -> None:
+        response = client.get("/leaderboard")
+        assert "Leaderboard" in response.text
+
+    def test_shows_most_experienced_section(self, client: TestClient) -> None:
+        response = client.get("/leaderboard")
+        assert "Most Experienced" in response.text
+
+    def test_shows_longest_streak_section(self, client: TestClient) -> None:
+        response = client.get("/leaderboard")
+        assert "Longest Streak" in response.text
+
+    def test_shows_pet_on_leaderboard(self, client: TestClient) -> None:
+        _leaderboard_cache.clear()
+        _create_pet_for_leaderboard(
+            repo_owner="lbpageowner", repo_name="lbpagerepo", name="PagePet", experience=999
+        )
+        response = client.get("/leaderboard")
+        assert "PagePet" in response.text
+
+    def test_cache_control_header(self, client: TestClient) -> None:
+        response = client.get("/leaderboard")
+        assert "Cache-Control" in response.headers
+
+    def test_shows_login_cta_when_unauthenticated(self, client: TestClient) -> None:
+        response = client.get("/leaderboard")
+        assert "Login" in response.text

--- a/tests/api/test_pet_profile.py
+++ b/tests/api/test_pet_profile.py
@@ -1,12 +1,30 @@
-"""Tests for the pet profile page."""
+"""Tests for the pet profile and pet admin HTML pages."""
 
 import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
+from github_tamagotchi.api.auth import _create_jwt
 from github_tamagotchi.models.pet import Pet, PetMood, PetStage
+from github_tamagotchi.models.user import User
 from tests.conftest import test_session_factory
+
+
+@contextmanager
+def _as_admin(login: str) -> Iterator[None]:
+    """Patch settings so the given login is treated as admin."""
+    with patch(
+        "github_tamagotchi.api.auth.settings.admin_github_logins",
+        new=[login],
+    ), patch(
+        "github_tamagotchi.main.settings.admin_github_logins",
+        new=[login],
+    ):
+        yield
 
 
 def _create_pet(
@@ -171,3 +189,105 @@ class TestPetProfilePage:
         response = client.get("/pet/testowner/testrepo", cookies={"session_token": token})
         assert response.status_code == 200
         assert "Get your own pet" not in response.text
+
+
+def _create_user_with_pet(
+    user_id: int,
+    github_login: str,
+    repo_owner: str,
+    repo_name: str,
+    encrypted_token: str | None = None,
+) -> str:
+    async def _setup() -> str:
+        async with test_session_factory() as session:
+            user = User(
+                id=user_id,
+                github_id=user_id * 1000,
+                github_login=github_login,
+                github_avatar_url=None,
+                encrypted_token=encrypted_token,
+            )
+            session.add(user)
+            pet = Pet(
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                name="AdminPet",
+                user_id=user_id,
+            )
+            session.add(pet)
+            await session.commit()
+        return _create_jwt(user_id=user_id)
+
+    return asyncio.run(_setup())
+
+
+class TestPetAdminHTMLPage:
+    """Tests for /pet/{owner}/{repo}/admin HTML page."""
+
+    def test_unauthenticated_redirects_to_auth(self, client: TestClient) -> None:
+        _create_pet(repo_owner="adminpageowner", repo_name="adminpagerepo", name="AdminPet")
+        response = client.get("/pet/adminpageowner/adminpagerepo/admin", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/auth/github" in response.headers["location"]
+
+    def test_not_found_returns_404(self, client: TestClient) -> None:
+        token = _create_user_with_pet(
+            user_id=200,
+            github_login="adminloginpet200",
+            repo_owner="adminloginpet200",
+            repo_name="somerepo200",
+        )
+        with _as_admin("adminloginpet200"):
+            response = client.get("/pet/nobody/nonexistent/admin", cookies={"session_token": token})
+        assert response.status_code == 404
+
+    def test_non_admin_user_without_token_gets_403(self, client: TestClient) -> None:
+        token = _create_user_with_pet(
+            user_id=201,
+            github_login="regularuser201",
+            repo_owner="adminpageowner201",
+            repo_name="adminpagerepo201",
+            encrypted_token=None,
+        )
+        response = client.get(
+            "/pet/adminpageowner201/adminpagerepo201/admin",
+            cookies={"session_token": token},
+        )
+        assert response.status_code == 403
+
+    def test_site_admin_can_access_any_pet_admin(self, client: TestClient) -> None:
+        token = _create_user_with_pet(
+            user_id=202,
+            github_login="siteadminlogin202",
+            repo_owner="siteadminlogin202",
+            repo_name="adminpagerepo202",
+        )
+        with _as_admin("siteadminlogin202"):
+            response = client.get(
+                "/pet/siteadminlogin202/adminpagerepo202/admin",
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_repo_admin_via_token_can_access(self, client: TestClient) -> None:
+        token = _create_user_with_pet(
+            user_id=203,
+            github_login="repoadmin203",
+            repo_owner="repoadmin203",
+            repo_name="repoadminrepo203",
+            encrypted_token="fake-encrypted-token",
+        )
+        with patch(
+            "github_tamagotchi.services.token_encryption.decrypt_token",
+            return_value="decrypted-token",
+        ), patch(
+            "github_tamagotchi.main.GitHubService.get_repo_permission",
+            new_callable=AsyncMock,
+            return_value="admin",
+        ):
+            response = client.get(
+                "/pet/repoadmin203/repoadminrepo203/admin",
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 200

--- a/tests/services/test_crud_contributor_relationship.py
+++ b/tests/services/test_crud_contributor_relationship.py
@@ -2,7 +2,6 @@
 
 from datetime import UTC, datetime
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.crud import contributor_relationship as cr_crud

--- a/tests/services/test_crud_contributor_relationship.py
+++ b/tests/services/test_crud_contributor_relationship.py
@@ -1,0 +1,252 @@
+"""Unit tests for ContributorRelationship CRUD operations."""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.crud import contributor_relationship as cr_crud
+from github_tamagotchi.crud import pet as pet_crud
+from github_tamagotchi.models.contributor_relationship import ContributorStanding
+
+
+async def _make_pet(db: AsyncSession, *, owner: str = "testuser", repo: str = "testrepo") -> object:
+    """Helper to create and persist a pet."""
+    pet = await pet_crud.create_pet(db, owner, repo, "TestPet")
+    return pet
+
+
+async def test_get_contributors_for_pet_empty(test_db: AsyncSession) -> None:
+    """Returns an empty list when no relationships exist for a pet."""
+    pet = await _make_pet(test_db)
+    result = await cr_crud.get_contributors_for_pet(test_db, pet.id)
+    assert result == []
+
+
+async def test_get_contributors_for_pet_ordered_by_score(test_db: AsyncSession) -> None:
+    """Results are ordered by score descending."""
+    pet = await _make_pet(test_db)
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=10, standing=ContributorStanding.GOOD,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "bob", score=50, standing=ContributorStanding.FAVORITE,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "carol", score=5, standing=ContributorStanding.NEUTRAL,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await test_db.commit()
+
+    result = await cr_crud.get_contributors_for_pet(test_db, pet.id)
+
+    assert len(result) == 3
+    assert result[0].github_username == "bob"
+    assert result[1].github_username == "alice"
+    assert result[2].github_username == "carol"
+
+
+async def test_upsert_contributor_relationship_insert(test_db: AsyncSession) -> None:
+    """Inserts a new relationship when none exists."""
+    pet = await _make_pet(test_db)
+    now = datetime.now(UTC)
+
+    rel = await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=20, standing=ContributorStanding.GOOD,
+        last_activity=now, good_deeds=["merged PR"], sins=[],
+    )
+    await test_db.commit()
+
+    assert rel.pet_id == pet.id
+    assert rel.github_username == "alice"
+    assert rel.score == 20
+    assert rel.standing == ContributorStanding.GOOD
+    assert rel.last_activity == now
+    assert rel.good_deeds == ["merged PR"]
+    assert rel.sins == []
+
+
+async def test_upsert_contributor_relationship_update(test_db: AsyncSession) -> None:
+    """Updates an existing relationship on second upsert."""
+    pet = await _make_pet(test_db)
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=10, standing=ContributorStanding.NEUTRAL,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await test_db.commit()
+
+    # Update the same contributor
+    now = datetime.now(UTC)
+    updated = await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=99, standing=ContributorStanding.FAVORITE,
+        last_activity=now, good_deeds=["big feature"], sins=["broke build"],
+    )
+    await test_db.commit()
+
+    assert updated.score == 99
+    assert updated.standing == ContributorStanding.FAVORITE
+    assert updated.last_activity == now
+    assert updated.good_deeds == ["big feature"]
+    assert updated.sins == ["broke build"]
+
+
+async def test_upsert_contributor_relationship_different_pets(test_db: AsyncSession) -> None:
+    """Same username on different pets creates two separate records."""
+    pet1 = await _make_pet(test_db, owner="user1", repo="repo1")
+    pet2 = await _make_pet(test_db, owner="user2", repo="repo2")
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet1.id, "alice", score=5, standing=ContributorStanding.NEUTRAL,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet2.id, "alice", score=99, standing=ContributorStanding.FAVORITE,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await test_db.commit()
+
+    rels1 = await cr_crud.get_contributors_for_pet(test_db, pet1.id)
+    rels2 = await cr_crud.get_contributors_for_pet(test_db, pet2.id)
+
+    assert len(rels1) == 1
+    assert rels1[0].score == 5
+    assert len(rels2) == 1
+    assert rels2[0].score == 99
+
+
+async def test_apply_score_delta_creates_new_relationship(test_db: AsyncSession) -> None:
+    """apply_score_delta creates a minimal record when no relationship exists."""
+    pet = await _make_pet(test_db)
+    now = datetime.now(UTC)
+
+    rel = await cr_crud.apply_score_delta(
+        test_db, pet.id, "newguy", delta=10,
+        event_description="opened a PR", now=now,
+    )
+    await test_db.commit()
+
+    assert rel is not None
+    assert rel.score == 10
+    assert rel.last_activity == now
+    assert rel.good_deeds == ["opened a PR"]
+    assert rel.sins == []
+
+
+async def test_apply_score_delta_updates_existing_positive(test_db: AsyncSession) -> None:
+    """Positive delta increments score and records a good deed."""
+    pet = await _make_pet(test_db)
+    now = datetime.now(UTC)
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=10, standing=ContributorStanding.NEUTRAL,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await test_db.commit()
+
+    rel = await cr_crud.apply_score_delta(
+        test_db, pet.id, "alice", delta=5, event_description="fixed a bug", now=now,
+    )
+    await test_db.commit()
+
+    assert rel is not None
+    assert rel.score == 15
+    assert "fixed a bug" in rel.good_deeds
+    assert rel.last_activity == now
+
+
+async def test_apply_score_delta_updates_existing_negative(test_db: AsyncSession) -> None:
+    """Negative delta decrements score and records a sin."""
+    pet = await _make_pet(test_db)
+    now = datetime.now(UTC)
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=20, standing=ContributorStanding.GOOD,
+        last_activity=None, good_deeds=[], sins=[],
+    )
+    await test_db.commit()
+
+    rel = await cr_crud.apply_score_delta(
+        test_db, pet.id, "alice", delta=-3, event_description="broke the build", now=now,
+    )
+    await test_db.commit()
+
+    assert rel is not None
+    assert rel.score == 17
+    assert "broke the build" in rel.sins
+    assert rel.good_deeds == []
+
+
+async def test_apply_score_delta_good_deeds_capped_at_five(test_db: AsyncSession) -> None:
+    """Good deeds list is capped at 5 entries, most recent first."""
+    pet = await _make_pet(test_db)
+    now = datetime.now(UTC)
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=0, standing=ContributorStanding.NEUTRAL,
+        last_activity=None,
+        good_deeds=["deed1", "deed2", "deed3", "deed4", "deed5"],
+        sins=[],
+    )
+    await test_db.commit()
+
+    rel = await cr_crud.apply_score_delta(
+        test_db, pet.id, "alice", delta=1, event_description="new deed", now=now,
+    )
+    await test_db.commit()
+
+    assert rel is not None
+    assert len(rel.good_deeds) == 5
+    assert rel.good_deeds[0] == "new deed"
+
+
+async def test_apply_score_delta_sins_capped_at_five(test_db: AsyncSession) -> None:
+    """Sins list is capped at 5 entries, most recent first."""
+    pet = await _make_pet(test_db)
+    now = datetime.now(UTC)
+
+    await cr_crud.upsert_contributor_relationship(
+        test_db, pet.id, "alice", score=0, standing=ContributorStanding.NEUTRAL,
+        last_activity=None, good_deeds=[],
+        sins=["sin1", "sin2", "sin3", "sin4", "sin5"],
+    )
+    await test_db.commit()
+
+    rel = await cr_crud.apply_score_delta(
+        test_db, pet.id, "alice", delta=-1, event_description="new sin", now=now,
+    )
+    await test_db.commit()
+
+    assert rel is not None
+    assert len(rel.sins) == 5
+    assert rel.sins[0] == "new sin"
+
+
+async def test_apply_score_delta_uses_current_time_when_now_is_none(
+    test_db: AsyncSession,
+) -> None:
+    """apply_score_delta uses current UTC time when `now` is not provided."""
+    pet = await _make_pet(test_db)
+    before = datetime.now(UTC)
+
+    rel = await cr_crud.apply_score_delta(
+        test_db, pet.id, "alice", delta=1, event_description="automated event",
+    )
+    await test_db.commit()
+
+    after = datetime.now(UTC)
+
+    assert rel is not None
+    # last_activity should be approximately now
+    assert rel.last_activity is not None
+    # Compare as naive or aware consistently
+    last_activity = rel.last_activity
+    if last_activity.tzinfo is None:
+        last_activity = last_activity.replace(tzinfo=UTC)
+    before_naive = before.replace(tzinfo=None) if before.tzinfo else before
+    after_naive = after.replace(tzinfo=None) if after.tzinfo else after
+    last_naive = last_activity.replace(tzinfo=None)
+    assert before_naive <= last_naive <= after_naive

--- a/tests/services/test_crud_user.py
+++ b/tests/services/test_crud_user.py
@@ -1,6 +1,5 @@
 """Unit tests for User CRUD operations."""
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.crud import user as user_crud

--- a/tests/services/test_crud_user.py
+++ b/tests/services/test_crud_user.py
@@ -1,0 +1,177 @@
+"""Unit tests for User CRUD operations."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.crud import user as user_crud
+
+
+async def test_get_user_by_github_id_not_found(test_db: AsyncSession) -> None:
+    """Returns None when no user exists with that GitHub ID."""
+    result = await user_crud.get_user_by_github_id(test_db, 99999)
+    assert result is None
+
+
+async def test_get_user_by_id_not_found(test_db: AsyncSession) -> None:
+    """Returns None when no user exists with that internal ID."""
+    result = await user_crud.get_user_by_id(test_db, 99999)
+    assert result is None
+
+
+async def test_create_or_update_user_creates_new(test_db: AsyncSession) -> None:
+    """Creates a new user record on first call."""
+    user = await user_crud.create_or_update_user(
+        test_db,
+        github_id=1001,
+        github_login="alice",
+        github_avatar_url="https://example.com/alice.png",
+        encrypted_token="tok_abc",
+    )
+
+    assert user.id is not None
+    assert user.github_id == 1001
+    assert user.github_login == "alice"
+    assert user.github_avatar_url == "https://example.com/alice.png"
+    assert user.encrypted_token == "tok_abc"
+
+
+async def test_create_or_update_user_updates_existing(test_db: AsyncSession) -> None:
+    """Updates login, avatar, and token on subsequent call for same github_id."""
+    await user_crud.create_or_update_user(
+        test_db,
+        github_id=2001,
+        github_login="bob",
+        github_avatar_url="https://example.com/bob.png",
+        encrypted_token="tok_original",
+    )
+
+    updated = await user_crud.create_or_update_user(
+        test_db,
+        github_id=2001,
+        github_login="bob-renamed",
+        github_avatar_url="https://example.com/bob2.png",
+        encrypted_token="tok_new",
+    )
+
+    assert updated.github_login == "bob-renamed"
+    assert updated.github_avatar_url == "https://example.com/bob2.png"
+    assert updated.encrypted_token == "tok_new"
+
+
+async def test_create_or_update_user_does_not_overwrite_token_when_none(
+    test_db: AsyncSession,
+) -> None:
+    """Passing encrypted_token=None on update leaves the existing token unchanged."""
+    await user_crud.create_or_update_user(
+        test_db,
+        github_id=3001,
+        github_login="carol",
+        github_avatar_url=None,
+        encrypted_token="tok_keep_me",
+    )
+
+    updated = await user_crud.create_or_update_user(
+        test_db,
+        github_id=3001,
+        github_login="carol",
+        github_avatar_url=None,
+        encrypted_token=None,  # should NOT overwrite
+    )
+
+    assert updated.encrypted_token == "tok_keep_me"
+
+
+async def test_get_user_by_github_id_returns_created_user(test_db: AsyncSession) -> None:
+    """get_user_by_github_id returns the user after creation."""
+    await user_crud.create_or_update_user(
+        test_db,
+        github_id=4001,
+        github_login="dave",
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+
+    user = await user_crud.get_user_by_github_id(test_db, 4001)
+
+    assert user is not None
+    assert user.github_login == "dave"
+
+
+async def test_get_user_by_id_returns_created_user(test_db: AsyncSession) -> None:
+    """get_user_by_id returns the user after creation."""
+    created = await user_crud.create_or_update_user(
+        test_db,
+        github_id=5001,
+        github_login="eve",
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+
+    user = await user_crud.get_user_by_id(test_db, created.id)
+
+    assert user is not None
+    assert user.github_id == 5001
+
+
+async def test_create_or_update_user_with_null_avatar(test_db: AsyncSession) -> None:
+    """Creates a user with no avatar URL (nullable field)."""
+    user = await user_crud.create_or_update_user(
+        test_db,
+        github_id=6001,
+        github_login="frank",
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+
+    assert user.github_avatar_url is None
+    assert user.encrypted_token is None
+
+
+async def test_create_or_update_user_updates_avatar_to_none(test_db: AsyncSession) -> None:
+    """Avatar URL can be cleared on update."""
+    await user_crud.create_or_update_user(
+        test_db,
+        github_id=7001,
+        github_login="grace",
+        github_avatar_url="https://example.com/grace.png",
+        encrypted_token=None,
+    )
+
+    updated = await user_crud.create_or_update_user(
+        test_db,
+        github_id=7001,
+        github_login="grace",
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+
+    assert updated.github_avatar_url is None
+
+
+async def test_create_or_update_user_different_users_isolated(test_db: AsyncSession) -> None:
+    """Two different GitHub IDs result in two independent user records."""
+    user_a = await user_crud.create_or_update_user(
+        test_db,
+        github_id=8001,
+        github_login="heidi",
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+    user_b = await user_crud.create_or_update_user(
+        test_db,
+        github_id=8002,
+        github_login="ivan",
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+
+    assert user_a.id != user_b.id
+    assert user_a.github_id != user_b.github_id
+
+    fetched_a = await user_crud.get_user_by_github_id(test_db, 8001)
+    fetched_b = await user_crud.get_user_by_github_id(test_db, 8002)
+
+    assert fetched_a is not None
+    assert fetched_b is not None
+    assert fetched_a.github_login == "heidi"
+    assert fetched_b.github_login == "ivan"

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -990,7 +990,7 @@ class TestGetContributorStats:
 
         recent_date = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         user_commits = [
-            {"sha": f"sha{i}", "author": {"login": "alice"}, "commit": {"committer": {"date": recent_date}}}
+            {"sha": f"sha{i}", "author": {"login": "alice"}, "commit": {"committer": {"date": recent_date}}}  # noqa: E501
             for i in range(5)
         ]
         all_commits = (
@@ -1248,10 +1248,11 @@ class TestGetAllContributorActivity:
     @pytest.mark.asyncio
     async def test_returns_commits_by_user(self) -> None:
         """Should aggregate commit counts per user."""
+        d1, d2, d3 = "2025-03-01T10:00:00Z", "2025-03-02T10:00:00Z", "2025-03-03T10:00:00Z"
         commits = [
-            {"sha": "s1", "author": {"login": "alice"}, "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}}},
-            {"sha": "s2", "author": {"login": "alice"}, "commit": {"committer": {"date": "2025-03-02T10:00:00Z"}}},
-            {"sha": "s3", "author": {"login": "bob"}, "commit": {"committer": {"date": "2025-03-03T10:00:00Z"}}},
+            {"sha": "s1", "author": {"login": "alice"}, "commit": {"committer": {"date": d1}}},
+            {"sha": "s2", "author": {"login": "alice"}, "commit": {"committer": {"date": d2}}},
+            {"sha": "s3", "author": {"login": "bob"}, "commit": {"committer": {"date": d3}}},
         ]
         respx.get("https://api.github.com/repos/owner/repo/commits").mock(
             return_value=httpx.Response(200, json=commits)
@@ -1296,7 +1297,7 @@ class TestGetAllContributorActivity:
     async def test_skips_commits_without_author_login(self) -> None:
         """Should skip commits missing author or login."""
         commits = [
-            {"sha": "s1", "author": None, "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}}},
+            {"sha": "s1", "author": None, "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}}},  # noqa: E501
             {"sha": "s2", "commit": {"committer": {"date": "2025-03-02T10:00:00Z"}}},
         ]
         respx.get("https://api.github.com/repos/owner/repo/commits").mock(
@@ -1334,8 +1335,9 @@ class TestGetWeeklyCommits30d:
         from datetime import timedelta
 
         now = datetime.now(UTC)
+        fmt = "%Y-%m-%dT%H:%M:%SZ"
         commits = [
-            {"sha": f"sha{i}", "commit": {"committer": {"date": (now - timedelta(days=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}}}
+            {"sha": f"sha{i}", "commit": {"committer": {"date": (now - timedelta(days=i)).strftime(fmt)}}}  # noqa: E501
             for i in range(1, 8)
         ]
         respx.get("https://api.github.com/repos/owner/repo/commits").mock(
@@ -1884,7 +1886,9 @@ class TestGetBlameBoardData:
         )
 
         service = GitHubService(token="test")
-        result = await service.get_blame_board_data("owner", "repo", pet_health=80, pet_mood="happy")
+        result = await service.get_blame_board_data(
+            "owner", "repo", pet_health=80, pet_mood="happy"
+        )
 
         assert isinstance(result, BlameBoardData)
         assert result.is_healthy is True
@@ -1909,7 +1913,7 @@ class TestGetBlameBoardData:
             }
         ]
         repo_data = {"id": 1, "name": "repo", "default_branch": "main"}
-        commits = [{"sha": "sha1", "author": {"login": "alice"}, "commit": {"committer": {"date": old_pr_date}}}]
+        commits = [{"sha": "sha1", "author": {"login": "alice"}, "commit": {"committer": {"date": old_pr_date}}}]  # noqa: E501
 
         respx.get("https://api.github.com/repos/owner/repo/commits").mock(
             return_value=httpx.Response(200, json=commits)

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -771,3 +771,1162 @@ class TestGetDependentCount:
             result = await service._get_dependent_count(client, "owner", "repo")
 
         assert result == 0
+
+
+class TestGetStarForkCounts:
+    """Tests for _get_star_fork_counts method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_star_and_fork_counts(self) -> None:
+        """Should return star and fork counts from repo data."""
+        repo_data = {
+            "id": 12345,
+            "name": "test-repo",
+            "stargazers_count": 150,
+            "forks_count": 42,
+        }
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=repo_data)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            stars, forks = await service._get_star_fork_counts(client, "owner", "repo")
+
+        assert stars == 150
+        assert forks == 42
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zeros_on_error(self) -> None:
+        """Should return (0, 0) when API call fails."""
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            stars, forks = await service._get_star_fork_counts(client, "owner", "repo")
+
+        assert stars == 0
+        assert forks == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_defaults_to_zero_when_keys_missing(self) -> None:
+        """Should default to 0 when stargazers_count or forks_count keys are absent."""
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json={"id": 1, "name": "repo"})
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            stars, forks = await service._get_star_fork_counts(client, "owner", "repo")
+
+        assert stars == 0
+        assert forks == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError when rate limit is hit."""
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(RateLimitError):
+                await service._get_star_fork_counts(client, "owner", "repo")
+
+
+class TestGetRepoHealthStarFork:
+    """Tests that get_repo_health correctly includes star and fork counts."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_includes_star_and_fork_counts(
+        self,
+        mock_commit_response: list[dict[str, Any]],
+        mock_prs_response: list[dict[str, Any]],
+        mock_issues_response: list[dict[str, Any]],
+        mock_status_response_success: dict[str, Any],
+        mock_security_alerts_empty: list[dict[str, Any]],
+    ) -> None:
+        """RepoHealth should contain star and fork counts."""
+        repo_data = {
+            "id": 12345,
+            "name": "test-repo",
+            "full_name": "owner/test-repo",
+            "default_branch": "main",
+            "stargazers_count": 99,
+            "forks_count": 7,
+        }
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=mock_commit_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=mock_prs_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=mock_issues_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=repo_data)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/main/status").mock(
+            return_value=httpx.Response(200, json=mock_status_response_success)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/releases").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get("https://api.github.com/repos/owner/repo/dependabot/alerts").mock(
+            return_value=httpx.Response(200, json=mock_security_alerts_empty)
+        )
+        respx.get("https://github.com/owner/repo/network/dependents").mock(
+            return_value=httpx.Response(200, text="<html><body>10 Repositories</body></html>")
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_repo_health("owner", "repo")
+
+        assert result.star_count == 99
+        assert result.fork_count == 7
+        assert result.dependent_count == 10
+
+
+class TestGetContributorStats:
+    """Tests for get_contributor_stats method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_stats_for_active_contributor(self) -> None:
+        """Should return correct stats when user has recent commits."""
+        from datetime import timedelta
+
+        now = datetime.now(UTC)
+        recent_date = (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        user_commits = [
+            {
+                "sha": "abc123",
+                "author": {"login": "alice"},
+                "commit": {"committer": {"date": recent_date}},
+            }
+        ]
+        all_commits = [
+            {"sha": "abc123", "author": {"login": "alice"}},
+            {"sha": "def456", "author": {"login": "bob"}},
+        ]
+        # Both calls go to same URL with different params — respx matches by URL only
+        # so we use a side_effect approach with a counter
+        call_count = 0
+
+        def commit_side_effect(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if "author=alice" in str(request.url):
+                return httpx.Response(200, json=user_commits)
+            return httpx.Response(200, json=all_commits)
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            side_effect=commit_side_effect
+        )
+        # CI check for the latest commit sha
+        respx.get("https://api.github.com/repos/owner/repo/commits/abc123/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": []})
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_contributor_stats("owner", "repo", "alice")
+
+        assert result.commits_30d == 1
+        assert result.last_commit_at is not None
+        assert result.days_since_last_commit is not None
+        assert result.days_since_last_commit >= 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_zero_commits_for_inactive_contributor(self) -> None:
+        """Should look up historical commit when no recent commits found."""
+        from datetime import timedelta
+
+        old_date = (datetime.now(UTC) - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        old_commits = [
+            {
+                "sha": "old123",
+                "author": {"login": "alice"},
+                "commit": {"committer": {"date": old_date}},
+            }
+        ]
+        call_count = 0
+
+        def commit_side_effect(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            url = str(request.url)
+            # _fetch_commits_parallel makes two calls: one with author=alice (user commits)
+            # and one without (all commits). Then _get_user_last_commit makes a third call
+            # with author=alice&per_page=1 (no since param).
+            if "author=alice" in url and "per_page=1" in url and "since" not in url:
+                return httpx.Response(200, json=old_commits)  # historical lookup
+            if "author=alice" in url:
+                return httpx.Response(200, json=[])  # no recent user commits
+            return httpx.Response(200, json=[])  # no all-repo commits either
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            side_effect=commit_side_effect
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_contributor_stats("owner", "repo", "alice")
+
+        assert result.commits_30d == 0
+        assert result.last_commit_at is not None  # found via historical lookup
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_is_top_contributor_when_has_most_commits(self) -> None:
+        """Should mark contributor as top when they have the most commits."""
+        from datetime import timedelta
+
+        recent_date = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        user_commits = [
+            {"sha": f"sha{i}", "author": {"login": "alice"}, "commit": {"committer": {"date": recent_date}}}
+            for i in range(5)
+        ]
+        all_commits = (
+            [{"sha": f"sha{i}", "author": {"login": "alice"}} for i in range(5)]
+            + [{"sha": f"othsha{i}", "author": {"login": "bob"}} for i in range(2)]
+        )
+
+        def commit_side_effect(request: httpx.Request) -> httpx.Response:
+            if "author=alice" in str(request.url):
+                return httpx.Response(200, json=user_commits)
+            return httpx.Response(200, json=all_commits)
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            side_effect=commit_side_effect
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha0/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": []})
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_contributor_stats("owner", "repo", "alice")
+
+        assert result.is_top_contributor is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_has_failed_ci_when_commit_check_fails(self) -> None:
+        """Should detect failed CI on the contributor's latest commit."""
+        from datetime import timedelta
+
+        recent_date = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        user_commits = [
+            {
+                "sha": "failsha",
+                "author": {"login": "alice"},
+                "commit": {"committer": {"date": recent_date}},
+            }
+        ]
+
+        def commit_side_effect(request: httpx.Request) -> httpx.Response:
+            if "author=alice" in str(request.url):
+                return httpx.Response(200, json=user_commits)
+            return httpx.Response(200, json=user_commits)
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            side_effect=commit_side_effect
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/failsha/check-runs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "check_runs": [
+                        {"conclusion": "failure", "status": "completed", "name": "test"}
+                    ]
+                },
+            )
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_contributor_stats("owner", "repo", "alice")
+
+        assert result.has_failed_ci is True
+
+
+class TestFetchCommitsParallel:
+    """Tests for _fetch_commits_parallel helper."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_both_user_and_all_commits(self) -> None:
+        """Should return user commits and all commits as a tuple."""
+        user_commits = [{"sha": "u1", "author": {"login": "alice"}}]
+        all_commits = [
+            {"sha": "u1", "author": {"login": "alice"}},
+            {"sha": "a2", "author": {"login": "bob"}},
+        ]
+
+        def side_effect(request: httpx.Request) -> httpx.Response:
+            if "author=alice" in str(request.url):
+                return httpx.Response(200, json=user_commits)
+            return httpx.Response(200, json=all_commits)
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            side_effect=side_effect
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            u, a = await service._fetch_commits_parallel(
+                client, "owner", "repo", "alice", "2024-01-01T00:00:00"
+            )
+
+        assert len(u) == 1
+        assert len(a) == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_empty_lists_on_error(self) -> None:
+        """Should return empty lists when API call fails."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            u, a = await service._fetch_commits_parallel(
+                client, "owner", "repo", "alice", "2024-01-01T00:00:00"
+            )
+
+        assert u == []
+        assert a == []
+
+
+class TestGetUserLastCommit:
+    """Tests for _get_user_last_commit helper."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_datetime_when_found(self) -> None:
+        """Should return datetime of user's last commit."""
+        commits = [
+            {
+                "sha": "abc",
+                "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}},
+            }
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_user_last_commit(client, "owner", "repo", "alice")
+
+        assert result is not None
+        assert result.year == 2025
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_commits(self) -> None:
+        """Should return None when user has no commits."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_user_last_commit(client, "owner", "repo", "alice")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self) -> None:
+        """Should return None on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_user_last_commit(client, "owner", "repo", "alice")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(RateLimitError):
+                await service._get_user_last_commit(client, "owner", "repo", "alice")
+
+
+class TestHasFailedCi:
+    """Tests for _has_failed_ci method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_runs(self) -> None:
+        """Should return False when there are no check runs."""
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha123/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": []})
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._has_failed_ci(client, "owner", "repo", "sha123")
+
+        assert result is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_true_when_failure(self) -> None:
+        """Should return True when at least one run failed."""
+        runs = [
+            {"conclusion": "failure", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha123/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": runs})
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._has_failed_ci(client, "owner", "repo", "sha123")
+
+        assert result is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_true_when_timed_out(self) -> None:
+        """Should return True when a run timed out."""
+        runs = [{"conclusion": "timed_out", "status": "completed"}]
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha123/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": runs})
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._has_failed_ci(client, "owner", "repo", "sha123")
+
+        assert result is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_false_on_error(self) -> None:
+        """Should return False on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha123/check-runs").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._has_failed_ci(client, "owner", "repo", "sha123")
+
+        assert result is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError."""
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha123/check-runs").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(RateLimitError):
+                await service._has_failed_ci(client, "owner", "repo", "sha123")
+
+
+class TestGetAllContributorActivity:
+    """Tests for get_all_contributor_activity method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_commits_by_user(self) -> None:
+        """Should aggregate commit counts per user."""
+        commits = [
+            {"sha": "s1", "author": {"login": "alice"}, "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}}},
+            {"sha": "s2", "author": {"login": "alice"}, "commit": {"committer": {"date": "2025-03-02T10:00:00Z"}}},
+            {"sha": "s3", "author": {"login": "bob"}, "commit": {"committer": {"date": "2025-03-03T10:00:00Z"}}},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        service = GitHubService(token="test")
+        result = await service.get_all_contributor_activity("owner", "repo")
+
+        assert result.commits_by_user["alice"] == 2
+        assert result.commits_by_user["bob"] == 1
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_merged_prs_by_user(self) -> None:
+        """Should count recently merged PRs per user."""
+        from datetime import timedelta
+
+        recent_merge = (datetime.now(UTC) - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        old_merge = (datetime.now(UTC) - timedelta(days=40)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        prs = [
+            {"merged_at": recent_merge, "merged_by": {"login": "alice"}},
+            {"merged_at": recent_merge, "merged_by": {"login": "alice"}},
+            {"merged_at": old_merge, "merged_by": {"login": "alice"}},  # too old
+            {"merged_at": None, "merged_by": {"login": "bob"}},  # not merged
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs)
+        )
+        service = GitHubService(token="test")
+        result = await service.get_all_contributor_activity("owner", "repo")
+
+        assert result.merged_prs_by_user.get("alice") == 2
+        assert "bob" not in result.merged_prs_by_user
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skips_commits_without_author_login(self) -> None:
+        """Should skip commits missing author or login."""
+        commits = [
+            {"sha": "s1", "author": None, "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}}},
+            {"sha": "s2", "commit": {"committer": {"date": "2025-03-02T10:00:00Z"}}},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        service = GitHubService(token="test")
+        result = await service.get_all_contributor_activity("owner", "repo")
+
+        assert result.commits_by_user == {}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_on_commits(self) -> None:
+        """Should propagate RateLimitError from commits API."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        with pytest.raises(RateLimitError):
+            await service.get_all_contributor_activity("owner", "repo")
+
+
+class TestGetWeeklyCommits30d:
+    """Tests for _get_weekly_commits_30d method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_four_weekly_buckets(self) -> None:
+        """Should return exactly 4 weekly buckets."""
+        from datetime import timedelta
+
+        now = datetime.now(UTC)
+        commits = [
+            {"sha": f"sha{i}", "commit": {"committer": {"date": (now - timedelta(days=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}}}
+            for i in range(1, 8)
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            buckets, total = await service._get_weekly_commits_30d(client, "owner", "repo")
+
+        assert len(buckets) == 4
+        assert total == 7
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_empty_buckets_on_error(self) -> None:
+        """Should return 4 zero-count buckets on error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            buckets, total = await service._get_weekly_commits_30d(client, "owner", "repo")
+
+        assert len(buckets) == 4
+        assert all(b.count == 0 for b in buckets)
+        assert total == 0
+
+
+class TestGetAvgPrMergeHours:
+    """Tests for _get_avg_pr_merge_hours method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_avg_merge_hours(self) -> None:
+        """Should compute average merge time in hours."""
+        prs = [
+            {
+                "created_at": "2025-01-01T00:00:00Z",
+                "merged_at": "2025-01-01T02:00:00Z",  # 2 hours
+            },
+            {
+                "created_at": "2025-01-02T00:00:00Z",
+                "merged_at": "2025-01-02T06:00:00Z",  # 6 hours
+            },
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_pr_merge_hours(client, "owner", "repo")
+
+        assert result == pytest.approx(4.0)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_merged_prs(self) -> None:
+        """Should return None when no PRs have merged_at."""
+        prs = [{"created_at": "2025-01-01T00:00:00Z", "merged_at": None}]
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_pr_merge_hours(client, "owner", "repo")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        """Should return None on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_pr_merge_hours(client, "owner", "repo")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError."""
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(RateLimitError):
+                await service._get_avg_pr_merge_hours(client, "owner", "repo")
+
+
+class TestGetAvgIssueResponseHours:
+    """Tests for _get_avg_issue_response_hours method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_avg_response_time(self) -> None:
+        """Should compute average response time from issue creation to first comment."""
+        issues = [
+            {
+                "number": 1,
+                "created_at": "2025-01-01T00:00:00Z",
+                "comments": 1,
+                "state": "open",
+            }
+        ]
+        comments = [{"created_at": "2025-01-01T04:00:00Z", "body": "reply"}]
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=issues)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/issues/1/comments").mock(
+            return_value=httpx.Response(200, json=comments)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_issue_response_hours(client, "owner", "repo")
+
+        assert result == pytest.approx(4.0)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_issues_with_comments(self) -> None:
+        """Should return None when no issues have any comments."""
+        issues = [{"number": 1, "created_at": "2025-01-01T00:00:00Z", "comments": 0}]
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=issues)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_issue_response_hours(client, "owner", "repo")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        """Should return None on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_issue_response_hours(client, "owner", "repo")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_filters_out_pull_requests_from_issues(self) -> None:
+        """Should filter out PRs before computing response time."""
+        issues = [
+            {
+                "number": 1,
+                "created_at": "2025-01-01T00:00:00Z",
+                "comments": 1,
+                "pull_request": {"url": "https://..."},
+            }
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=issues)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            result = await service._get_avg_issue_response_hours(client, "owner", "repo")
+
+        assert result is None
+
+
+class TestGetCiPassRate:
+    """Tests for _get_ci_pass_rate method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_pass_rate(self, mock_repo_response: dict[str, Any]) -> None:
+        """Should compute pass rate from recent check runs."""
+        commits = [{"sha": "s1"}, {"sha": "s2"}]
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=mock_repo_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/s1/check-runs").mock(
+            return_value=httpx.Response(
+                200, json={"check_runs": [{"conclusion": "success", "status": "completed"}]}
+            )
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/s2/check-runs").mock(
+            return_value=httpx.Response(
+                200, json={"check_runs": [{"conclusion": "failure", "status": "completed"}]}
+            )
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            rate, count = await service._get_ci_pass_rate(client, "owner", "repo")
+
+        assert rate == pytest.approx(0.5)
+        assert count == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_commits(self, mock_repo_response: dict[str, Any]) -> None:
+        """Should return (None, 0) when no commits."""
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=mock_repo_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            rate, count = await service._get_ci_pass_rate(client, "owner", "repo")
+
+        assert rate is None
+        assert count == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_repo_error(self) -> None:
+        """Should return (None, 0) when repo lookup fails."""
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        async with httpx.AsyncClient() as client:
+            rate, count = await service._get_ci_pass_rate(client, "owner", "repo")
+
+        assert rate is None
+        assert count == 0
+
+
+class TestGetRepoInsights:
+    """Tests for get_repo_insights method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_repo_insights_object(
+        self, mock_repo_response: dict[str, Any]
+    ) -> None:
+        """Should return a complete RepoInsights object."""
+        from github_tamagotchi.services.github import RepoInsights
+
+        commits = [
+            {"sha": "sha1", "commit": {"committer": {"date": "2025-03-01T10:00:00Z"}}}
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=mock_repo_response)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha1/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": []})
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_repo_insights("owner", "repo")
+
+        assert isinstance(result, RepoInsights)
+        assert len(result.weekly_commits) == 4
+        assert result.open_prs_count == 0
+
+
+class TestListUserRepos:
+    """Tests for list_user_repos method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_list_of_repos(self) -> None:
+        """Should return list of repository data."""
+        repos = [{"id": 1, "name": "repo1"}, {"id": 2, "name": "repo2"}]
+        respx.get("https://api.github.com/user/repos").mock(
+            return_value=httpx.Response(200, json=repos)
+        )
+        service = GitHubService(token="test")
+        result = await service.list_user_repos()
+
+        assert len(result) == 2
+        assert result[0]["name"] == "repo1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_error(self) -> None:
+        """Should return empty list on API error."""
+        respx.get("https://api.github.com/user/repos").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        result = await service.list_user_repos()
+
+        assert result == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError."""
+        respx.get("https://api.github.com/user/repos").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        with pytest.raises(RateLimitError):
+            await service.list_user_repos()
+
+
+class TestGetTopContributor:
+    """Tests for get_top_contributor method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_top_committer(self) -> None:
+        """Should return login of user with most commits."""
+        commits = [
+            {"sha": "s1", "author": {"login": "alice"}},
+            {"sha": "s2", "author": {"login": "alice"}},
+            {"sha": "s3", "author": {"login": "bob"}},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        result = await service.get_top_contributor("owner", "repo")
+
+        assert result == "alice"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_commits(self) -> None:
+        """Should return None when no commits found."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        service = GitHubService(token="test")
+        result = await service.get_top_contributor("owner", "repo")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self) -> None:
+        """Should return None on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        result = await service.get_top_contributor("owner", "repo")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError."""
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        with pytest.raises(RateLimitError):
+            await service.get_top_contributor("owner", "repo")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skips_commits_without_author(self) -> None:
+        """Should skip commits with no author login."""
+        commits = [
+            {"sha": "s1", "author": None},
+            {"sha": "s2", "author": {"login": "bob"}},
+        ]
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        service = GitHubService(token="test")
+        result = await service.get_top_contributor("owner", "repo")
+
+        assert result == "bob"
+
+
+class TestGetRepoPermission:
+    """Tests for get_repo_permission method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_permission_level(self) -> None:
+        """Should return the permission string."""
+        respx.get("https://api.github.com/repos/owner/repo/collaborators/alice/permission").mock(
+            return_value=httpx.Response(200, json={"permission": "write"})
+        )
+        service = GitHubService(token="test")
+        result = await service.get_repo_permission("owner", "repo", "alice")
+
+        assert result == "write"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_404_returns_none(self) -> None:
+        """Should return 'none' when user is not a collaborator."""
+        respx.get("https://api.github.com/repos/owner/repo/collaborators/unknown/permission").mock(
+            return_value=httpx.Response(404)
+        )
+        service = GitHubService(token="test")
+        result = await service.get_repo_permission("owner", "repo", "unknown")
+
+        assert result == "none"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self) -> None:
+        """Should return None on API error."""
+        respx.get("https://api.github.com/repos/owner/repo/collaborators/alice/permission").mock(
+            return_value=httpx.Response(500)
+        )
+        service = GitHubService(token="test")
+        result = await service.get_repo_permission("owner", "repo", "alice")
+
+        assert result is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error(self) -> None:
+        """Should propagate RateLimitError."""
+        respx.get("https://api.github.com/repos/owner/repo/collaborators/alice/permission").mock(
+            return_value=httpx.Response(
+                403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"}
+            )
+        )
+        service = GitHubService(token="test")
+        with pytest.raises(RateLimitError):
+            await service.get_repo_permission("owner", "repo", "alice")
+
+
+class TestFormatDurationAndWhen:
+    """Tests for _format_duration and _format_when helpers."""
+
+    def test_format_duration_just_now(self) -> None:
+        """Should return 'just now' for very recent datetimes."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(minutes=30)
+        assert service._format_duration(dt) == "just now"
+
+    def test_format_duration_hours(self) -> None:
+        """Should return hours string for same-day events."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(hours=5)
+        assert "hours" in service._format_duration(dt)
+
+    def test_format_duration_one_day(self) -> None:
+        """Should return '1 day' for ~24 hours ago."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(hours=25)
+        assert service._format_duration(dt) == "1 day"
+
+    def test_format_duration_multiple_days(self) -> None:
+        """Should return 'N days' for multi-day events."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(days=5)
+        result = service._format_duration(dt)
+        assert "days" in result
+
+    def test_format_when_today(self) -> None:
+        """Should return 'Today' for events within the last 24 hours."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(hours=1)
+        assert service._format_when(dt) == "Today"
+
+    def test_format_when_yesterday(self) -> None:
+        """Should return 'Yesterday' for events 24-48 hours ago."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(hours=36)
+        assert service._format_when(dt) == "Yesterday"
+
+    def test_format_when_this_week(self) -> None:
+        """Should return 'This week' for events 2-7 days ago."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(days=4)
+        assert service._format_when(dt) == "This week"
+
+    def test_format_when_days_ago(self) -> None:
+        """Should return 'N days ago' for events more than 7 days ago."""
+        from datetime import timedelta
+
+        service = GitHubService()
+        dt = datetime.now(UTC) - timedelta(days=10)
+        result = service._format_when(dt)
+        assert "days ago" in result
+
+
+class TestGetBlameBoardData:
+    """Tests for get_blame_board_data method."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_hero_entries_when_healthy(self) -> None:
+        """Should return hero entries when pet is healthy."""
+        from datetime import timedelta
+
+        from github_tamagotchi.services.github import BlameBoardData
+
+        since = (datetime.now(UTC) - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        commits = [
+            {"sha": "sha1", "author": {"login": "alice"}, "commit": {"committer": {"date": since}}},
+            {"sha": "sha1", "author": {"login": "alice"}, "commit": {"committer": {"date": since}}},
+            {"sha": "sha2", "author": {"login": "alice"}, "commit": {"committer": {"date": since}}},
+        ]
+        repo_data = {"id": 1, "name": "repo", "default_branch": "main"}
+        check_runs = {"check_runs": [{"conclusion": "success", "status": "completed"}]}
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=repo_data)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha1/check-runs").mock(
+            return_value=httpx.Response(200, json=check_runs)
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_blame_board_data("owner", "repo", pet_health=80, pet_mood="happy")
+
+        assert isinstance(result, BlameBoardData)
+        assert result.is_healthy is True
+        assert result.blame_entries == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_blame_entries_when_unhealthy(self) -> None:
+        """Should return blame entries when pet is unhealthy."""
+        from datetime import timedelta
+
+        from github_tamagotchi.services.github import BlameBoardData
+
+        old_pr_date = (datetime.now(UTC) - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        prs = [
+            {
+                "number": 1,
+                "title": "My old PR",
+                "created_at": old_pr_date,
+                "requested_reviewers": [{"login": "bob"}],
+                "user": {"login": "alice"},
+            }
+        ]
+        repo_data = {"id": 1, "name": "repo", "default_branch": "main"}
+        commits = [{"sha": "sha1", "author": {"login": "alice"}, "commit": {"committer": {"date": old_pr_date}}}]
+
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(200, json=commits)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs)
+        )
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json=repo_data)
+        )
+        respx.get("https://api.github.com/repos/owner/repo/commits/sha1/check-runs").mock(
+            return_value=httpx.Response(200, json={"check_runs": []})
+        )
+
+        service = GitHubService(token="test")
+        result = await service.get_blame_board_data("owner", "repo", pet_health=20, pet_mood="sick")
+
+        assert isinstance(result, BlameBoardData)
+        assert result.is_healthy is False
+        assert result.hero_entries == []

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -2,12 +2,11 @@
 
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -89,7 +88,6 @@ async def auth_test_db() -> AsyncIterator[AsyncSession]:
 
         await conn.execute(text("DELETE FROM users"))
 
-    from sqlalchemy.ext.asyncio import AsyncSession as _AsyncSession
     from tests.conftest import test_session_factory
 
     async with test_session_factory() as session:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,17 +1,30 @@
 """Unit tests for authentication module."""
 
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.api.auth import (
     _cleanup_expired_states,
     _create_jwt,
     _decode_jwt,
     _oauth_states,
+    auth_router,
+    get_admin_user,
+    get_current_user,
+    get_optional_user,
 )
+from github_tamagotchi.core.database import get_session
+from github_tamagotchi.models.pet import Base
+from github_tamagotchi.models.user import User
+from tests.conftest import get_test_session, test_engine
 
 
 class TestJWT:
@@ -59,3 +72,350 @@ class TestOAuthStateCleanup:
         assert "fresh" in _oauth_states
         assert "expired" not in _oauth_states
         _oauth_states.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for auth endpoint testing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def auth_test_db() -> AsyncIterator[AsyncSession]:
+    """Create test tables, yield a session, then drop everything."""
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with test_engine.begin() as conn:
+        from sqlalchemy import text
+
+        await conn.execute(text("DELETE FROM users"))
+
+    from sqlalchemy.ext.asyncio import AsyncSession as _AsyncSession
+    from tests.conftest import test_session_factory
+
+    async with test_session_factory() as session:
+        yield session
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture
+async def auth_client() -> AsyncIterator[AsyncClient]:
+    """Async test client with auth_router and real test DB."""
+    app = FastAPI(title="Auth Test")
+    app.include_router(auth_router)
+    app.dependency_overrides[get_session] = get_test_session
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+async def _make_user(session: AsyncSession, *, github_login: str = "testuser") -> User:
+    """Insert a User row and return it."""
+    user = User(
+        github_id=12345,
+        github_login=github_login,
+        github_avatar_url=None,
+        encrypted_token=None,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# get_current_user dependency tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentUser:
+    """Tests for the get_current_user FastAPI dependency."""
+
+    async def test_returns_user_for_valid_token(self, auth_test_db: AsyncSession) -> None:
+        """Valid JWT cookie resolves to the corresponding User."""
+        user = await _make_user(auth_test_db)
+        token = _create_jwt(user.id)
+        result = await get_current_user(
+            session=auth_test_db,
+            session_token=token,
+        )
+        assert result.id == user.id
+
+    async def test_raises_401_when_no_token(self, auth_test_db: AsyncSession) -> None:
+        """Missing cookie raises 401."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(session=auth_test_db, session_token=None)
+        assert exc_info.value.status_code == 401
+        assert "Not authenticated" in exc_info.value.detail
+
+    async def test_raises_401_for_invalid_token(self, auth_test_db: AsyncSession) -> None:
+        """Garbage token raises 401."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(session=auth_test_db, session_token="not-a-jwt")
+        assert exc_info.value.status_code == 401
+
+    async def test_raises_401_for_expired_token(self, auth_test_db: AsyncSession) -> None:
+        """Expired JWT raises 401."""
+        from fastapi import HTTPException
+
+        payload = {
+            "sub": "1",
+            "exp": datetime.now(UTC) - timedelta(minutes=5),
+            "iat": datetime.now(UTC) - timedelta(minutes=10),
+        }
+        expired_token = jwt.encode(payload, "change-me-in-production", algorithm="HS256")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(session=auth_test_db, session_token=expired_token)
+        assert exc_info.value.status_code == 401
+
+    async def test_raises_401_when_user_not_in_db(self, auth_test_db: AsyncSession) -> None:
+        """JWT for non-existent user raises 401."""
+        from fastapi import HTTPException
+
+        token = _create_jwt(99999)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(session=auth_test_db, session_token=token)
+        assert exc_info.value.status_code == 401
+        assert "User not found" in exc_info.value.detail
+
+    async def test_syncs_is_admin_flag(self, auth_test_db: AsyncSession) -> None:
+        """is_admin is updated when user login is in admin_github_logins."""
+        user = await _make_user(auth_test_db, github_login="webwiebe")
+        assert not user.is_admin  # starts False
+
+        token = _create_jwt(user.id)
+        result = await get_current_user(session=auth_test_db, session_token=token)
+        assert result.is_admin is True
+
+
+# ---------------------------------------------------------------------------
+# get_admin_user dependency tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetAdminUser:
+    """Tests for the get_admin_user dependency."""
+
+    async def test_returns_user_when_admin(self) -> None:
+        """Admin user passes through without error."""
+        admin = MagicMock(spec=User)
+        admin.is_admin = True
+        admin.github_login = "webwiebe"
+
+        with patch("github_tamagotchi.api.auth.settings") as mock_settings:
+            mock_settings.admin_github_logins = ["webwiebe"]
+            result = await get_admin_user(admin)
+
+        assert result is admin
+
+    async def test_raises_403_for_non_admin(self) -> None:
+        """Non-admin user raises 403."""
+        from fastapi import HTTPException
+
+        user = MagicMock(spec=User)
+        user.is_admin = False
+        user.github_login = "regularuser"
+
+        with (
+            patch("github_tamagotchi.api.auth.settings") as mock_settings,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_settings.admin_github_logins = ["webwiebe"]
+            await get_admin_user(user)
+
+        assert exc_info.value.status_code == 403
+
+    async def test_admin_via_config_even_if_flag_false(self) -> None:
+        """User in admin_github_logins is admin even if is_admin flag is False."""
+        user = MagicMock(spec=User)
+        user.is_admin = False
+        user.github_login = "configadmin"
+
+        with patch("github_tamagotchi.api.auth.settings") as mock_settings:
+            mock_settings.admin_github_logins = ["configadmin"]
+            result = await get_admin_user(user)
+
+        assert result is user
+
+
+# ---------------------------------------------------------------------------
+# get_optional_user dependency tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetOptionalUser:
+    """Tests for the get_optional_user dependency."""
+
+    async def test_returns_none_when_no_token(self, auth_test_db: AsyncSession) -> None:
+        """No token returns None instead of raising."""
+        result = await get_optional_user(session=auth_test_db, session_token=None)
+        assert result is None
+
+    async def test_returns_none_for_invalid_token(self, auth_test_db: AsyncSession) -> None:
+        """Invalid token returns None instead of raising."""
+        result = await get_optional_user(session=auth_test_db, session_token="garbage")
+        assert result is None
+
+    async def test_returns_none_for_expired_token(self, auth_test_db: AsyncSession) -> None:
+        """Expired token returns None."""
+        payload = {
+            "sub": "1",
+            "exp": datetime.now(UTC) - timedelta(minutes=5),
+            "iat": datetime.now(UTC) - timedelta(minutes=10),
+        }
+        expired_token = jwt.encode(payload, "change-me-in-production", algorithm="HS256")
+        result = await get_optional_user(session=auth_test_db, session_token=expired_token)
+        assert result is None
+
+    async def test_returns_user_for_valid_token(self, auth_test_db: AsyncSession) -> None:
+        """Valid token with existing user returns the user."""
+        user = await _make_user(auth_test_db)
+        token = _create_jwt(user.id)
+        result = await get_optional_user(session=auth_test_db, session_token=token)
+        assert result is not None
+        assert result.id == user.id
+
+    async def test_returns_none_when_user_not_in_db(self, auth_test_db: AsyncSession) -> None:
+        """Valid token for non-existent user returns None."""
+        token = _create_jwt(99998)
+        result = await get_optional_user(session=auth_test_db, session_token=token)
+        assert result is None
+
+    async def test_syncs_is_admin_flag(self, auth_test_db: AsyncSession) -> None:
+        """is_admin is synced when user login is in admin_github_logins."""
+        user = await _make_user(auth_test_db, github_login="webwiebe")
+        token = _create_jwt(user.id)
+        result = await get_optional_user(session=auth_test_db, session_token=token)
+        assert result is not None
+        assert result.is_admin is True
+
+
+# ---------------------------------------------------------------------------
+# OAuth login endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoginGithubEndpoint:
+    """Tests for GET /auth/github (OAuth redirect)."""
+
+    async def test_redirects_when_configured(self, auth_client: AsyncClient) -> None:
+        """Returns 307 redirect to GitHub when OAuth is configured."""
+        with patch("github_tamagotchi.api.auth.settings") as mock_settings:
+            mock_settings.github_oauth_client_id = "my-client-id"
+            mock_settings.oauth_redirect_uri = "http://localhost/auth/callback"
+            response = await auth_client.get("/auth/github", follow_redirects=False)
+
+        assert response.status_code == 307
+        assert "github.com/login/oauth/authorize" in response.headers["location"]
+
+    async def test_503_when_oauth_not_configured(self, auth_client: AsyncClient) -> None:
+        """Returns 503 when GitHub OAuth client ID is not configured."""
+        with patch("github_tamagotchi.api.auth.settings") as mock_settings:
+            mock_settings.github_oauth_client_id = None
+            response = await auth_client.get("/auth/github")
+
+        assert response.status_code == 503
+
+    async def test_state_stored_in_oauth_states(self, auth_client: AsyncClient) -> None:
+        """OAuth state parameter is stored for CSRF validation."""
+        _oauth_states.clear()
+        with patch("github_tamagotchi.api.auth.settings") as mock_settings:
+            mock_settings.github_oauth_client_id = "my-client-id"
+            mock_settings.oauth_redirect_uri = "http://localhost/auth/callback"
+            response = await auth_client.get("/auth/github", follow_redirects=False)
+
+        assert response.status_code == 307
+        assert len(_oauth_states) == 1
+        _oauth_states.clear()
+
+
+# ---------------------------------------------------------------------------
+# OAuth callback early-exit error path tests (no real GitHub calls)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthCallbackErrors:
+    """Tests for early error paths in GET /auth/callback."""
+
+    async def test_400_when_no_code(self, auth_client: AsyncClient) -> None:
+        """Missing code parameter returns 400."""
+        response = await auth_client.get("/auth/callback?state=something")
+        assert response.status_code == 400
+        assert "Missing authorization code" in response.json()["detail"]
+
+    async def test_400_when_no_state(self, auth_client: AsyncClient) -> None:
+        """Missing state parameter returns 400."""
+        response = await auth_client.get("/auth/callback?code=mycode")
+        assert response.status_code == 400
+        assert "Invalid or expired OAuth state" in response.json()["detail"]
+
+    async def test_400_when_state_not_in_store(self, auth_client: AsyncClient) -> None:
+        """Unknown state value returns 400."""
+        _oauth_states.clear()
+        response = await auth_client.get("/auth/callback?code=mycode&state=unknownstate")
+        assert response.status_code == 400
+
+    async def test_503_when_oauth_not_configured(self, auth_client: AsyncClient) -> None:
+        """Returns 503 when client_id/secret is missing after state validation."""
+        _oauth_states.clear()
+        _oauth_states["validstate"] = datetime.now(UTC)
+
+        with patch("github_tamagotchi.api.auth.settings") as mock_settings:
+            mock_settings.github_oauth_client_id = None
+            mock_settings.github_oauth_client_secret = None
+            response = await auth_client.get(
+                "/auth/callback?code=mycode&state=validstate"
+            )
+
+        assert response.status_code == 503
+        _oauth_states.clear()
+
+
+# ---------------------------------------------------------------------------
+# Auth API endpoints — /me and /logout
+# ---------------------------------------------------------------------------
+
+
+class TestMeEndpoint:
+    """Tests for GET /auth/me."""
+
+    async def test_returns_user_info(self, auth_client: AsyncClient) -> None:
+        """Returns user data for authenticated request."""
+        # Create a user in the DB
+        from tests.conftest import test_session_factory
+
+        async with test_session_factory() as session:
+            user = await _make_user(session, github_login="apitestuser")
+
+        token = _create_jwt(user.id)
+        response = await auth_client.get(
+            "/auth/me", cookies={"session_token": token}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["github_login"] == "apitestuser"
+
+    async def test_401_without_token(self, auth_client: AsyncClient) -> None:
+        """Returns 401 when no session cookie is present."""
+        response = await auth_client.get("/auth/me")
+        assert response.status_code == 401
+
+
+class TestLogoutEndpoint:
+    """Tests for POST /auth/logout."""
+
+    async def test_logout_returns_200(self, auth_client: AsyncClient) -> None:
+        """Logout returns 200 and clears session cookie."""
+        response = await auth_client.post("/auth/logout")
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Coverage was sitting at 70.45% with a 70% floor — one careless commit away from failing CI.
- Added 134 new tests across the lowest-coverage modules.
- Raised the threshold to 75% (actual coverage is now **80.69%**).

## What was covered

| Module | Before | After |
|--------|--------|-------|
| `crud/contributor_relationship.py` | 17% | ~90% |
| `crud/user.py` | 28% | ~90% |
| `api/auth.py` | 57% | ~85% |
| `api/health.py` | 50% | ~85% |
| `services/github.py` | 52% | ~88% |
| `main.py` page handlers | 59% | ~75% |
| **Total** | **70.45%** | **80.69%** |

## New test files / additions

- `tests/services/test_crud_contributor_relationship.py` — upsert, score delta, cap logic, isolation
- `tests/services/test_crud_user.py` — create/update, token preservation, nullable fields
- `tests/api/test_health.py` — `_check_database`, `_check_github_api`, `_check_scheduler` internals; uptime formatter
- `tests/unit/test_auth.py` — `get_current_user`, `get_admin_user`, `get_optional_user`, JWT error paths, `/me`, `/logout`
- `tests/services/test_github_service.py` — contributor stats, release frequency, health score aggregation, blame board, insights
- `tests/api/test_admin_pages.py` — all admin HTML pages (403/401 + happy path)
- `tests/api/test_dashboard.py`, `test_leaderboard.py`, `test_pet_profile.py` — unauthenticated redirect + page load

## CI change

`--cov-fail-under=70` → `--cov-fail-under=75` (also updated `pyproject.toml fail_under`)

Added `coverage.json` to `.gitignore`.