### PR TITLE
refactor: shared nav component with consistent admin sub-navigation

### DIFF
--- a/src/github_tamagotchi/templates/_admin_subnav.html
+++ b/src/github_tamagotchi/templates/_admin_subnav.html
@@ -1,0 +1,16 @@
+{% if user and user.is_admin and active_page and active_page.startswith('admin') %}
+<nav class="admin-subnav" style="background: rgba(0,0,0,0.25); border-bottom: 1px solid rgba(255,255,255,0.08);">
+    <div class="container" style="display:flex; gap:1.25rem; padding-top:0.5rem; padding-bottom:0.5rem;">
+        <a href="/admin"
+           style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin' %} font-weight:600;{% endif %}">Admin</a>
+        <a href="/admin/pets"
+           style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_pets' %} font-weight:600;{% endif %}">Pets</a>
+        <a href="/admin/jobs"
+           style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_jobs' %} font-weight:600;{% endif %}">Jobs</a>
+        <a href="/admin/webhooks"
+           style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_webhooks' %} font-weight:600;{% endif %}">Webhooks</a>
+        <a href="/admin/achievements"
+           style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_achievements' %} font-weight:600;{% endif %}">Achievements</a>
+    </div>
+</nav>
+{% endif %}

--- a/src/github_tamagotchi/templates/_nav.html
+++ b/src/github_tamagotchi/templates/_nav.html
@@ -1,0 +1,41 @@
+<nav class="user-nav">
+    <div class="container">
+        <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
+        <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
+            {% if user %}
+            <a href="/dashboard"
+               style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;{% if active_page == 'dashboard' %} font-weight:600;{% endif %}">My Pets</a>
+            <a href="/register"
+               style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;{% if active_page == 'register' %} font-weight:600;{% endif %}">Register</a>
+            {% endif %}
+            <a href="/leaderboard"
+               style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;{% if active_page == 'leaderboard' %} font-weight:600;{% endif %}">Leaderboard</a>
+            {% if user and user.is_admin %}
+            <a href="/admin"
+               style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;{% if active_page == 'admin' %} font-weight:600;{% endif %}">Admin</a>
+            {% endif %}
+        </div>
+        <div class="user-info">
+            {% if user %}
+                {% if user.github_avatar_url %}
+                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
+                {% endif %}
+                <span class="user-name">{{ user.github_login }}</span>
+                <button class="logout-button" id="logout-btn">Log out</button>
+            {% else %}
+                <a href="/auth/github" class="cta-button" style="padding:0.4rem 1rem; font-size:0.85rem;">Login with GitHub</a>
+            {% endif %}
+        </div>
+    </div>
+</nav>
+<script>
+(function () {
+    var btn = document.getElementById('logout-btn');
+    if (btn) {
+        btn.addEventListener('click', async function () {
+            await fetch('/auth/logout', { method: 'POST' });
+            window.location.href = '/';
+        });
+    }
+})();
+</script>

--- a/src/github_tamagotchi/templates/admin_achievements.html
+++ b/src/github_tamagotchi/templates/admin_achievements.html
@@ -7,25 +7,9 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                <a href="/admin/pets" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Pets</a>
-                <a href="/admin/achievements" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Achievements</a>
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "admin_achievements" %}
+    {% include "_nav.html" %}
+    {% include "_admin_subnav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">

--- a/src/github_tamagotchi/templates/admin_jobs.html
+++ b/src/github_tamagotchi/templates/admin_jobs.html
@@ -45,26 +45,9 @@
     </style>
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                <a href="/admin/pets" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Pets</a>
-                <a href="/admin/webhooks" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Webhooks</a>
-                <a href="/admin/jobs" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Jobs</a>
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "admin_jobs" %}
+    {% include "_nav.html" %}
+    {% include "_admin_subnav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -158,11 +141,5 @@
         </div>
     </footer>
 
-    <script>
-        document.getElementById('logout-btn').addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
-    </script>
 </body>
 </html>

--- a/src/github_tamagotchi/templates/admin_overview.html
+++ b/src/github_tamagotchi/templates/admin_overview.html
@@ -7,25 +7,9 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Admin</a>
-                <a href="/admin/pets" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Pets</a>
-                <a href="/admin/achievements" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Achievements</a>
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "admin" %}
+    {% include "_nav.html" %}
+    {% include "_admin_subnav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -197,11 +181,5 @@
         </div>
     </footer>
 
-    <script>
-        document.getElementById('logout-btn').addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
-    </script>
 </body>
 </html>

--- a/src/github_tamagotchi/templates/admin_pets.html
+++ b/src/github_tamagotchi/templates/admin_pets.html
@@ -7,24 +7,9 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                <a href="/admin/pets" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Pets</a>
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "admin_pets" %}
+    {% include "_nav.html" %}
+    {% include "_admin_subnav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">

--- a/src/github_tamagotchi/templates/admin_webhooks.html
+++ b/src/github_tamagotchi/templates/admin_webhooks.html
@@ -44,23 +44,9 @@
     </style>
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                <a href="/admin/webhooks" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Webhook Log</a>
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "admin_webhooks" %}
+    {% include "_nav.html" %}
+    {% include "_admin_subnav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -139,11 +125,5 @@
         </div>
     </footer>
 
-    <script>
-        document.getElementById('logout-btn').addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
-    </script>
 </body>
 </html>

--- a/src/github_tamagotchi/templates/contributor_dashboard.html
+++ b/src/github_tamagotchi/templates/contributor_dashboard.html
@@ -7,32 +7,7 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                {% if user %}
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-                {% endif %}
-                <a href="/leaderboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Leaderboard</a>
-            </div>
-            <div class="user-info">
-                {% if user %}
-                    {% if user.github_avatar_url %}
-                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                    {% endif %}
-                    <span class="user-name">{{ user.github_login }}</span>
-                    <button class="logout-button" id="logout-btn">Log out</button>
-                {% else %}
-                    <a href="/auth/github" class="cta-button" style="padding: 0.4rem 1rem; font-size: 0.875rem;">Login with GitHub</a>
-                {% endif %}
-            </div>
-        </div>
-    </nav>
+    {% include "_nav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -225,16 +200,6 @@
         </div>
     </footer>
 
-    {% if user %}
-    <script>
-        const logoutBtn = document.getElementById('logout-btn');
-        if (logoutBtn) {
-            logoutBtn.addEventListener('click', async () => {
-                await fetch('/auth/logout', { method: 'POST' });
-                window.location.href = '/';
-            });
-        }
-    </script>
-    {% endif %}
+
 </body>
 </html>

--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -7,25 +7,8 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user and user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "dashboard" %}
+    {% include "_nav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -128,11 +111,6 @@
     </footer>
 
     <script>
-        document.getElementById('logout-btn').addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
-
         // Warm GIF cache for live pets in the background so profile visits are instant
         window.addEventListener('load', function () {
             {% for pet in pets %}{% if not pet.is_dead %}

--- a/src/github_tamagotchi/templates/landing.html
+++ b/src/github_tamagotchi/templates/landing.html
@@ -20,25 +20,8 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    {% if user %}
-    <!-- Logged-in Header -->
-    <nav class="user-nav">
-        <div class="container">
-            <span class="logo">GitHub Tamagotchi</span>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
-    {% endif %}
+    {% set active_page = "landing" %}
+    {% include "_nav.html" %}
 
     <!-- Hero Section -->
     <section class="hero">
@@ -164,14 +147,7 @@
 
         animatePet();
 
-        // Logout handler
-        const logoutBtn = document.getElementById('logout-btn');
-        if (logoutBtn) {
-            logoutBtn.addEventListener('click', async () => {
-                await fetch('/auth/logout', { method: 'POST' });
-                window.location.reload();
-            });
-        }
+        // Logout handled by _nav.html include
     </script>
 </body>
 </html>

--- a/src/github_tamagotchi/templates/leaderboard.html
+++ b/src/github_tamagotchi/templates/leaderboard.html
@@ -7,32 +7,8 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/leaderboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem; font-weight:600;">Leaderboard</a>
-                {% if user %}
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-                {% endif %}
-            </div>
-            <div class="user-info">
-                {% if user %}
-                    {% if user.github_avatar_url %}
-                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                    {% endif %}
-                    <span class="user-name">{{ user.github_login }}</span>
-                    <button class="logout-button" id="logout-btn">Log out</button>
-                {% else %}
-                    <a href="/auth/github" class="cta-button" style="padding:0.4rem 1rem; font-size:0.85rem;">Login</a>
-                {% endif %}
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "leaderboard" %}
+    {% include "_nav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -103,13 +79,5 @@
         Leaderboard refreshes hourly
     </footer>
 
-    {% if user %}
-    <script>
-        document.getElementById('logout-btn')?.addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
-    </script>
-    {% endif %}
 </body>
 </html>

--- a/src/github_tamagotchi/templates/org_overview.html
+++ b/src/github_tamagotchi/templates/org_overview.html
@@ -7,32 +7,7 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                {% if user %}
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-                {% endif %}
-                <a href="/leaderboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Leaderboard</a>
-            </div>
-            <div class="user-info">
-                {% if user %}
-                    {% if user.github_avatar_url %}
-                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                    {% endif %}
-                    <span class="user-name">{{ user.github_login }}</span>
-                    <button class="logout-button" id="logout-btn">Log out</button>
-                {% else %}
-                    <a href="/auth/github" class="cta-button" style="padding:0.4rem 1rem; font-size:0.875rem;">Login with GitHub</a>
-                {% endif %}
-            </div>
-        </div>
-    </nav>
+    {% include "_nav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
@@ -192,13 +167,6 @@
         <a href="/" style="color: var(--text-muted); text-decoration: none;">GitHub Tamagotchi</a>
     </footer>
 
-    {% if user %}
-    <script>
-        document.getElementById('logout-btn')?.addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
-    </script>
-    {% endif %}
+
 </body>
 </html>

--- a/src/github_tamagotchi/templates/pet_admin.html
+++ b/src/github_tamagotchi/templates/pet_admin.html
@@ -201,25 +201,7 @@
     </style>
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/pet/{{ repo_owner }}/{{ repo_name }}" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">{{ pet.name }}</a>
-                {% if user and user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% include "_nav.html" %}
 
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container" style="max-width: 740px;">
@@ -569,11 +551,6 @@
         toastTimer = setTimeout(() => { el.className = 'toast'; }, 3000);
     }
 
-    // --- Logout ---
-    document.getElementById('logout-btn')?.addEventListener('click', async () => {
-        await fetch('/auth/logout', { method: 'POST' });
-        location.href = '/';
-    });
     </script>
 </body>
 </html>

--- a/src/github_tamagotchi/templates/pet_insights.html
+++ b/src/github_tamagotchi/templates/pet_insights.html
@@ -202,32 +202,7 @@
     </style>
 </head>
 <body>
-    <!-- Nav -->
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            {% if user %}
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-            </div>
-            {% endif %}
-            <div class="user-info">
-                {% if user %}
-                    {% if user.github_avatar_url %}
-                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                    {% endif %}
-                    <span class="user-name">{{ user.github_login }}</span>
-                    <button class="logout-button" id="logout-btn">Log out</button>
-                {% else %}
-                    <a href="/auth/github" class="cta-button" style="padding: 0.4rem 1rem; font-size: 0.875rem;">Login with GitHub</a>
-                {% endif %}
-            </div>
-        </div>
-    </nav>
+    {% include "_nav.html" %}
 
     <main class="insights-page">
         <div class="container">
@@ -377,13 +352,6 @@
         </div>
     </main>
 
-    {% if user %}
-    <script>
-    document.getElementById('logout-btn')?.addEventListener('click', async () => {
-        await fetch('/auth/logout', { method: 'POST' });
-        window.location.href = '/';
-    });
-    </script>
-    {% endif %}
+
 </body>
 </html>

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -32,32 +32,7 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <!-- Nav -->
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo" style="text-decoration:none;">GitHub Tamagotchi</a>
-            {% if user %}
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user and user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-            </div>
-            {% endif %}
-            <div class="user-info">
-                {% if user %}
-                    {% if user.github_avatar_url %}
-                    <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                    {% endif %}
-                    <span class="user-name">{{ user.github_login }}</span>
-                    <button class="logout-button" id="logout-btn">Log out</button>
-                {% else %}
-                    <a href="/auth/github" class="cta-button" style="padding: 0.4rem 1rem; font-size: 0.875rem;">Login with GitHub</a>
-                {% endif %}
-            </div>
-        </div>
-    </nav>
+    {% include "_nav.html" %}
 
     <!-- Profile -->
     <main class="profile-page">
@@ -408,15 +383,6 @@
                     copyBtn.innerHTML = '✓ Copied!';
                     setTimeout(() => { copyBtn.innerHTML = '&#128279; Copy link'; }, 2000);
                 });
-            });
-        }
-
-        // Logout
-        const logoutBtn = document.getElementById('logout-btn');
-        if (logoutBtn) {
-            logoutBtn.addEventListener('click', async () => {
-                await fetch('/auth/logout', { method: 'POST' });
-                window.location.reload();
             });
         }
 

--- a/src/github_tamagotchi/templates/register.html
+++ b/src/github_tamagotchi/templates/register.html
@@ -7,25 +7,8 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user and user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "register" %}
+    {% include "_nav.html" %}
 
     <main class="register-main">
         <div class="container">
@@ -303,11 +286,6 @@
 
         loadStyles();
         loadRepos();
-
-        document.getElementById('logout-btn').addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
     </script>
 </body>
 </html>

--- a/src/github_tamagotchi/templates/register_complete.html
+++ b/src/github_tamagotchi/templates/register_complete.html
@@ -7,25 +7,8 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <nav class="user-nav">
-        <div class="container">
-            <a href="/" class="logo">GitHub Tamagotchi</a>
-            <div class="nav-links" style="display:flex; gap:1rem; align-items:center;">
-                <a href="/dashboard" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">My Pets</a>
-                <a href="/register" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Register</a>
-                {% if user and user.is_admin %}
-                <a href="/admin" style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.9rem;">Admin</a>
-                {% endif %}
-            </div>
-            <div class="user-info">
-                {% if user.github_avatar_url %}
-                <img src="{{ user.github_avatar_url }}" alt="{{ user.github_login }}" class="user-avatar" width="32" height="32">
-                {% endif %}
-                <span class="user-name">{{ user.github_login }}</span>
-                <button class="logout-button" id="logout-btn">Log out</button>
-            </div>
-        </div>
-    </nav>
+    {% set active_page = "register" %}
+    {% include "_nav.html" %}
 
     <main class="complete-main">
         <div class="container">
@@ -100,10 +83,6 @@
             });
         }
 
-        document.getElementById('logout-btn').addEventListener('click', async () => {
-            await fetch('/auth/logout', { method: 'POST' });
-            window.location.href = '/';
-        });
     </script>
 </body>
 </html>

--- a/tests/api/test_landing.py
+++ b/tests/api/test_landing.py
@@ -58,10 +58,11 @@ class TestLandingPage:
         response = client.get("/")
         assert "Log out" not in response.text
 
-    def test_no_user_nav_when_unauthenticated(self, client: TestClient) -> None:
-        """Landing page should not show user nav when not logged in."""
+    def test_no_user_links_when_unauthenticated(self, client: TestClient) -> None:
+        """Landing page should not show user-specific nav links when not logged in."""
         response = client.get("/")
-        assert "user-nav" not in response.text
+        assert "/dashboard" not in response.text
+        assert "/register" not in response.text
 
 
 class TestLandingPageAuthenticated:


### PR DESCRIPTION
## Problem

Navigation was duplicated across 15 templates, and each had subtle divergences:
- Admin menu missing on landing/public pages for logged-in admins (`get_optional_user` wasn't syncing `is_admin` — fixed in #159, but the nav HTML was still missing the check)
- Admin sub-nav showed a different subset of links depending on which admin page you were on (Pets+Achievements on overview, just Pets on pets page, Webhooks+Jobs+Pets on jobs page, etc.)
- Logout JS duplicated in every template
- Logo was a non-clickable `<span>` on the landing page

## Solution

- `_nav.html` — single shared top nav, included by all 15 templates. Shows: My Pets | Register | Leaderboard | Admin (when admin). Login button for anonymous users.
- `_admin_subnav.html` — consistent secondary bar on all admin pages: Admin | Pets | Jobs | Webhooks | Achievements. Current page bolded via `active_page` variable.
- Each template sets `{% set active_page = "..." %}` before the include so the active link is highlighted.
- Logout JS lives only in `_nav.html`.