### PR TITLE
fix: pin admin sub-nav below fixed main nav

### DIFF
--- a/src/github_tamagotchi/static/css/style.css
+++ b/src/github_tamagotchi/static/css/style.css
@@ -96,6 +96,20 @@ body {
     padding-top: 5rem;
 }
 
+/* Admin sub-nav: fixed directly below the main nav */
+.admin-subnav {
+    position: fixed;
+    top: 57px;
+    left: 0;
+    right: 0;
+    z-index: 99;
+}
+
+/* Pages with admin sub-nav need extra top clearance */
+.has-admin-subnav {
+    padding-top: 97px !important;
+}
+
 /* Hero Section */
 .hero {
     min-height: 100vh;

--- a/src/github_tamagotchi/templates/_admin_subnav.html
+++ b/src/github_tamagotchi/templates/_admin_subnav.html
@@ -1,5 +1,5 @@
 {% if user and user.is_admin and active_page and active_page.startswith('admin') %}
-<nav class="admin-subnav" style="background: rgba(0,0,0,0.25); border-bottom: 1px solid rgba(255,255,255,0.08);">
+<nav class="admin-subnav" style="background: rgba(0,0,0,0.25); border-bottom: 1px solid rgba(255,255,255,0.08); backdrop-filter: blur(8px);">
     <div class="container" style="display:flex; gap:1.25rem; padding-top:0.5rem; padding-bottom:0.5rem;">
         <a href="/admin"
            style="color:rgba(255,255,255,0.85); text-decoration:none; font-size:0.85rem;{% if active_page == 'admin' %} font-weight:600;{% endif %}">Admin</a>

--- a/src/github_tamagotchi/templates/admin_achievements.html
+++ b/src/github_tamagotchi/templates/admin_achievements.html
@@ -11,7 +11,7 @@
     {% include "_nav.html" %}
     {% include "_admin_subnav.html" %}
 
-    <main style="padding-top: 5rem; min-height: 80vh;">
+    <main style="padding-top: 7rem; min-height: 80vh;">
         <div class="container">
             <h1 style="font-size: 1.75rem; font-weight: 700; margin-bottom: 2rem;">Achievements</h1>
 

--- a/src/github_tamagotchi/templates/admin_jobs.html
+++ b/src/github_tamagotchi/templates/admin_jobs.html
@@ -49,7 +49,7 @@
     {% include "_nav.html" %}
     {% include "_admin_subnav.html" %}
 
-    <main style="padding-top: 5rem; min-height: 80vh;">
+    <main style="padding-top: 7rem; min-height: 80vh;">
         <div class="container">
             <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem;">
                 <h1 style="font-size: 1.75rem; font-weight: 700;">Job History</h1>

--- a/src/github_tamagotchi/templates/admin_overview.html
+++ b/src/github_tamagotchi/templates/admin_overview.html
@@ -11,7 +11,7 @@
     {% include "_nav.html" %}
     {% include "_admin_subnav.html" %}
 
-    <main style="padding-top: 5rem; min-height: 80vh;">
+    <main style="padding-top: 7rem; min-height: 80vh;">
         <div class="container">
             <h1 style="font-size: 1.75rem; font-weight: 700; margin-bottom: 2rem;">Admin Overview</h1>
 

--- a/src/github_tamagotchi/templates/admin_pets.html
+++ b/src/github_tamagotchi/templates/admin_pets.html
@@ -11,7 +11,7 @@
     {% include "_nav.html" %}
     {% include "_admin_subnav.html" %}
 
-    <main style="padding-top: 5rem; min-height: 80vh;">
+    <main style="padding-top: 7rem; min-height: 80vh;">
         <div class="container">
             <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem;">
                 <div>

--- a/src/github_tamagotchi/templates/admin_sprites.html
+++ b/src/github_tamagotchi/templates/admin_sprites.html
@@ -11,7 +11,7 @@
     {% include "_nav.html" %}
     {% include "_admin_subnav.html" %}
 
-    <main style="padding-top: 5rem; min-height: 80vh;">
+    <main style="padding-top: 7rem; min-height: 80vh;">
         <div class="container">
             <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem;">
                 <h1 style="font-size: 1.75rem; font-weight: 700;">Sprite Sheet Overview</h1>

--- a/src/github_tamagotchi/templates/admin_webhooks.html
+++ b/src/github_tamagotchi/templates/admin_webhooks.html
@@ -48,7 +48,7 @@
     {% include "_nav.html" %}
     {% include "_admin_subnav.html" %}
 
-    <main style="padding-top: 5rem; min-height: 80vh;">
+    <main style="padding-top: 7rem; min-height: 80vh;">
         <div class="container">
             <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem;">
                 <h1 style="font-size: 1.75rem; font-weight: 700;">Webhook Event Log</h1>


### PR DESCRIPTION
## Summary
- `.admin-subnav` had no CSS positioning, so it rendered in normal flow and was covered by the fixed `.user-nav`
- Added `position: fixed; top: 57px; z-index: 99` to `.admin-subnav` in the stylesheet
- Increased `padding-top` on all 6 admin page `<main>` elements from `5rem` to `7rem` to clear both fixed bars
- Added `backdrop-filter: blur` to the sub-nav for visual polish