### PR TITLE
Closes #164: Admin sprite sheet overview and regenerate button

### DIFF
--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -14,7 +14,7 @@ from typing import Annotated
 import sentry_sdk
 import structlog
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
@@ -1166,3 +1166,79 @@ async def admin_achievements(
             "achievement_order": ACHIEVEMENT_ORDER,
         },
     )
+
+
+@app.get("/admin/sprites", response_class=HTMLResponse)
+async def admin_sprites(
+    request: Request,
+    user: AdminUser,
+    session: DbSession,
+) -> HTMLResponse:
+    """Admin page showing sprite sheet overview per creature stage."""
+    stages = []
+    for stage in PetStage:
+        # Count pets at this stage
+        count_result = await session.execute(
+            select(func.count()).select_from(Pet).where(Pet.stage == stage.value)
+        )
+        pet_count = count_result.scalar() or 0
+
+        # Get the most recent images_generated_at for pets at this stage
+        recent_result = await session.execute(
+            select(func.max(Pet.images_generated_at)).where(Pet.stage == stage.value)
+        )
+        last_generated = recent_result.scalar()
+
+        # Pick a sample pet for thumbnail display
+        sample_result = await session.execute(
+            select(Pet)
+            .where(Pet.stage == stage.value)
+            .order_by(Pet.images_generated_at.desc().nullslast())
+            .limit(1)
+        )
+        sample_pet = sample_result.scalar_one_or_none()
+
+        stages.append(
+            {
+                "stage": stage.value,
+                "pet_count": pet_count,
+                "last_generated": last_generated,
+                "sample_pet": sample_pet,
+            }
+        )
+
+    return templates.TemplateResponse(
+        request,
+        "admin_sprites.html",
+        {"user": user, "stages": stages},
+    )
+
+
+@app.post("/admin/sprites/regenerate")
+async def admin_sprites_regenerate(
+    request: Request,
+    user: AdminUser,
+    session: DbSession,
+) -> Response:
+    """Queue image regeneration for all pets of a given stage (or all stages)."""
+    body = await request.json()
+    stage_param = body.get("stage", "all")
+
+    if stage_param == "all":
+        stages_to_regen = [s.value for s in PetStage]
+    elif stage_param in {s.value for s in PetStage}:
+        stages_to_regen = [stage_param]
+    else:
+        return JSONResponse({"error": f"Unknown stage: {stage_param}"}, status_code=400)
+
+    total_queued = 0
+    for stage_val in stages_to_regen:
+        pets_result = await session.execute(
+            select(Pet).where(Pet.stage == stage_val)
+        )
+        pets = pets_result.scalars().all()
+        for pet in pets:
+            await image_queue.create_job(session, pet.id, stage_val)
+            total_queued += 1
+
+    return JSONResponse({"queued": total_queued, "stage": stage_param})

--- a/src/github_tamagotchi/templates/_admin_subnav.html
+++ b/src/github_tamagotchi/templates/_admin_subnav.html
@@ -11,6 +11,8 @@
            style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_webhooks' %} font-weight:600;{% endif %}">Webhooks</a>
         <a href="/admin/achievements"
            style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_achievements' %} font-weight:600;{% endif %}">Achievements</a>
+        <a href="/admin/sprites"
+           style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin_sprites' %} font-weight:600;{% endif %}">Sprites</a>
     </div>
 </nav>
 {% endif %}

--- a/src/github_tamagotchi/templates/admin_sprites.html
+++ b/src/github_tamagotchi/templates/admin_sprites.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Sprites - GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    {% set active_page = "admin_sprites" %}
+    {% include "_nav.html" %}
+    {% include "_admin_subnav.html" %}
+
+    <main style="padding-top: 5rem; min-height: 80vh;">
+        <div class="container">
+            <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem;">
+                <h1 style="font-size: 1.75rem; font-weight: 700;">Sprite Sheet Overview</h1>
+                <button id="regen-all-btn" onclick="regenAll()"
+                    style="background: var(--primary); color: #fff; border: none; border-radius: 6px;
+                           padding: 0.55rem 1.2rem; font-size: 0.9rem; font-weight: 600; cursor: pointer;">
+                    Regenerate All
+                </button>
+            </div>
+
+            <div id="global-feedback" style="display:none; margin-bottom: 1.5rem; padding: 0.75rem 1rem;
+                 border-radius: 6px; font-size: 0.9rem;"></div>
+
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem;">
+                {% for item in stages %}
+                <div class="feature" style="padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem;">
+                    <div style="display: flex; align-items: center; justify-content: space-between;">
+                        <h2 style="font-size: 1.05rem; font-weight: 600; margin: 0;">
+                            {% if item.stage == "egg" %}&#x1F95A;
+                            {% elif item.stage == "baby" %}&#x1F423;
+                            {% elif item.stage == "child" %}&#x1F425;
+                            {% elif item.stage == "teen" %}&#x1F426;
+                            {% elif item.stage == "adult" %}&#x1F989;
+                            {% elif item.stage == "elder" %}&#x1F985;
+                            {% else %}&#x1F95A;
+                            {% endif %}
+                            {{ item.stage | capitalize }}
+                        </h2>
+                        <span style="color: var(--text-muted); font-size: 0.82rem;">{{ item.pet_count }} pet{{ 's' if item.pet_count != 1 else '' }}</span>
+                    </div>
+
+                    <!-- Sprite thumbnail -->
+                    <div style="background: var(--surface-light); border-radius: 8px; overflow: hidden;
+                                display: flex; align-items: center; justify-content: center;
+                                min-height: 120px;">
+                        {% if item.sample_pet %}
+                        <img
+                            src="/api/v1/pets/{{ item.sample_pet.repo_owner }}/{{ item.sample_pet.repo_name }}/image/{{ item.stage }}"
+                            alt="{{ item.stage }} sprite"
+                            style="max-width: 100%; max-height: 160px; object-fit: contain; display: block;"
+                            onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
+                        />
+                        <span style="display:none; color: var(--text-muted); font-size: 0.85rem;">No image</span>
+                        {% else %}
+                        <span style="color: var(--text-muted); font-size: 0.85rem;">No pets at this stage</span>
+                        {% endif %}
+                    </div>
+
+                    <!-- Metadata -->
+                    <div style="font-size: 0.82rem; color: var(--text-muted);">
+                        {% if item.last_generated %}
+                        Last generated: {{ item.last_generated.strftime('%Y-%m-%d %H:%M') }} UTC
+                        {% else %}
+                        Never generated
+                        {% endif %}
+                    </div>
+
+                    <!-- Per-stage feedback -->
+                    <div id="feedback-{{ item.stage }}" style="display:none; padding: 0.5rem 0.75rem;
+                         border-radius: 4px; font-size: 0.85rem;"></div>
+
+                    <!-- Regenerate button -->
+                    <button
+                        id="btn-{{ item.stage }}"
+                        onclick="regenStage('{{ item.stage }}')"
+                        {% if item.pet_count == 0 %}disabled{% endif %}
+                        style="background: {% if item.pet_count > 0 %}var(--secondary){% else %}var(--surface-light){% endif %};
+                               color: {% if item.pet_count > 0 %}#fff{% else %}var(--text-muted){% endif %};
+                               border: none; border-radius: 6px; padding: 0.5rem 1rem;
+                               font-size: 0.85rem; font-weight: 600;
+                               cursor: {% if item.pet_count > 0 %}pointer{% else %}not-allowed{% endif %};">
+                        Regenerate
+                    </button>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </main>
+
+    <footer style="margin-top: 4rem; padding: 2rem 0; border-top: 1px solid var(--surface-light);">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-brand">
+                    <span class="logo">GitHub Tamagotchi</span>
+                    <p>Making repository health visible and fun.</p>
+                </div>
+                <div class="footer-links">
+                    <a href="https://github.com/wiebe-xyz/github-tamagotchi" target="_blank" rel="noopener">GitHub</a>
+                    <a href="/docs">API Docs</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        async function regenStage(stage) {
+            const btn = document.getElementById('btn-' + stage);
+            const fb = document.getElementById('feedback-' + stage);
+            btn.disabled = true;
+            btn.textContent = 'Queuing…';
+            fb.style.display = 'none';
+
+            try {
+                const resp = await fetch('/admin/sprites/regenerate', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({stage}),
+                });
+                const data = await resp.json();
+                if (resp.ok) {
+                    fb.style.background = 'rgba(76,175,80,0.15)';
+                    fb.style.color = '#4caf50';
+                    fb.textContent = `Queued ${data.queued} job${data.queued !== 1 ? 's' : ''}`;
+                } else {
+                    fb.style.background = 'rgba(239,68,68,0.15)';
+                    fb.style.color = '#ef4444';
+                    fb.textContent = data.error || 'Error queuing jobs';
+                }
+            } catch {
+                fb.style.background = 'rgba(239,68,68,0.15)';
+                fb.style.color = '#ef4444';
+                fb.textContent = 'Request failed';
+            }
+
+            fb.style.display = 'block';
+            btn.disabled = false;
+            btn.textContent = 'Regenerate';
+        }
+
+        async function regenAll() {
+            const btn = document.getElementById('regen-all-btn');
+            const gfb = document.getElementById('global-feedback');
+            btn.disabled = true;
+            btn.textContent = 'Queuing…';
+            gfb.style.display = 'none';
+
+            try {
+                const resp = await fetch('/admin/sprites/regenerate', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({stage: 'all'}),
+                });
+                const data = await resp.json();
+                if (resp.ok) {
+                    gfb.style.background = 'rgba(76,175,80,0.15)';
+                    gfb.style.color = '#4caf50';
+                    gfb.textContent = `Queued ${data.queued} job${data.queued !== 1 ? 's' : ''} across all stages`;
+                } else {
+                    gfb.style.background = 'rgba(239,68,68,0.15)';
+                    gfb.style.color = '#ef4444';
+                    gfb.textContent = data.error || 'Error queuing jobs';
+                }
+            } catch {
+                gfb.style.background = 'rgba(239,68,68,0.15)';
+                gfb.style.color = '#ef4444';
+                gfb.textContent = 'Request failed';
+            }
+
+            gfb.style.display = 'block';
+            btn.disabled = false;
+            btn.textContent = 'Regenerate All';
+        }
+    </script>
+</body>
+</html>

--- a/tests/api/test_admin_pages.py
+++ b/tests/api/test_admin_pages.py
@@ -168,3 +168,88 @@ class TestAdminWebhooksPage:
         token = _create_user(user_id=355, github_login="notadmin355")
         response = client.get("/admin/webhooks", cookies={"session_token": token})
         assert response.status_code == 403
+
+
+class TestAdminSpritesPage:
+    """Tests for /admin/sprites HTML page and regenerate endpoint."""
+
+    def test_admin_sprites_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=360, github_login="adminlogin360")
+        with _as_admin("adminlogin360"):
+            response = client.get("/admin/sprites", cookies={"session_token": token})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    def test_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=361, github_login="notadmin361")
+        response = client.get("/admin/sprites", cookies={"session_token": token})
+        assert response.status_code == 403
+
+    def test_shows_all_stages(self, client: TestClient) -> None:
+        token = _create_user(user_id=362, github_login="adminlogin362")
+        with _as_admin("adminlogin362"):
+            response = client.get("/admin/sprites", cookies={"session_token": token})
+        for stage in PetStage:
+            assert stage.value.capitalize() in response.text
+
+    def test_shows_sprites_nav_link(self, client: TestClient) -> None:
+        token = _create_user(user_id=363, github_login="adminlogin363")
+        with _as_admin("adminlogin363"):
+            response = client.get("/admin/sprites", cookies={"session_token": token})
+        assert "/admin/sprites" in response.text
+
+    def test_regenerate_unknown_stage_returns_400(self, client: TestClient) -> None:
+        token = _create_user(user_id=364, github_login="adminlogin364")
+        with _as_admin("adminlogin364"):
+            response = client.post(
+                "/admin/sprites/regenerate",
+                json={"stage": "notastage"},
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 400
+
+    def test_regenerate_valid_stage_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=365, github_login="adminlogin365")
+        with _as_admin("adminlogin365"):
+            response = client.post(
+                "/admin/sprites/regenerate",
+                json={"stage": "egg"},
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert "queued" in data
+        assert data["stage"] == "egg"
+
+    def test_regenerate_all_stages_returns_200(self, client: TestClient) -> None:
+        token = _create_user(user_id=366, github_login="adminlogin366")
+        with _as_admin("adminlogin366"):
+            response = client.post(
+                "/admin/sprites/regenerate",
+                json={"stage": "all"},
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stage"] == "all"
+
+    def test_regenerate_queues_jobs_for_pets(self, client: TestClient) -> None:
+        token = _create_user(user_id=367, github_login="adminlogin367")
+        _create_pet(repo_owner="spriteowner", repo_name="spriterepo", name="SpritePet")
+        with _as_admin("adminlogin367"):
+            response = client.post(
+                "/admin/sprites/regenerate",
+                json={"stage": "baby"},
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 200
+        assert response.json()["queued"] >= 1
+
+    def test_regenerate_non_admin_gets_403(self, client: TestClient) -> None:
+        token = _create_user(user_id=368, github_login="notadmin368")
+        response = client.post(
+            "/admin/sprites/regenerate",
+            json={"stage": "egg"},
+            cookies={"session_token": token},
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary

- Adds `/admin/sprites` page showing each creature stage (egg → elder) with thumbnail, pet count, and last-generated timestamp
- Per-stage **Regenerate** button queues image generation jobs for all pets at that stage (no page reload)
- Global **Regenerate All** button at the top queues jobs for every stage at once
- Adds **Sprites** link to the admin sub-nav alongside Admin | Pets | Jobs | Webhooks | Achievements
- New `POST /admin/sprites/regenerate` endpoint accepts `{ stage: "<stage>" | "all" }` and returns `{ queued, stage }`

## Changes

- `main.py` — `GET /admin/sprites` route + `POST /admin/sprites/regenerate` endpoint
- `templates/admin_sprites.html` — new sprite overview page (grid layout, inline JS for async feedback)
- `templates/_admin_subnav.html` — Sprites nav link added
- `tests/api/test_admin_pages.py` — 9 new tests covering auth, content, and regenerate behaviour

## Testing

- [x] All tests pass (1079 passed)
- [x] Lint passes (`ruff check` clean)
- [x] No breaking changes

Closes #164