### PR TITLE
fix: replace chroma-key with corner flood-fill for background removal

### DIFF
--- a/src/github_tamagotchi/services/image_generation.py
+++ b/src/github_tamagotchi/services/image_generation.py
@@ -3,6 +3,7 @@
 import hashlib
 import io
 import json
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -128,32 +129,65 @@ CHROMA_KEY_TOLERANCE: int = 40
 
 def remove_background(
     image_bytes: bytes,
-    chroma: tuple[int, int, int] = CHROMA_KEY_COLOR,
     tolerance: int = CHROMA_KEY_TOLERANCE,
 ) -> bytes:
-    """Remove the chroma-key background from an image, making it transparent.
+    """Remove the background from an image by flood-filling from all four corners.
+
+    Samples the top-left corner pixel as the background colour reference and
+    BFS-floods from all 4 corners.  This works regardless of the exact shade
+    the AI model generated (hot-pink, magenta, salmon, etc.) without touching
+    interior pixels of the same colour.
 
     Args:
         image_bytes: Raw PNG image data.
-        chroma: RGB colour to treat as background (default: magenta #FF00FF).
-        tolerance: Per-channel tolerance for colour matching.
+        tolerance: Per-channel absolute tolerance for colour matching.
 
     Returns:
         PNG image data with the background replaced by transparency.
     """
     img = Image.open(io.BytesIO(image_bytes)).convert("RGBA")
-    raw = bytearray(img.tobytes())
-    for i in range(0, len(raw), 4):
-        r, g, b = raw[i], raw[i + 1], raw[i + 2]
-        if (
-            abs(r - chroma[0]) < tolerance
-            and abs(g - chroma[1]) < tolerance
-            and abs(b - chroma[2]) < tolerance
-        ):
-            raw[i + 3] = 0
-    result = Image.frombytes("RGBA", img.size, bytes(raw))
+    width, height = img.size
+    pixels = list(img.getdata())
+
+    bg_r, bg_g, bg_b = pixels[0][:3]
+
+    def _matches(r: int, g: int, b: int) -> bool:
+        return (
+            abs(r - bg_r) <= tolerance
+            and abs(g - bg_g) <= tolerance
+            and abs(b - bg_b) <= tolerance
+        )
+
+    result: list[tuple[int, int, int, int]] = list(pixels)
+    visited: list[bool] = [False] * (width * height)
+
+    queue: deque[tuple[int, int]] = deque()
+    for sx, sy in ((0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)):
+        idx = sy * width + sx
+        if not visited[idx]:
+            r, g, b, _ = pixels[idx]
+            if _matches(r, g, b):
+                visited[idx] = True
+                queue.append((sx, sy))
+
+    while queue:
+        x, y = queue.popleft()
+        idx = y * width + x
+        r, g, b, a = result[idx]
+        result[idx] = (r, g, b, 0)
+        for nx, ny in ((x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)):
+            if 0 <= nx < width and 0 <= ny < height:
+                nidx = ny * width + nx
+                if not visited[nidx]:
+                    nr, ng, nb, _ = pixels[nidx]
+                    if _matches(nr, ng, nb):
+                        visited[nidx] = True
+                        queue.append((nx, ny))
+
+    out_img = img.copy()
+    out_img.putdata(result)
     out = io.BytesIO()
-    result.save(out, format="PNG")
+    out_img.save(out, format="PNG")
     return out.getvalue()
 
 

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -1,6 +1,7 @@
 """Sprite sheet generation, frame extraction, and animated GIF composition."""
 
 import io
+from collections import deque
 from dataclasses import dataclass, field
 
 import structlog
@@ -137,24 +138,62 @@ def build_sprite_sheet_prompt(
     return prompt, negative
 
 
-def _remove_chroma_key(img: Image.Image, tolerance: int = 60) -> Image.Image:
-    """Replace magenta (#FF00FF) chroma-key pixels with transparency.
+def _remove_background_from_corners(img: Image.Image, tolerance: int = 40) -> Image.Image:
+    """Remove background by flood-filling outward from all four corners.
+
+    Samples the top-left corner pixel as the background colour reference, then
+    BFS-floods from all 4 corners making matched pixels transparent.  This
+    works regardless of the exact shade the AI model generates (hot-pink,
+    magenta, salmon, etc.) and will never remove interior pixels of the same
+    colour because they are not reachable from the border.
 
     Args:
         img: RGBA PIL Image
-        tolerance: Per-channel distance tolerance for matching magenta (default 60)
+        tolerance: Per-channel absolute tolerance for colour matching (default 40)
 
     Returns:
-        RGBA image with chroma-key pixels made transparent
+        RGBA image with connected background pixels made transparent
     """
+    img = img.convert("RGBA")
+    width, height = img.size
     pixels = list(img.getdata())
-    thresh = tolerance * tolerance * 3
-    result: list[tuple[int, int, int, int]] = [
-        (r, g, b, 0)
-        if (r - 255) ** 2 + g**2 + (b - 255) ** 2 < thresh
-        else (r, g, b, a)
-        for r, g, b, a in pixels
-    ]
+
+    # Derive background colour from the top-left corner pixel
+    bg_r, bg_g, bg_b = pixels[0][:3]
+
+    def _matches(r: int, g: int, b: int) -> bool:
+        return (
+            abs(r - bg_r) <= tolerance
+            and abs(g - bg_g) <= tolerance
+            and abs(b - bg_b) <= tolerance
+        )
+
+    result: list[tuple[int, int, int, int]] = list(pixels)
+    visited: list[bool] = [False] * (width * height)
+
+    queue: deque[tuple[int, int]] = deque()
+    for sx, sy in ((0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)):
+        idx = sy * width + sx
+        if not visited[idx]:
+            r, g, b, _ = pixels[idx]
+            if _matches(r, g, b):
+                visited[idx] = True
+                queue.append((sx, sy))
+
+    while queue:
+        x, y = queue.popleft()
+        idx = y * width + x
+        r, g, b, a = result[idx]
+        result[idx] = (r, g, b, 0)
+        for nx, ny in ((x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)):
+            if 0 <= nx < width and 0 <= ny < height:
+                nidx = ny * width + nx
+                if not visited[nidx]:
+                    nr, ng, nb, _ = pixels[nidx]
+                    if _matches(nr, ng, nb):
+                        visited[nidx] = True
+                        queue.append((nx, ny))
+
     out = img.copy()
     out.putdata(result)
     return out
@@ -201,8 +240,8 @@ def extract_frames(
                     fw - border_trim,
                     fh - border_trim,
                 ))
-            # Remove chroma-key background
-            frame = _remove_chroma_key(frame)
+            # Remove background by flood-filling from corners
+            frame = _remove_background_from_corners(frame)
             out = io.BytesIO()
             frame.save(out, format="PNG")
             frames.append(out.getvalue())

--- a/tests/test_sprite_sheet.py
+++ b/tests/test_sprite_sheet.py
@@ -8,7 +8,7 @@ from PIL import Image
 from github_tamagotchi.services.sprite_sheet import (
     SPRITE_COLS,
     SPRITE_ROWS,
-    _remove_chroma_key,
+    _remove_background_from_corners,
     build_sprite_sheet_prompt,
     compose_animated_gif,
     extract_frames,
@@ -170,25 +170,33 @@ class TestExtractFrames:
             assert all(a == 0 for _, _, _, a in pixels), "Magenta pixels should be transparent"
 
 
-class TestRemoveChromaKey:
-    def test_pure_magenta_becomes_transparent(self) -> None:
-        img = Image.new("RGBA", (4, 4), color=(255, 0, 255, 255))
-        result = _remove_chroma_key(img)
+class TestRemoveBackgroundFromCorners:
+    def test_solid_background_becomes_transparent(self) -> None:
+        # Solid hot-pink (not pure magenta): all pixels connected to corners → all transparent
+        img = Image.new("RGBA", (4, 4), color=(255, 105, 180, 255))
+        result = _remove_background_from_corners(img)
         pixels = list(result.getdata())
         assert all(a == 0 for _, _, _, a in pixels)
 
-    def test_non_magenta_pixels_preserved(self) -> None:
-        img = Image.new("RGBA", (4, 4), color=(100, 150, 200, 255))
-        result = _remove_chroma_key(img)
-        pixels = list(result.getdata())
-        assert all(a == 255 for _, _, _, a in pixels)
+    def test_interior_pixels_not_removed(self) -> None:
+        # Magenta border, blue interior: only border-connected pixels become transparent
+        img = Image.new("RGBA", (6, 6), color=(255, 0, 255, 255))
+        for y in range(1, 5):
+            for x in range(1, 5):
+                img.putpixel((x, y), (0, 0, 255, 255))
+        result = _remove_background_from_corners(img)
+        assert result.getpixel((0, 0))[3] == 0, "Corner (border) pixel should be transparent"
+        assert result.getpixel((2, 2))[3] == 255, "Interior blue pixel should remain opaque"
 
-    def test_tolerance_catches_near_magenta(self) -> None:
-        # Near-magenta (240, 20, 240) should be caught with default tolerance
-        img = Image.new("RGBA", (2, 2), color=(240, 20, 240, 255))
-        result = _remove_chroma_key(img, tolerance=60)
-        pixels = list(result.getdata())
-        assert all(a == 0 for _, _, _, a in pixels)
+    def test_tolerance_catches_near_background_color(self) -> None:
+        # Near-magenta background with gray interior
+        img = Image.new("RGBA", (6, 6), color=(250, 10, 250, 255))
+        for y in range(1, 5):
+            for x in range(1, 5):
+                img.putpixel((x, y), (200, 200, 200, 255))
+        result = _remove_background_from_corners(img)
+        assert result.getpixel((0, 0))[3] == 0, "Near-magenta border should be transparent"
+        assert result.getpixel((2, 2))[3] == 255, "Gray interior should remain opaque"
 
 
 class TestComposeAnimatedGif:

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -365,15 +365,22 @@ class TestRemoveBackground:
         pixels = self._get_all_pixels(img)
         assert all(a == 0 for _, _, _, a in pixels), "All pixels should be transparent"
 
-    def test_non_chroma_pixels_are_preserved(self) -> None:
-        """Pixels that are not near magenta must keep their original colour and opacity."""
-        blue_png = _make_png(4, 4, (0, 0, 255, 255))
-        result_bytes = remove_background(blue_png)
+    def test_non_background_pixels_are_preserved(self) -> None:
+        """Pixels not reachable from corners must keep their original colour and opacity."""
+        # Magenta border with blue 2×2 interior; only border is removed
+        img = Image.new("RGBA", (4, 4), (255, 0, 255, 255))
+        for y in range(1, 3):
+            for x in range(1, 3):
+                img.putpixel((x, y), (0, 0, 255, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
 
-        img = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
-        pixels = self._get_all_pixels(img)
-        assert all(a == 255 for _, _, _, a in pixels), "Blue pixels should remain opaque"
-        assert all(r == 0 and g == 0 and b == 255 for r, g, b, _ in pixels)
+        result_bytes = remove_background(buf.getvalue())
+        out = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+        assert out.getpixel((0, 0))[3] == 0, "Corner (magenta) should be transparent"
+        assert out.getpixel((1, 1))[3] == 255, "Interior blue pixel should remain opaque"
+        r, g, b, _ = out.getpixel((1, 1))
+        assert r == 0 and g == 0 and b == 255
 
     def test_mixed_image_transparent_background_opaque_body(self) -> None:
         """Magenta background pixels become transparent; non-magenta body pixels stay opaque."""
@@ -412,11 +419,17 @@ class TestRemoveBackground:
         pixels = self._get_all_pixels(img)
         assert all(a == 0 for _, _, _, a in pixels)
 
-    def test_custom_chroma_and_tolerance(self) -> None:
-        """Custom chroma colour and tolerance should be respected."""
-        red_png = _make_png(2, 2, (255, 0, 0, 255))
-        result_bytes = remove_background(red_png, chroma=(255, 0, 0), tolerance=10)
+    def test_tight_tolerance_preserves_slightly_different_interior(self) -> None:
+        """Pixels just outside tolerance of the sampled background colour are preserved."""
+        # Red border (255,0,0); dark-red interior (200,0,0); tolerance=40 → abs(55)>40 → kept
+        img = Image.new("RGBA", (4, 4), (255, 0, 0, 255))
+        for y in range(1, 3):
+            for x in range(1, 3):
+                img.putpixel((x, y), (200, 0, 0, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
 
-        img = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
-        pixels = self._get_all_pixels(img)
-        assert all(a == 0 for _, _, _, a in pixels)
+        result_bytes = remove_background(buf.getvalue(), tolerance=40)
+        out = Image.open(io.BytesIO(result_bytes)).convert("RGBA")
+        assert out.getpixel((0, 0))[3] == 0, "Border (red) should be transparent"
+        assert out.getpixel((1, 1))[3] == 255, "Interior dark-red should remain opaque"


### PR DESCRIPTION
## Summary
- The AI (ComfyUI/SD) generates hot-pink backgrounds instead of exact magenta (#FF00FF), causing the old Euclidean distance check to miss them
- Replaced both `remove_background()` (static images) and `_remove_chroma_key()` (sprite sheet frames) with a BFS flood-fill that samples the corner pixel as the background reference
- Flood-fill only removes pixels **connected to the border** — interior character pixels of the same shade are never touched
- Updated tests to match the new flood-fill contract

## Test plan
- [ ] All 1098 existing tests pass
- [ ] Regenerate a pet image and verify hot-pink background is gone
- [ ] Verify animated GIF shows transparent background on pages