### PR TITLE
Closes #172: admin sprites page lists pets individually with full sprite sheets

### DIFF
--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -1187,43 +1187,16 @@ async def admin_sprites(
     user: AdminUser,
     session: DbSession,
 ) -> HTMLResponse:
-    """Admin page showing sprite sheet overview per creature stage."""
-    stages = []
-    for stage in PetStage:
-        # Count pets at this stage
-        count_result = await session.execute(
-            select(func.count()).select_from(Pet).where(Pet.stage == stage.value)
-        )
-        pet_count = count_result.scalar() or 0
-
-        # Get the most recent images_generated_at for pets at this stage
-        recent_result = await session.execute(
-            select(func.max(Pet.images_generated_at)).where(Pet.stage == stage.value)
-        )
-        last_generated = recent_result.scalar()
-
-        # Pick a sample pet for thumbnail display
-        sample_result = await session.execute(
-            select(Pet)
-            .where(Pet.stage == stage.value)
-            .order_by(Pet.images_generated_at.desc().nullslast())
-            .limit(1)
-        )
-        sample_pet = sample_result.scalar_one_or_none()
-
-        stages.append(
-            {
-                "stage": stage.value,
-                "pet_count": pet_count,
-                "last_generated": last_generated,
-                "sample_pet": sample_pet,
-            }
-        )
-
+    """Admin page listing all pets with their full sprite sheets."""
+    pets_result = await session.execute(
+        select(Pet).order_by(Pet.repo_owner, Pet.repo_name)
+    )
+    pets = pets_result.scalars().all()
+    stages = [s.value for s in PetStage]
     return templates.TemplateResponse(
         request,
         "admin_sprites.html",
-        {"user": user, "stages": stages},
+        {"user": user, "pets": pets, "stages": stages},
     )
 
 
@@ -1233,25 +1206,35 @@ async def admin_sprites_regenerate(
     user: AdminUser,
     session: DbSession,
 ) -> Response:
-    """Queue image regeneration for all pets of a given stage (or all stages)."""
+    """Queue image regeneration. Per-pet: {repo_owner, repo_name}. All: {stage: 'all'}."""
     body = await request.json()
-    stage_param = body.get("stage", "all")
 
-    if stage_param == "all":
-        stages_to_regen = [s.value for s in PetStage]
-    elif stage_param in {s.value for s in PetStage}:
-        stages_to_regen = [stage_param]
-    else:
+    if "repo_owner" in body and "repo_name" in body:
+        pet_result = await session.execute(
+            select(Pet).where(
+                Pet.repo_owner == body["repo_owner"],
+                Pet.repo_name == body["repo_name"],
+            )
+        )
+        pet = pet_result.scalar_one_or_none()
+        if not pet:
+            return JSONResponse({"error": "Pet not found"}, status_code=404)
+        total_queued = 0
+        for stage in PetStage:
+            await image_queue.create_job(session, pet.id, stage.value)
+            total_queued += 1
+        return JSONResponse({"queued": total_queued})
+
+    stage_param = body.get("stage", "all")
+    if stage_param != "all":
         return JSONResponse({"error": f"Unknown stage: {stage_param}"}, status_code=400)
 
     total_queued = 0
-    for stage_val in stages_to_regen:
-        pets_result = await session.execute(
-            select(Pet).where(Pet.stage == stage_val)
-        )
-        pets = pets_result.scalars().all()
-        for pet in pets:
-            await image_queue.create_job(session, pet.id, stage_val)
+    pets_result = await session.execute(select(Pet))
+    all_pets = pets_result.scalars().all()
+    for pet in all_pets:
+        for stage in PetStage:
+            await image_queue.create_job(session, pet.id, stage.value)
             total_queued += 1
 
-    return JSONResponse({"queued": total_queued, "stage": stage_param})
+    return JSONResponse({"queued": total_queued, "stage": "all"})

--- a/src/github_tamagotchi/templates/admin_sprites.html
+++ b/src/github_tamagotchi/templates/admin_sprites.html
@@ -25,69 +25,71 @@
             <div id="global-feedback" style="display:none; margin-bottom: 1.5rem; padding: 0.75rem 1rem;
                  border-radius: 6px; font-size: 0.9rem;"></div>
 
-            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem;">
-                {% for item in stages %}
-                <div class="feature" style="padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem;">
-                    <div style="display: flex; align-items: center; justify-content: space-between;">
-                        <h2 style="font-size: 1.05rem; font-weight: 600; margin: 0;">
-                            {% if item.stage == "egg" %}&#x1F95A;
-                            {% elif item.stage == "baby" %}&#x1F423;
-                            {% elif item.stage == "child" %}&#x1F425;
-                            {% elif item.stage == "teen" %}&#x1F426;
-                            {% elif item.stage == "adult" %}&#x1F989;
-                            {% elif item.stage == "elder" %}&#x1F985;
-                            {% else %}&#x1F95A;
-                            {% endif %}
-                            {{ item.stage | capitalize }}
-                        </h2>
-                        <span style="color: var(--text-muted); font-size: 0.82rem;">{{ item.pet_count }} pet{{ 's' if item.pet_count != 1 else '' }}</span>
+            {% if pets %}
+            <div style="display: flex; flex-direction: column; gap: 1.5rem;">
+                {% for pet in pets %}
+                <div class="feature" style="padding: 1.5rem;">
+                    <!-- Pet header -->
+                    <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
+                        <div>
+                            <span style="font-size: 1.05rem; font-weight: 600;">{{ pet.name }}</span>
+                            <span style="color: var(--text-muted); font-size: 0.85rem; margin-left: 0.5rem;">
+                                {{ pet.repo_owner }}/{{ pet.repo_name }}
+                            </span>
+                            <span style="margin-left: 0.75rem; font-size: 0.8rem; padding: 0.15rem 0.5rem;
+                                         background: var(--surface-light); border-radius: 4px; color: var(--text-muted);">
+                                {{ pet.stage }}
+                            </span>
+                        </div>
+                        <div style="display: flex; align-items: center; gap: 1rem;">
+                            <span style="color: var(--text-muted); font-size: 0.8rem;">
+                                {% if pet.images_generated_at %}
+                                {{ pet.images_generated_at.strftime('%Y-%m-%d %H:%M') }} UTC
+                                {% else %}
+                                Never generated
+                                {% endif %}
+                            </span>
+                            <div id="feedback-{{ pet.repo_owner }}-{{ pet.repo_name }}"
+                                 style="display:none; padding: 0.35rem 0.65rem; border-radius: 4px; font-size: 0.82rem;"></div>
+                            <button
+                                id="btn-{{ pet.repo_owner }}-{{ pet.repo_name }}"
+                                onclick="regenPet('{{ pet.repo_owner }}', '{{ pet.repo_name }}')"
+                                style="background: var(--secondary); color: #fff; border: none; border-radius: 6px;
+                                       padding: 0.4rem 0.9rem; font-size: 0.82rem; font-weight: 600; cursor: pointer;">
+                                Regenerate
+                            </button>
+                        </div>
                     </div>
 
-                    <!-- Sprite thumbnail -->
-                    <div style="background: var(--surface-light); border-radius: 8px; overflow: hidden;
-                                display: flex; align-items: center; justify-content: center;
-                                min-height: 120px;">
-                        {% if item.sample_pet %}
-                        <img
-                            src="/api/v1/pets/{{ item.sample_pet.repo_owner }}/{{ item.sample_pet.repo_name }}/image/{{ item.stage }}"
-                            alt="{{ item.stage }} sprite"
-                            style="max-width: 100%; max-height: 160px; object-fit: contain; display: block;"
-                            onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
-                        />
-                        <span style="display:none; color: var(--text-muted); font-size: 0.85rem;">No image</span>
-                        {% else %}
-                        <span style="color: var(--text-muted); font-size: 0.85rem;">No pets at this stage</span>
-                        {% endif %}
+                    <!-- Full sprite sheet row -->
+                    <div style="display: flex; gap: 0.75rem; overflow-x: auto; padding-bottom: 0.25rem;">
+                        {% for stage in stages %}
+                        <div style="display: flex; flex-direction: column; align-items: center; gap: 0.4rem; min-width: 80px;">
+                            <div style="background: var(--surface-light); border-radius: 6px; overflow: hidden;
+                                        width: 80px; height: 80px; display: flex; align-items: center; justify-content: center;">
+                                <img
+                                    src="/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ stage }}"
+                                    alt="{{ stage }}"
+                                    style="max-width: 100%; max-height: 100%; object-fit: contain; display: block;"
+                                    onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
+                                />
+                                <span style="display:none; color: var(--text-muted); font-size: 0.7rem; text-align: center;">—</span>
+                            </div>
+                            <span style="font-size: 0.75rem; color: var(--text-muted);
+                                         {% if pet.stage == stage %}font-weight: 600; color: var(--primary);{% endif %}">
+                                {{ stage }}
+                            </span>
+                        </div>
+                        {% endfor %}
                     </div>
-
-                    <!-- Metadata -->
-                    <div style="font-size: 0.82rem; color: var(--text-muted);">
-                        {% if item.last_generated %}
-                        Last generated: {{ item.last_generated.strftime('%Y-%m-%d %H:%M') }} UTC
-                        {% else %}
-                        Never generated
-                        {% endif %}
-                    </div>
-
-                    <!-- Per-stage feedback -->
-                    <div id="feedback-{{ item.stage }}" style="display:none; padding: 0.5rem 0.75rem;
-                         border-radius: 4px; font-size: 0.85rem;"></div>
-
-                    <!-- Regenerate button -->
-                    <button
-                        id="btn-{{ item.stage }}"
-                        onclick="regenStage('{{ item.stage }}')"
-                        {% if item.pet_count == 0 %}disabled{% endif %}
-                        style="background: {% if item.pet_count > 0 %}var(--secondary){% else %}var(--surface-light){% endif %};
-                               color: {% if item.pet_count > 0 %}#fff{% else %}var(--text-muted){% endif %};
-                               border: none; border-radius: 6px; padding: 0.5rem 1rem;
-                               font-size: 0.85rem; font-weight: 600;
-                               cursor: {% if item.pet_count > 0 %}pointer{% else %}not-allowed{% endif %};">
-                        Regenerate
-                    </button>
                 </div>
                 {% endfor %}
             </div>
+            {% else %}
+            <div style="text-align: center; padding: 4rem 2rem; color: var(--text-muted);">
+                <p style="font-size: 1rem;">No pets found.</p>
+            </div>
+            {% endif %}
         </div>
     </main>
 
@@ -107,18 +109,23 @@
     </footer>
 
     <script>
-        async function regenStage(stage) {
-            const btn = document.getElementById('btn-' + stage);
-            const fb = document.getElementById('feedback-' + stage);
+        function petKey(owner, repo) {
+            return owner + '-' + repo;
+        }
+
+        async function regenPet(owner, repo) {
+            const key = petKey(owner, repo);
+            const btn = document.getElementById('btn-' + key);
+            const fb = document.getElementById('feedback-' + key);
             btn.disabled = true;
-            btn.textContent = 'Queuing…';
+            btn.textContent = 'Queuing\u2026';
             fb.style.display = 'none';
 
             try {
                 const resp = await fetch('/admin/sprites/regenerate', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({stage}),
+                    body: JSON.stringify({repo_owner: owner, repo_name: repo}),
                 });
                 const data = await resp.json();
                 if (resp.ok) {
@@ -145,7 +152,7 @@
             const btn = document.getElementById('regen-all-btn');
             const gfb = document.getElementById('global-feedback');
             btn.disabled = true;
-            btn.textContent = 'Queuing…';
+            btn.textContent = 'Queuing\u2026';
             gfb.style.display = 'none';
 
             try {
@@ -158,7 +165,7 @@
                 if (resp.ok) {
                     gfb.style.background = 'rgba(76,175,80,0.15)';
                     gfb.style.color = '#4caf50';
-                    gfb.textContent = `Queued ${data.queued} job${data.queued !== 1 ? 's' : ''} across all stages`;
+                    gfb.textContent = `Queued ${data.queued} job${data.queued !== 1 ? 's' : ''} across all pets`;
                 } else {
                     gfb.style.background = 'rgba(239,68,68,0.15)';
                     gfb.style.color = '#ef4444';

--- a/tests/api/test_admin_pages.py
+++ b/tests/api/test_admin_pages.py
@@ -185,12 +185,15 @@ class TestAdminSpritesPage:
         response = client.get("/admin/sprites", cookies={"session_token": token})
         assert response.status_code == 403
 
-    def test_shows_all_stages(self, client: TestClient) -> None:
+    def test_shows_pet_in_list(self, client: TestClient) -> None:
         token = _create_user(user_id=362, github_login="adminlogin362")
+        _create_pet(repo_owner="spritelistowner", repo_name="spritelistrepo", name="SpriteListPet")
         with _as_admin("adminlogin362"):
             response = client.get("/admin/sprites", cookies={"session_token": token})
+        assert "SpriteListPet" in response.text
+        assert "spritelistowner/spritelistrepo" in response.text
         for stage in PetStage:
-            assert stage.value.capitalize() in response.text
+            assert stage.value in response.text
 
     def test_shows_sprites_nav_link(self, client: TestClient) -> None:
         token = _create_user(user_id=363, github_login="adminlogin363")
@@ -208,18 +211,29 @@ class TestAdminSpritesPage:
             )
         assert response.status_code == 400
 
-    def test_regenerate_valid_stage_returns_200(self, client: TestClient) -> None:
+    def test_regenerate_per_pet_returns_200(self, client: TestClient) -> None:
         token = _create_user(user_id=365, github_login="adminlogin365")
+        _create_pet(repo_owner="perpetowner365", repo_name="perpetrepo365", name="PerPetRegen365")
         with _as_admin("adminlogin365"):
             response = client.post(
                 "/admin/sprites/regenerate",
-                json={"stage": "egg"},
+                json={"repo_owner": "perpetowner365", "repo_name": "perpetrepo365"},
                 cookies={"session_token": token},
             )
         assert response.status_code == 200
         data = response.json()
         assert "queued" in data
-        assert data["stage"] == "egg"
+        assert data["queued"] == len(list(PetStage))
+
+    def test_regenerate_per_pet_not_found_returns_404(self, client: TestClient) -> None:
+        token = _create_user(user_id=3651, github_login="adminlogin3651")
+        with _as_admin("adminlogin3651"):
+            response = client.post(
+                "/admin/sprites/regenerate",
+                json={"repo_owner": "nobody", "repo_name": "notexist"},
+                cookies={"session_token": token},
+            )
+        assert response.status_code == 404
 
     def test_regenerate_all_stages_returns_200(self, client: TestClient) -> None:
         token = _create_user(user_id=366, github_login="adminlogin366")
@@ -233,17 +247,17 @@ class TestAdminSpritesPage:
         data = response.json()
         assert data["stage"] == "all"
 
-    def test_regenerate_queues_jobs_for_pets(self, client: TestClient) -> None:
+    def test_regenerate_all_queues_jobs_for_all_pets(self, client: TestClient) -> None:
         token = _create_user(user_id=367, github_login="adminlogin367")
-        _create_pet(repo_owner="spriteowner", repo_name="spriterepo", name="SpritePet")
+        _create_pet(repo_owner="spriteowner367", repo_name="spriterepo367", name="SpritePet367")
         with _as_admin("adminlogin367"):
             response = client.post(
                 "/admin/sprites/regenerate",
-                json={"stage": "baby"},
+                json={"stage": "all"},
                 cookies={"session_token": token},
             )
         assert response.status_code == 200
-        assert response.json()["queued"] >= 1
+        assert response.json()["queued"] >= len(list(PetStage))
 
     def test_regenerate_non_admin_gets_403(self, client: TestClient) -> None:
         token = _create_user(user_id=368, github_login="notadmin368")


### PR DESCRIPTION
## Summary
- Replace stage-grouped grid with a per-pet list on `/admin/sprites`
- Each pet shows its full sprite sheet (all 6 stages side by side), name, repo path, current stage badge, and last generated timestamp
- Per-pet **Regenerate** button queues all stages for that specific pet
- Global **Regenerate All** button remains at the top
- Empty state shown when no pets exist

## Changes
- `GET /admin/sprites`: now queries all pets sorted by owner/repo, passes flat list + stages to template
- `POST /admin/sprites/regenerate`: accepts `{repo_owner, repo_name}` for per-pet regeneration (returns 404 if not found); keeps `{stage: "all"}` for global; rejects other stage values with 400
- `admin_sprites.html`: rewritten with per-pet cards and horizontal sprite sheet rows
- Tests updated: replaced per-stage regeneration tests with per-pet equivalents; added 404 test for unknown pet

## Testing
- All 1093 tests pass
- Linter clean

Closes #172