### PR TITLE
Closes #167: fix death mechanics — 0% health shows hunger, eggs can die

### DIFF
--- a/src/github_tamagotchi/services/image_generation.py
+++ b/src/github_tamagotchi/services/image_generation.py
@@ -152,7 +152,7 @@ def remove_background(
     bg_r, bg_g, bg_b = pixels[0][:3]
 
     def _matches(r: int, g: int, b: int) -> bool:
-        return (
+        return bool(
             abs(r - bg_r) <= tolerance
             and abs(g - bg_g) <= tolerance
             and abs(b - bg_b) <= tolerance

--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -39,6 +39,10 @@ def calculate_mood(health: RepoHealth, current_health: int) -> PetMood:
     """Determine pet mood based on repository health metrics."""
     now = datetime.now(UTC)
 
+    # Health floor: dying pet overrides all other mood signals
+    if current_health == 0:
+        return PetMood.SICK
+
     # Check for sick (critical/high security alerts — highest priority)
     if health.security_alerts_critical > 0 or health.security_alerts_high > 0:
         return PetMood.SICK
@@ -288,7 +292,10 @@ def update_grace_period(pet: "Pet", now: datetime) -> None:
 
     If health is 0, record the start of the grace period (if not already set).
     If health is above 0, clear the grace period.
+    Eggs are not alive yet — death mechanics do not apply until baby stage.
     """
+    if pet.stage == PetStage.EGG.value:
+        return
     if pet.health == 0:
         if pet.grace_period_started is None:
             pet.grace_period_started = now
@@ -304,7 +311,11 @@ def check_death_conditions(pet: "Pet", now: datetime) -> tuple[bool, str | None]
       - "abandonment" — no activity for 90 days
 
     Returns (False, None) if the pet should stay alive.
+    Eggs are not alive yet — death mechanics do not apply until baby stage.
     """
+    if pet.stage == PetStage.EGG.value:
+        return False, None
+
     # Abandonment: no activity (last_checked_at or last_fed_at) for 90 days
     last_activity = pet.last_checked_at or pet.last_fed_at or pet.created_at
     # Normalise: if naive datetime, compare against naive now

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -162,7 +162,7 @@ def _remove_background_from_corners(img: Image.Image, tolerance: int = 40) -> Im
     bg_r, bg_g, bg_b = pixels[0][:3]
 
     def _matches(r: int, g: int, b: int) -> bool:
-        return (
+        return bool(
             abs(r - bg_r) <= tolerance
             and abs(g - bg_g) <= tolerance
             and abs(b - bg_b) <= tolerance

--- a/tests/services/test_pet_death.py
+++ b/tests/services/test_pet_death.py
@@ -19,7 +19,7 @@ def _make_pet(**kwargs: Any) -> Any:
         "repo_owner": "owner",
         "repo_name": "repo",
         "name": "TestPet",
-        "stage": PetStage.EGG.value,
+        "stage": PetStage.BABY.value,
         "mood": PetMood.CONTENT.value,
         "health": 100,
         "experience": 0,
@@ -169,6 +169,52 @@ class TestCheckDeathConditions:
         should_die, cause = check_death_conditions(pet, now)
         assert should_die is True
         assert cause == "abandonment"
+
+
+class TestEggExemptions:
+    """Eggs must not be subject to death or grace-period mechanics."""
+
+    def test_update_grace_period_is_noop_for_egg(self) -> None:
+        now = datetime.now(UTC)
+        pet = _make_pet(stage=PetStage.EGG.value, health=0, grace_period_started=None)
+        update_grace_period(pet, now)
+        assert pet.grace_period_started is None
+
+    def test_update_grace_period_does_not_clear_egg(self) -> None:
+        """Even if grace_period_started is somehow set on an egg, we don't touch it."""
+        earlier = datetime.now(UTC) - timedelta(days=1)
+        pet = _make_pet(stage=PetStage.EGG.value, health=50, grace_period_started=earlier)
+        update_grace_period(pet, datetime.now(UTC))
+        # should be a no-op — value unchanged
+        assert pet.grace_period_started == earlier
+
+    def test_check_death_conditions_returns_false_for_egg(self) -> None:
+        now = datetime.now(UTC)
+        long_ago = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS + 10)
+        pet = _make_pet(
+            stage=PetStage.EGG.value,
+            health=0,
+            grace_period_started=now - timedelta(days=DEATH_GRACE_PERIOD_DAYS + 1),
+            last_checked_at=long_ago,
+            created_at=long_ago - timedelta(days=5),
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is False
+        assert cause is None
+
+    def test_check_death_conditions_egg_not_abandoned(self) -> None:
+        now = datetime.now(UTC)
+        long_ago = now - timedelta(days=ABANDONMENT_THRESHOLD_DAYS + 30)
+        pet = _make_pet(
+            stage=PetStage.EGG.value,
+            health=100,
+            grace_period_started=None,
+            last_checked_at=long_ago,
+            created_at=long_ago,
+        )
+        should_die, cause = check_death_conditions(pet, now)
+        assert should_die is False
+        assert cause is None
 
 
 class TestDeadPetBadge:

--- a/tests/unit/test_pet_logic.py
+++ b/tests/unit/test_pet_logic.py
@@ -238,6 +238,45 @@ class TestCalculateMood:
         )
         assert calculate_mood(health, current_health=100) == PetMood.SICK
 
+    def test_sick_when_health_is_zero(self) -> None:
+        """Pet should be sick when health is 0, even if repo has stale commits."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC) - timedelta(days=HUNGRY_THRESHOLD_DAYS + 5),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+        )
+        assert calculate_mood(health, current_health=0) == PetMood.SICK
+
+    def test_zero_health_overrides_hungry(self) -> None:
+        """Health floor (0) takes priority over stale-commit hungry check."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC) - timedelta(days=HUNGRY_THRESHOLD_DAYS + 10),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+        )
+        assert calculate_mood(health, current_health=0) == PetMood.SICK
+
+    def test_nonzero_health_does_not_trigger_floor(self) -> None:
+        """Health floor does not fire at health=1."""
+        health = RepoHealth(
+            last_commit_at=datetime.now(UTC),
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+        )
+        assert calculate_mood(health, current_health=1) != PetMood.SICK
+
 
 
 class TestCalculateHealthDelta:


### PR DESCRIPTION
## Summary

- `calculate_mood()` now returns `SICK` immediately when `current_health == 0`, preventing a dying pet from displaying hunger messages caused by stale-commit checks running before the health check
- `update_grace_period()` skips processing for `PetStage.EGG` — eggs are not yet alive and should not start a death grace period
- `check_death_conditions()` returns `(False, None)` for `PetStage.EGG` — eggs cannot die from neglect or abandonment

## Changes

- `src/github_tamagotchi/services/pet_logic.py`: health-floor guard in `calculate_mood`; egg-stage early returns in `update_grace_period` and `check_death_conditions`
- `tests/unit/test_pet_logic.py`: new tests for zero-health SICK override and non-triggering at health=1
- `tests/services/test_pet_death.py`: default test stage changed from EGG to BABY (existing tests now correctly exercise death mechanics); new `TestEggExemptions` class with four tests

## Testing

- [x] All 250 unit + service tests pass
- [x] Lint clean

Closes #167