### PR TITLE
refactor: introduce repository pattern, service layer, and schema package

### DIFF
--- a/specs/003-repository-pattern/spec.md
+++ b/specs/003-repository-pattern/spec.md
@@ -1,0 +1,238 @@
+# Feature Specification: Repository Pattern and Exception Abstraction
+
+**Feature Branch**: `refactor/repository-pattern`
+**Created**: 2026-04-13
+**Status**: Implementing
+
+## Overview
+
+Route handlers currently call `crud/` functions directly, and those functions let SQLAlchemy
+errors propagate unhandled. There is no layer that owns the mapping between "a database uniqueness
+constraint was violated" and "this means a conflict at the domain level".
+
+This spec introduces three architectural changes:
+
+1. **Repository layer** (`repositories/`) — all SQLAlchemy queries live here. Each repository
+   function catches database exceptions and translates them into domain exceptions.
+
+2. **Domain exception hierarchy** (`exceptions.py`) — typed errors that describe *what went wrong*
+   at the domain level, not *how it went wrong* at the database level.
+
+3. **Service layer** (`services/pet.py`, etc.) — sits between routes and repositories. Owns
+   business rules. Calls repositories. May further translate or re-raise domain exceptions.
+   Routes call services; services call repositories. No route touches a repository directly.
+
+---
+
+## Architecture
+
+```
+HTTP Request
+    │
+    ▼
+api/routes/v1/*.py          ← HTTP only: parse request, call service, return response
+    │                          catches domain exceptions via FastAPI exception handlers
+    │
+    ▼
+services/pet.py             ← Business rules: validation, coordination, domain invariants
+    │                          calls repositories; may raise NotFoundError, ConflictError, etc.
+    │
+    ▼
+repositories/pet.py         ← Data access only: SQLAlchemy queries
+                               catches SQLAlchemyError → raises RepositoryError (or subclass)
+                               catches IntegrityError → raises ConflictError
+                               never exposes SQLAlchemy internals to callers
+```
+
+### Exception hierarchy (`exceptions.py`)
+
+```
+AppError(Exception)
+└── RepositoryError(AppError)       ← generic DB failure (wraps SQLAlchemyError)
+    ├── NotFoundError               ← record does not exist
+    ├── ConflictError               ← uniqueness/integrity violation
+    └── ConstraintError             ← other constraint violation (FK, check, etc.)
+```
+
+Routes never import SQLAlchemy exceptions. Services never import SQLAlchemy exceptions.
+Repositories import SQLAlchemy exceptions and convert them at the boundary.
+
+### FastAPI exception handlers
+
+Registered on the app in `main.py`:
+
+| Domain exception | HTTP status | Response body |
+|-----------------|-------------|---------------|
+| `NotFoundError` | 404 | `{"detail": str(exc)}` |
+| `ConflictError` | 409 | `{"detail": str(exc)}` |
+| `RepositoryError` | 500 | `{"detail": "Internal error"}` (detail hidden) |
+
+---
+
+## User Stories
+
+### Story 1 — Route handler contains no database knowledge (Priority: P1)
+
+A route handler should read like a controller: get input, call service, return output. It should
+not know whether the service uses Postgres, Redis, or a flat file.
+
+**Acceptance Scenarios**:
+
+1. **Given** any route handler, **When** a developer reads it, **Then** it contains zero
+   SQLAlchemy imports, zero `session.execute` calls, and zero `pet_crud.*` calls
+2. **Given** a handler that needs a pet, **When** the pet doesn't exist, **Then** the 404
+   is produced by the exception handler on the app — not by an explicit `if not pet` guard
+   inside the handler itself
+
+---
+
+### Story 2 — Repository hides all database implementation details (Priority: P1)
+
+A service function should be able to call a repository without knowing which ORM or database
+is used.
+
+**Acceptance Scenarios**:
+
+1. **Given** a service function, **When** a developer reads it, **Then** it imports from
+   `repositories.*`, not from SQLAlchemy directly
+2. **Given** a `create` call on the repository, **When** a uniqueness constraint is violated,
+   **Then** the caller receives `ConflictError`, not `sqlalchemy.exc.IntegrityError`
+3. **Given** any repository function, **When** a database connection fails, **Then** the caller
+   receives `RepositoryError`, not a raw `sqlalchemy.exc.OperationalError`
+
+---
+
+### Story 3 — Exception messages are domain-readable (Priority: P2)
+
+An error that propagates to the HTTP response body should describe what went wrong in terms of
+the domain, not the database internals.
+
+**Acceptance Scenarios**:
+
+1. **Given** a 409 response from `POST /pets`, **When** a client inspects the detail, **Then**
+   it reads `"Pet already exists for owner/repo"`, not a PostgreSQL constraint name
+2. **Given** a 500 response from a repository failure, **When** a client inspects the detail,
+   **Then** it reads `"Internal error"` — the SQLAlchemy message is logged but not exposed
+
+---
+
+## Functional Requirements
+
+- **FR-001**: All SQLAlchemy `select`, `insert`, `update`, `delete` statements must live in
+  `repositories/`. No service or route may execute raw ORM queries.
+- **FR-002**: Every repository function must wrap exceptions: `IntegrityError` → `ConflictError`;
+  `SQLAlchemyError` → `RepositoryError`; never let SQLAlchemy exceptions propagate to callers.
+- **FR-003**: The `crud/` package must be kept as a re-export shim pointing to `repositories/`
+  for backwards compatibility with existing code outside the route layer (`main.py`, `services/
+  webhook.py`, `api/auth.py`, `mcp/server.py`) and with existing test imports.
+- **FR-004**: No route handler may import from `repositories/` or `crud/` directly — only from
+  `services/`.
+- **FR-005**: `api/dependencies.py`'s `get_pet_or_404` becomes a service call; `NotFoundError`
+  is raised by the service, not by a guard in `dependencies.py`.
+- **FR-006**: FastAPI exception handlers for `NotFoundError`, `ConflictError`, and
+  `RepositoryError` must be registered on the app.
+- **FR-007**: All 1121+ existing tests must pass. Repository renaming is transparent via the
+  `crud/` shim layer; domain exception types must produce the same HTTP status codes as before.
+
+---
+
+## Repository Design
+
+Each repository module exposes async functions (not classes). The session is always the first
+parameter so callers can participate in a shared transaction.
+
+```python
+# Pattern for every repository function
+async def create(db: AsyncSession, ...) -> ModelType:
+    try:
+        obj = ModelType(...)
+        db.add(obj)
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError("...") from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError("...") from exc
+```
+
+---
+
+## Service Design
+
+Services are modules of async functions (not classes for this scale). Each function:
+- Takes `db: AsyncSession` as its first parameter
+- Calls one or more repository functions
+- Contains domain logic (validation, calculations, invariants)
+- May call `services/pet_logic.py` for pure computations
+- May raise domain exceptions (`NotFoundError`, `ConflictError`) — never raises `HTTPException`
+
+```python
+# services/pet.py
+async def get_or_raise(db: AsyncSession, owner: str, repo: str) -> Pet:
+    pet = await pet_repo.get_by_repo(db, owner, repo)
+    if pet is None:
+        raise NotFoundError(f"Pet not found for {owner}/{repo}")
+    return pet
+```
+
+---
+
+## Backwards Compatibility
+
+`crud/` stays as re-export shims:
+```python
+# crud/pet.py
+from github_tamagotchi.repositories.pet import (
+    create_pet, get_pet_by_repo, get_pets, ...
+)
+```
+
+This preserves:
+- `from github_tamagotchi.crud import pet as pet_crud` in non-route code
+- Direct test imports like `from github_tamagotchi.crud.pet import _leaderboard_cache`
+- `services/webhook.py` and `main.py` which are out of scope for this refactor
+
+---
+
+---
+
+## Schema Layer (Request/Response DTOs)
+
+Pydantic `BaseModel` classes are currently defined inline inside router files. This makes them
+invisible to the rest of the app, hard to share, and forces a developer to read route code to
+understand what the API sends and receives.
+
+All request and response models move to a `schemas/` package:
+
+```
+src/github_tamagotchi/schemas/
+├── __init__.py
+├── pets.py       ← PetCreate, PetResponse, PetListResponse, FeedResponse,
+│                   StyleUpdateRequest, PetRenameRequest, BadgeStyleUpdateRequest,
+│                   SkinInfo, SkinSelectRequest, SkinSelectResponse,
+│                   ImageGenerationResponse
+├── social.py     ← LeaderboardEntry, LeaderboardCategory, LeaderboardResponse
+├── admin.py      ← PetAdminSettingsUpdate, ExcludedContributorItem, PetAdminResponse
+└── info.py       ← PetCharacteristics, CommentResponse, CommentsListResponse,
+                    CommentCreate, AchievementItem, AchievementsResponse,
+                    MilestoneItem, MilestonesResponse, ContributorRelationshipItem,
+                    ContributorRelationshipsResponse, BlameEntryItem, HeroEntryItem,
+                    BlameBoardResponse
+```
+
+Route handlers import schemas from `schemas.*`, not define them inline. Router files contain
+only: imports, a router instance, and handler functions.
+
+---
+
+## Out of Scope
+
+- Refactoring `services/webhook.py` (complex, has its own DB access patterns)
+- Refactoring `main.py` page routes (HTML routes, separate concern)
+- Refactoring `mcp/server.py`
+- Making `api/auth.py` use the service layer (identity/session concern, low value)
+- Class-based repositories (overkill at this scale; module functions are idiomatic in FastAPI)
+- Unit testing repositories in isolation with mocked DB sessions (integration tests already cover this)

--- a/src/github_tamagotchi/api/dependencies.py
+++ b/src/github_tamagotchi/api/dependencies.py
@@ -6,9 +6,9 @@ from fastapi import Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from github_tamagotchi.core.database import get_session
-from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.models.pet import Pet
 from github_tamagotchi.models.user import User
+from github_tamagotchi.services import pet as pet_service
 from github_tamagotchi.services.github import GitHubService
 from github_tamagotchi.services.token_encryption import decrypt_token
 
@@ -16,14 +16,8 @@ DbSession = Annotated[AsyncSession, Depends(get_session)]
 
 
 async def get_pet_or_404(repo_owner: str, repo_name: str, session: AsyncSession) -> Pet:
-    """Fetch a pet by repo or raise HTTP 404."""
-    pet = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
-    if not pet:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Pet not found for {repo_owner}/{repo_name}",
-        )
-    return pet
+    """Fetch a pet by repo or raise NotFoundError (→ HTTP 404 via exception handler)."""
+    return await pet_service.get_or_raise(session, repo_owner, repo_name)
 
 
 def require_pet_owner(pet: Pet, user: User) -> None:

--- a/src/github_tamagotchi/api/exception_handlers.py
+++ b/src/github_tamagotchi/api/exception_handlers.py
@@ -1,0 +1,22 @@
+"""FastAPI exception handlers for domain exceptions."""
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from github_tamagotchi.exceptions import ConflictError, NotFoundError, RepositoryError
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register domain exception → HTTP status handlers on *app*."""
+
+    @app.exception_handler(NotFoundError)
+    async def not_found_handler(request: Request, exc: NotFoundError) -> JSONResponse:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ConflictError)
+    async def conflict_handler(request: Request, exc: ConflictError) -> JSONResponse:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(RepositoryError)
+    async def repository_error_handler(request: Request, exc: RepositoryError) -> JSONResponse:
+        return JSONResponse(status_code=500, content={"detail": "Internal error"})

--- a/src/github_tamagotchi/api/routes/v1/admin.py
+++ b/src/github_tamagotchi/api/routes/v1/admin.py
@@ -1,20 +1,23 @@
 """Pet admin endpoints: settings, contributor exclusion, reset, delete."""
 
-from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select as _select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import github_tamagotchi.api.routes as _api_routes  # for test-patch-compatible symbol lookup
 from github_tamagotchi.api.auth import get_current_user
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404
-from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.models.pet import Pet
 from github_tamagotchi.models.user import User
+from github_tamagotchi.schemas.admin import (
+    ExcludedContributorItem,
+    PetAdminResponse,
+    PetAdminSettingsUpdate,
+)
+from github_tamagotchi.services import pet as pet_service
 from github_tamagotchi.services.naming import is_valid_pet_name
 
 router: APIRouter = APIRouter(prefix="/api/v1", tags=["admin"])
@@ -48,41 +51,6 @@ async def _require_repo_admin(
         ) from exc
     if permission != "admin":
         raise HTTPException(status_code=403, detail="Repo admin permission required")
-
-
-class PetAdminSettingsUpdate(BaseModel):
-    name: str | None = Field(None, min_length=1, max_length=20)
-    blame_board_enabled: bool | None = None
-    contributor_badges_enabled: bool | None = None
-    leaderboard_opt_out: bool | None = None
-    hungry_after_days: int | None = Field(None, ge=1, le=30)
-    pr_review_sla_hours: int | None = Field(None, ge=1, le=336)
-    issue_response_sla_days: int | None = Field(None, ge=1, le=90)
-
-
-class ExcludedContributorItem(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    github_login: str
-    excluded_by: str
-    excluded_at: datetime
-
-
-class PetAdminResponse(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    name: str
-    blame_board_enabled: bool
-    contributor_badges_enabled: bool
-    leaderboard_opt_out: bool
-    hungry_after_days: int
-    pr_review_sla_hours: int
-    issue_response_sla_days: int
-    excluded_contributors: list[ExcludedContributorItem]
-    is_dead: bool
-    generation: int
 
 
 async def _build_pet_admin_response(pet: Pet, session: AsyncSession) -> PetAdminResponse:
@@ -149,8 +117,7 @@ async def update_pet_admin_settings(
     if body.issue_response_sla_days is not None:
         pet.issue_response_sla_days = body.issue_response_sla_days
 
-    await session.commit()
-    await session.refresh(pet)
+    pet = await pet_service.save(session, pet)
     return await _build_pet_admin_response(pet, session)
 
 
@@ -226,7 +193,7 @@ async def reset_pet(
     """Reset pet stats and start a new generation. Requires repo admin permission."""
     pet = await get_pet_or_404(repo_owner, repo_name, session)
     await _require_repo_admin(repo_owner, repo_name, user, session)
-    pet = await pet_crud.reset_pet(session, pet)
+    pet = await pet_service.reset(session, pet)
     return await _build_pet_admin_response(pet, session)
 
 
@@ -240,5 +207,5 @@ async def delete_pet_admin(
     """Delete a pet entirely. Requires repo admin permission."""
     pet = await get_pet_or_404(repo_owner, repo_name, session)
     await _require_repo_admin(repo_owner, repo_name, user, session)
-    await pet_crud.delete_pet(session, pet)
+    await pet_service.delete(session, pet)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/github_tamagotchi/api/routes/v1/pets/actions.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/actions.py
@@ -1,7 +1,5 @@
 """Pet action endpoints: resurrect."""
 
-import math
-from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -10,10 +8,10 @@ import github_tamagotchi.api.routes as _api_routes  # for test-patch-compatible 
 from github_tamagotchi import metrics as metrics_service
 from github_tamagotchi.api.auth import get_current_user
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404, require_pet_owner
-from github_tamagotchi.api.routes.v1.pets.crud import PetResponse
-from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.models.pet import PetStage
 from github_tamagotchi.models.user import User
+from github_tamagotchi.schemas.pets import PetResponse
+from github_tamagotchi.services import pet as pet_service
 
 router: APIRouter = APIRouter(prefix="/api/v1", tags=["pets"])
 
@@ -27,31 +25,11 @@ async def resurrect_pet(
 ) -> PetResponse:
     """Resurrect a dead pet after the mandatory 7-day mourning period."""
     pet = await get_pet_or_404(repo_owner, repo_name, session)
-    if not pet.is_dead:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Pet is not dead and cannot be resurrected",
-        )
     require_pet_owner(pet, user)
-    if pet.died_at is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Pet death timestamp is missing",
-        )
-    now = datetime.now(UTC)
-    died_at = pet.died_at
-    if died_at.tzinfo is None:
-        died_at = died_at.replace(tzinfo=UTC)
-    days_elapsed = (now - died_at).total_seconds() / 86400
-    mourning_days = 7
-    if days_elapsed < mourning_days:
-        days_remaining = math.ceil(mourning_days - days_elapsed)
-        day_word = "day" if days_remaining == 1 else "days"
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Your pet must rest for {days_remaining} more {day_word} before resurrection",
-        )
-    pet = await pet_crud.resurrect_pet(session, pet)
+    try:
+        pet = await pet_service.resurrect(session, pet)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     metrics_service.resurrections_total.inc()
     try:
         _api_routes.get_image_provider()

--- a/src/github_tamagotchi/api/routes/v1/pets/appearance.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/appearance.py
@@ -3,48 +3,28 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 
 import github_tamagotchi.api.routes as _api_routes  # for test-patch-compatible symbol lookup
 from github_tamagotchi.api.auth import get_current_user
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404, require_pet_owner
-from github_tamagotchi.api.routes.v1.pets.crud import PetResponse
-from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.models.pet import PetSkin
 from github_tamagotchi.models.user import User
+from github_tamagotchi.schemas.pets import (
+    BadgeStyleUpdateRequest,
+    PetRenameRequest,
+    PetResponse,
+    SkinInfo,
+    SkinSelectRequest,
+    SkinSelectResponse,
+    StyleUpdateRequest,
+)
+from github_tamagotchi.services import pet as pet_service
 from github_tamagotchi.services.badge import BADGE_STYLES
 from github_tamagotchi.services.image_generation import STYLES
 from github_tamagotchi.services.naming import is_valid_pet_name
 from github_tamagotchi.services.pet_logic import SKIN_UNLOCK_CONDITIONS, get_unlocked_skins
 
 router: APIRouter = APIRouter(prefix="/api/v1", tags=["pets"])
-
-
-class StyleUpdateRequest(BaseModel):
-    style: str = Field(..., min_length=1, max_length=30)
-
-
-class PetRenameRequest(BaseModel):
-    name: str = Field(..., min_length=1, max_length=20)
-
-
-class BadgeStyleUpdateRequest(BaseModel):
-    badge_style: str = Field(..., min_length=1, max_length=20)
-
-
-class SkinInfo(BaseModel):
-    skin: str
-    unlocked: bool
-    unlock_condition: str
-
-
-class SkinSelectRequest(BaseModel):
-    skin: str = Field(..., min_length=1, max_length=20)
-
-
-class SkinSelectResponse(BaseModel):
-    message: str
-    pet: PetResponse
 
 
 @router.put("/pets/{repo_owner}/{repo_name}/style", response_model=PetResponse)
@@ -64,9 +44,7 @@ async def update_pet_style(
         )
     pet = await get_pet_or_404(repo_owner, repo_name, session)
     require_pet_owner(pet, user)
-    pet.style = style_data.style
-    await session.commit()
-    await session.refresh(pet)
+    pet = await pet_service.update_style(session, pet, style_data.style)
     try:
         _api_routes.get_image_provider()
         await _api_routes.image_queue.create_job(session, pet.id, pet.stage)
@@ -91,9 +69,7 @@ async def rename_pet(
         )
     pet = await get_pet_or_404(repo_owner, repo_name, session)
     require_pet_owner(pet, user)
-    pet.name = rename_data.name
-    await session.commit()
-    await session.refresh(pet)
+    pet = await pet_service.rename(session, pet, rename_data.name)
     return PetResponse.model_validate(pet)
 
 
@@ -114,9 +90,7 @@ async def update_pet_badge_style(
         )
     pet = await get_pet_or_404(repo_owner, repo_name, session)
     require_pet_owner(pet, user)
-    pet.badge_style = badge_style_data.badge_style
-    await session.commit()
-    await session.refresh(pet)
+    pet = await pet_service.update_badge_style(session, pet, badge_style_data.badge_style)
     return PetResponse.model_validate(pet)
 
 
@@ -154,7 +128,7 @@ async def select_skin(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Skin '{body.skin}' is not yet unlocked for this pet",
         )
-    updated_pet = await pet_crud.select_skin(session, pet, chosen_skin)
+    updated_pet = await pet_service.select_skin(session, pet, chosen_skin)
     return SkinSelectResponse(
         message=f"{updated_pet.name} is now wearing the {chosen_skin.value} skin!",
         pet=PetResponse.model_validate(updated_pet),

--- a/src/github_tamagotchi/api/routes/v1/pets/crud.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/crud.py
@@ -4,85 +4,26 @@ import math
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import select as sa_select
 
 import github_tamagotchi.api.routes as _api_routes  # for test-patch-compatible symbol lookup
 from github_tamagotchi.api.auth import get_current_user, get_optional_user
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404
-from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.models.pet import Pet, PetStage
 from github_tamagotchi.models.user import User
+from github_tamagotchi.schemas.pets import (
+    FeedResponse,
+    PetCreate,
+    PetListResponse,
+    PetResponse,
+    RepoItem,
+)
+from github_tamagotchi.services import pet as pet_service
 from github_tamagotchi.services.github import GitHubService
-from github_tamagotchi.services.image_generation import DEFAULT_STYLE, STYLES
+from github_tamagotchi.services.image_generation import STYLES
 from github_tamagotchi.services.naming import generate_name_from_repo, is_valid_pet_name
 from github_tamagotchi.services.token_encryption import decrypt_token
 
 router: APIRouter = APIRouter(prefix="/api/v1", tags=["pets"])
-
-
-class PetCreate(BaseModel):
-    repo_owner: str = Field(..., min_length=1, max_length=255)
-    repo_name: str = Field(..., min_length=1, max_length=255)
-    name: str | None = Field(None, min_length=1, max_length=20)
-    style: str = Field(DEFAULT_STYLE, min_length=1, max_length=30)
-
-
-class PetResponse(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    repo_owner: str
-    repo_name: str
-    name: str
-    stage: str
-    mood: str
-    health: int
-    experience: int
-    skin: str
-    low_health_recoveries: int
-    style: str
-    badge_style: str
-    commit_streak: int
-    longest_streak: int
-    generation: int
-    is_dead: bool
-    died_at: object | None
-    cause_of_death: str | None
-    personality_activity: float | None
-    personality_sociability: float | None
-    personality_bravery: float | None
-    personality_tidiness: float | None
-    personality_appetite: float | None
-    created_at: object
-    updated_at: object
-    last_fed_at: object | None
-    last_checked_at: object | None
-    dependent_count: int
-    grace_period_started: object | None
-
-
-class PetListResponse(BaseModel):
-    items: list[PetResponse]
-    total: int
-    page: int
-    per_page: int
-    pages: int
-
-
-class FeedResponse(BaseModel):
-    message: str
-    pet: PetResponse
-
-
-class RepoItem(BaseModel):
-    full_name: str
-    owner: str
-    name: str
-    description: str | None
-    private: bool
-    has_pet: bool
-    pet_name: str | None
 
 
 def _build_pet_list_response(
@@ -110,12 +51,6 @@ async def create_pet(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Invalid style '{pet_data.style}'. Must be one of: {', '.join(STYLES.keys())}",
         )
-    existing = await pet_crud.get_pet_by_repo(session, pet_data.repo_owner, pet_data.repo_name)
-    if existing:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Pet already exists for {pet_data.repo_owner}/{pet_data.repo_name}",
-        )
     if pet_data.name is None:
         pet_name = generate_name_from_repo(pet_data.repo_owner, pet_data.repo_name)
     else:
@@ -125,7 +60,7 @@ async def create_pet(
                 detail="Invalid pet name. Use 1-20 alphanumeric chars and spaces, no profanity.",
             )
         pet_name = pet_data.name
-    pet = await pet_crud.create_pet(
+    pet = await pet_service.create(
         session,
         pet_data.repo_owner,
         pet_data.repo_name,
@@ -148,7 +83,7 @@ async def list_pets(
     per_page: Annotated[int, Query(ge=1, le=100)] = 10,
 ) -> PetListResponse:
     """List all pets with pagination."""
-    pets, total = await pet_crud.get_pets(session, page=page, per_page=per_page)
+    pets, total = await pet_service.get_list(session, page=page, per_page=per_page)
     return _build_pet_list_response(pets, total, page, per_page)
 
 
@@ -163,14 +98,14 @@ async def get_pet(repo_owner: str, repo_name: str, session: DbSession) -> PetRes
 async def delete_pet(repo_owner: str, repo_name: str, session: DbSession) -> None:
     """Delete a pet."""
     pet = await get_pet_or_404(repo_owner, repo_name, session)
-    await pet_crud.delete_pet(session, pet)
+    await pet_service.delete(session, pet)
 
 
 @router.post("/pets/{repo_owner}/{repo_name}/feed", response_model=FeedResponse)
 async def feed_pet(repo_owner: str, repo_name: str, session: DbSession) -> FeedResponse:
     """Manually feed the pet."""
     pet = await get_pet_or_404(repo_owner, repo_name, session)
-    updated_pet = await pet_crud.feed_pet(session, pet)
+    updated_pet = await pet_service.feed(session, pet)
     return FeedResponse(
         message=f"{updated_pet.name} has been fed!",
         pet=PetResponse.model_validate(updated_pet),
@@ -185,7 +120,7 @@ async def list_my_pets(
     per_page: Annotated[int, Query(ge=1, le=100)] = 10,
 ) -> PetListResponse:
     """List pets belonging to the authenticated user."""
-    pets, total = await pet_crud.get_pets(session, page=page, per_page=per_page, user_id=user.id)
+    pets, total = await pet_service.get_list(session, page=page, per_page=per_page, user_id=user.id)
     return _build_pet_list_response(pets, total, page, per_page)
 
 
@@ -215,8 +150,8 @@ async def list_my_repos(
 
     existing_pets: dict[tuple[str, str], str] = {}
     if writable:
-        result = await session.execute(sa_select(Pet))
-        for pet in result.scalars().all():
+        all_pets = await pet_service.get_all(session)
+        for pet in all_pets:
             existing_pets[(pet.repo_owner, pet.repo_name)] = pet.name
 
     return [

--- a/src/github_tamagotchi/api/routes/v1/pets/info.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/info.py
@@ -3,105 +3,32 @@
 Covers: characteristics, comments, achievements, milestones, contributors, blame-board.
 """
 
-from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select as sa_select
 
 from github_tamagotchi.api.auth import get_current_user, get_optional_user
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404
 from github_tamagotchi.models.user import User
+from github_tamagotchi.schemas.info import (
+    AchievementItem,
+    AchievementsResponse,
+    BlameBoardResponse,
+    BlameEntryItem,
+    CommentCreate,
+    CommentResponse,
+    CommentsListResponse,
+    ContributorRelationshipItem,
+    ContributorRelationshipsResponse,
+    HeroEntryItem,
+    MilestoneItem,
+    MilestonesResponse,
+    PetCharacteristics,
+)
 from github_tamagotchi.services.image_generation import get_pet_appearance
 
 router: APIRouter = APIRouter(prefix="/api/v1", tags=["pets"])
-
-
-class PetCharacteristics(BaseModel):
-    color: str
-    accent_color: str
-    body_type: str
-    feature: str
-
-
-class CommentResponse(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    author_name: str
-    body: str
-    created_at: datetime
-
-
-class CommentsListResponse(BaseModel):
-    comments: list[CommentResponse]
-
-
-class CommentCreate(BaseModel):
-    body: str = Field(..., min_length=1, max_length=500)
-
-
-class AchievementItem(BaseModel):
-    id: str
-    name: str
-    icon: str
-    description: str
-    unlocked: bool
-    unlocked_at: datetime | None
-
-
-class AchievementsResponse(BaseModel):
-    achievements: list[AchievementItem]
-
-
-class MilestoneItem(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    old_stage: str
-    new_stage: str
-    experience: int
-    age_days: int
-    created_at: datetime
-
-
-class MilestonesResponse(BaseModel):
-    milestones: list[MilestoneItem]
-
-
-class ContributorRelationshipItem(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    github_username: str
-    standing: str
-    score: int
-    last_activity: datetime | None
-    good_deeds: list[str]
-    sins: list[str]
-
-
-class ContributorRelationshipsResponse(BaseModel):
-    contributors: list[ContributorRelationshipItem]
-
-
-class BlameEntryItem(BaseModel):
-    issue: str
-    culprit: str
-    how_long: str
-
-
-class HeroEntryItem(BaseModel):
-    good_deed: str
-    hero: str
-    when: str
-
-
-class BlameBoardResponse(BaseModel):
-    is_healthy: bool
-    blame_board_enabled: bool
-    blame_entries: list[BlameEntryItem]
-    hero_entries: list[HeroEntryItem]
 
 
 @router.get("/pets/{repo_owner}/{repo_name}/characteristics", response_model=PetCharacteristics)

--- a/src/github_tamagotchi/api/routes/v1/pets/media.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/media.py
@@ -5,13 +5,13 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import github_tamagotchi.api.routes as _api_routes  # for test-patch-compatible symbol lookup
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404
-from github_tamagotchi.crud import pet as pet_crud
 from github_tamagotchi.models.pet import Pet, PetStage
+from github_tamagotchi.schemas.pets import ImageGenerationResponse
+from github_tamagotchi.services import pet as pet_service
 from github_tamagotchi.services.badge import BADGE_STYLES
 from github_tamagotchi.services.image_generation import DEFAULT_STYLE
 from github_tamagotchi.services.sprite_sheet import compose_animated_gif
@@ -33,11 +33,6 @@ def get_storage_service() -> StorageService:
 
 
 StorageDep = Annotated[StorageService, Depends(get_storage_service)]
-
-
-class ImageGenerationResponse(BaseModel):
-    message: str
-    stages: list[str]
 
 
 def _require_image_generation() -> None:
@@ -62,7 +57,7 @@ async def _generate_all_stages(
         if result.success and result.image_data:
             await storage.upload_image(repo_owner, repo_name, pet_stage.value, result.image_data)
             generated_stages.append(pet_stage.value)
-    await pet_crud.update_images_generated_at(session, repo_owner, repo_name)
+    await pet_service.update_images_generated_at(session, repo_owner, repo_name)
     return generated_stages
 
 
@@ -171,7 +166,7 @@ async def get_pet_image(
         if not result.success or not result.image_data:
             raise HTTPException(status_code=503, detail=result.error or "Image generation failed")
         await storage.upload_image(repo_owner, repo_name, stage, result.image_data)
-        await pet_crud.update_images_generated_at(session, repo_owner, repo_name)
+        await pet_service.update_images_generated_at(session, repo_owner, repo_name)
         return Response(
             content=result.image_data,
             media_type="image/png",
@@ -234,7 +229,7 @@ async def get_pet_animated_gif(
             ),
         )
 
-    pet: Pet | None = await pet_crud.get_pet_by_repo(session, repo_owner, repo_name)
+    pet: Pet | None = await pet_service.get_by_repo(session, repo_owner, repo_name)
     mood = pet.mood if pet else "content"
     health = pet.health if pet else 100
     style = pet.style if pet else DEFAULT_STYLE
@@ -281,7 +276,7 @@ async def get_pet_animated_gif(
 
     if pet and not pet.canonical_appearance and sheet_result.canonical_appearance:
         try:
-            await pet_crud.update_canonical_appearance(
+            await pet_service.update_canonical_appearance(
                 session, repo_owner, repo_name, sheet_result.canonical_appearance
             )
         except Exception as e:

--- a/src/github_tamagotchi/api/routes/v1/social.py
+++ b/src/github_tamagotchi/api/routes/v1/social.py
@@ -4,10 +4,14 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Query
 from fastapi.responses import Response
-from pydantic import BaseModel, ConfigDict
 
 from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404
-from github_tamagotchi.crud import pet as pet_crud
+from github_tamagotchi.schemas.social import (
+    LeaderboardCategory,
+    LeaderboardEntry,
+    LeaderboardResponse,
+)
+from github_tamagotchi.services import pet as pet_service
 from github_tamagotchi.services.badge import ContributorStanding, classify_contributor_standing
 from github_tamagotchi.services.github import GitHubService
 
@@ -35,29 +39,6 @@ _LEADERBOARD_CATEGORIES = [
 ]
 
 
-class LeaderboardEntry(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    rank: int
-    pet_name: str
-    repo_owner: str
-    repo_name: str
-    stage: str
-    value: int
-
-
-class LeaderboardCategory(BaseModel):
-    id: str
-    title: str
-    description: str
-    entries: list[LeaderboardEntry]
-
-
-class LeaderboardResponse(BaseModel):
-    categories: list[LeaderboardCategory]
-    cached_at: datetime
-
-
 @router.get("/leaderboard", response_model=LeaderboardResponse)
 async def get_leaderboard(session: DbSession) -> LeaderboardResponse:
     """Return the public leaderboard with multiple categories."""
@@ -65,7 +46,7 @@ async def get_leaderboard(session: DbSession) -> LeaderboardResponse:
     now = datetime.now(UTC)
 
     for cat in _LEADERBOARD_CATEGORIES:
-        pets = await pet_crud.get_leaderboard(session, cat["id"], limit=10)
+        pets = await pet_service.get_leaderboard(session, cat["id"], limit=10)
         entries = [
             LeaderboardEntry(
                 rank=i + 1,
@@ -100,7 +81,7 @@ async def get_showcase(
     """Return an SVG showcase of all pets for a GitHub user."""
     from github_tamagotchi.services.badge import generate_showcase_svg
 
-    pets = await pet_crud.get_pets_by_github_username(session, username, limit=max)
+    pets = await pet_service.get_by_username(session, username, limit=max)
     pets_data = [
         {
             "name": pet.name,

--- a/src/github_tamagotchi/crud/contributor_relationship.py
+++ b/src/github_tamagotchi/crud/contributor_relationship.py
@@ -1,127 +1,15 @@
-"""CRUD operations for contributor relationships."""
+"""Backwards-compatibility shim: re-exports from repositories.contributor.
 
-from datetime import datetime
-from typing import Any
+All callers that import from ``crud.contributor_relationship`` continue to work unchanged.
+New code should import from ``repositories.contributor`` directly.
+"""
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from github_tamagotchi.models.contributor_relationship import ContributorRelationship
-
-
-async def get_contributors_for_pet(
-    db: AsyncSession, pet_id: int
-) -> list[ContributorRelationship]:
-    """Return all contributor relationships for a pet, ordered by score descending."""
-    result = await db.execute(
-        select(ContributorRelationship)
-        .where(ContributorRelationship.pet_id == pet_id)
-        .order_by(ContributorRelationship.score.desc())
-    )
-    return list(result.scalars().all())
-
-
-async def upsert_contributor_relationship(
-    db: AsyncSession,
-    pet_id: int,
-    github_username: str,
-    score: int,
-    standing: str,
-    last_activity: datetime | None,
-    good_deeds: list[Any],
-    sins: list[Any],
-) -> ContributorRelationship:
-    """Insert or update a contributor relationship record."""
-    result = await db.execute(
-        select(ContributorRelationship).where(
-            ContributorRelationship.pet_id == pet_id,
-            ContributorRelationship.github_username == github_username,
-        )
-    )
-    existing = result.scalar_one_or_none()
-
-    if existing:
-        existing.score = score
-        existing.standing = standing
-        existing.last_activity = last_activity
-        existing.good_deeds = good_deeds
-        existing.sins = sins
-        return existing
-
-    relationship = ContributorRelationship(
-        pet_id=pet_id,
-        github_username=github_username,
-        score=score,
-        standing=standing,
-        last_activity=last_activity,
-        good_deeds=good_deeds,
-        sins=sins,
-    )
-    db.add(relationship)
-    return relationship
-
-
-async def apply_score_delta(
-    db: AsyncSession,
-    pet_id: int,
-    github_username: str,
-    delta: int,
-    event_description: str,
-    now: datetime | None = None,
-) -> ContributorRelationship | None:
-    """Apply a score delta to an existing contributor relationship.
-
-    Used for real-time webhook updates between poll cycles.
-    Returns None if the relationship does not yet exist.
-    """
-    from datetime import UTC
-
-    from github_tamagotchi.models.contributor_relationship import ContributorStanding
-    from github_tamagotchi.services.contributor_relationships import calculate_standing
-
-    if now is None:
-        from datetime import UTC
-
-        now = datetime.now(UTC)
-
-    result = await db.execute(
-        select(ContributorRelationship).where(
-            ContributorRelationship.pet_id == pet_id,
-            ContributorRelationship.github_username == github_username,
-        )
-    )
-    rel = result.scalar_one_or_none()
-    if rel is None:
-        # Create a minimal record for this contributor
-        rel = ContributorRelationship(
-            pet_id=pet_id,
-            github_username=github_username,
-            score=0,
-            standing=ContributorStanding.NEUTRAL,
-            last_activity=now,
-            good_deeds=[],
-            sins=[],
-        )
-        db.add(rel)
-
-    rel.score += delta
-    rel.last_activity = now
-
-    if delta > 0:
-        deeds = list(rel.good_deeds or [])
-        deeds.insert(0, event_description)
-        rel.good_deeds = deeds[:5]
-    else:
-        sins = list(rel.sins or [])
-        sins.insert(0, event_description)
-        rel.sins = sins[:5]
-
-    # Recalculate standing
-    rel.standing = calculate_standing(
-        score=rel.score,
-        is_top_scorer=False,  # Don't recalculate top scorer during webhook; poll will fix it
-        last_activity=rel.last_activity,
-        now=now,
-    )
-
-    return rel
+from github_tamagotchi.repositories.contributor import (
+    apply_score_delta as apply_score_delta,
+)
+from github_tamagotchi.repositories.contributor import (
+    get_contributors_for_pet as get_contributors_for_pet,
+)
+from github_tamagotchi.repositories.contributor import (
+    upsert_contributor_relationship as upsert_contributor_relationship,
+)

--- a/src/github_tamagotchi/crud/milestone.py
+++ b/src/github_tamagotchi/crud/milestone.py
@@ -1,58 +1,15 @@
-"""CRUD operations for PetMilestone model."""
+"""Backwards-compatibility shim: re-exports from repositories.milestone.
 
-from datetime import UTC, datetime
+All callers that import from ``crud.milestone`` continue to work unchanged.
+New code should import from ``repositories.milestone`` directly.
+"""
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from github_tamagotchi.models.milestone import PetMilestone
-from github_tamagotchi.models.pet import Pet
-
-
-async def create_milestone(
-    db: AsyncSession,
-    pet: Pet,
-    old_stage: str,
-    new_stage: str,
-    experience: int,
-) -> PetMilestone:
-    """Record an evolution milestone for a pet."""
-    now = datetime.now(UTC)
-    created_at = pet.created_at
-    # Normalise to UTC-aware for subtraction
-    if created_at.tzinfo is None:
-        created_at = created_at.replace(tzinfo=UTC)
-    age_days = max(0, int((now - created_at).total_seconds() / 86400))
-
-    milestone = PetMilestone(
-        pet_id=pet.id,
-        old_stage=old_stage,
-        new_stage=new_stage,
-        experience=experience,
-        age_days=age_days,
-    )
-    db.add(milestone)
-    # Caller is responsible for commit
-    return milestone
-
-
-async def get_latest_milestone(db: AsyncSession, pet_id: int) -> PetMilestone | None:
-    """Return the most recent evolution milestone for a pet, if any."""
-    result = await db.execute(
-        select(PetMilestone)
-        .where(PetMilestone.pet_id == pet_id)
-        .order_by(PetMilestone.created_at.desc())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
-
-
-async def get_milestones(db: AsyncSession, pet_id: int, limit: int = 10) -> list[PetMilestone]:
-    """Return recent evolution milestones for a pet, newest first."""
-    result = await db.execute(
-        select(PetMilestone)
-        .where(PetMilestone.pet_id == pet_id)
-        .order_by(PetMilestone.created_at.desc())
-        .limit(limit)
-    )
-    return list(result.scalars().all())
+from github_tamagotchi.repositories.milestone import (
+    create_milestone as create_milestone,
+)
+from github_tamagotchi.repositories.milestone import (
+    get_latest_milestone as get_latest_milestone,
+)
+from github_tamagotchi.repositories.milestone import (
+    get_milestones as get_milestones,
+)

--- a/src/github_tamagotchi/crud/pet.py
+++ b/src/github_tamagotchi/crud/pet.py
@@ -1,239 +1,60 @@
-"""CRUD operations for Pet model."""
+"""Backwards-compatibility shim: re-exports from repositories.pet.
 
-from datetime import UTC, datetime
+All callers that import from ``crud.pet`` continue to work unchanged.
+New code should import from ``repositories.pet`` or ``services.pet`` directly.
+"""
 
-from sqlalchemy import func, select, update
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from github_tamagotchi.models.pet import Pet, PetMood, PetSkin, PetStage
-from github_tamagotchi.services.pet_logic import generate_personality
-
-# Simple in-memory leaderboard cache: stores (timestamp, data) per category
-_leaderboard_cache: dict[str, tuple[datetime, list[Pet]]] = {}
-_LEADERBOARD_CACHE_TTL_SECONDS = 3600  # 1 hour
-
-
-async def create_pet(
-    db: AsyncSession,
-    repo_owner: str,
-    repo_name: str,
-    name: str,
-    user_id: int | None = None,
-    style: str = "kawaii",
-) -> Pet:
-    """Create a new pet with generated personality traits."""
-    personality = generate_personality(repo_owner, repo_name)
-    pet = Pet(
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        name=name,
-        user_id=user_id,
-        style=style,
-        personality_activity=personality.activity,
-        personality_sociability=personality.sociability,
-        personality_bravery=personality.bravery,
-        personality_tidiness=personality.tidiness,
-        personality_appetite=personality.appetite,
-    )
-    db.add(pet)
-    await db.commit()
-    await db.refresh(pet)
-    return pet
-
-
-async def get_pet_by_repo(db: AsyncSession, owner: str, repo: str) -> Pet | None:
-    """Get a pet by repository owner and name."""
-    result = await db.execute(select(Pet).where(Pet.repo_owner == owner, Pet.repo_name == repo))
-    return result.scalar_one_or_none()
-
-
-async def get_pets(
-    db: AsyncSession, page: int = 1, per_page: int = 10, user_id: int | None = None
-) -> tuple[list[Pet], int]:
-    """Get pets with pagination, optionally filtered by user."""
-    offset = (page - 1) * per_page
-
-    base_query = select(Pet)
-    count_query = select(func.count()).select_from(Pet)
-    if user_id is not None:
-        base_query = base_query.where(Pet.user_id == user_id)
-        count_query = count_query.where(Pet.user_id == user_id)
-
-    count_result = await db.execute(count_query)
-    total = count_result.scalar() or 0
-
-    result = await db.execute(
-        base_query.order_by(Pet.created_at.desc()).offset(offset).limit(per_page)
-    )
-    pets = list(result.scalars().all())
-
-    return pets, total
-
-
-async def get_pets_with_owners(
-    db: AsyncSession, page: int = 1, per_page: int = 20
-) -> tuple[list[dict[str, object]], int]:
-    """Get all pets with their owner info, paginated."""
-    from github_tamagotchi.models.user import User
-
-    offset = (page - 1) * per_page
-
-    count_result = await db.execute(select(func.count()).select_from(Pet))
-    total = count_result.scalar() or 0
-
-    result = await db.execute(
-        select(Pet, User)
-        .outerjoin(User, Pet.user_id == User.id)
-        .order_by(Pet.created_at.desc())
-        .offset(offset)
-        .limit(per_page)
-    )
-    rows = [{"pet": row.Pet, "owner": row.User} for row in result]
-    return rows, total
-
-
-async def get_leaderboard(
-    db: AsyncSession, category: str, limit: int = 10
-) -> list[Pet]:
-    """Return top pets for the given leaderboard category, with hourly caching.
-
-    Categories:
-      - "most_experienced": top by experience (XP)
-      - "longest_streak": top by longest_streak
-    """
-    now = datetime.now(UTC)
-    cache_key = f"{category}:{limit}"
-    cached = _leaderboard_cache.get(cache_key)
-    if cached is not None:
-        cached_at, cached_data = cached
-        if (now - cached_at).total_seconds() < _LEADERBOARD_CACHE_TTL_SECONDS:
-            return cached_data
-
-    base_filter = Pet.leaderboard_opt_out.is_(False), Pet.is_dead.is_(False)
-
-    if category == "most_experienced":
-        order_col = Pet.experience.desc()
-    elif category == "longest_streak":
-        order_col = Pet.longest_streak.desc()
-    else:
-        return []
-
-    result = await db.execute(
-        select(Pet).where(*base_filter).order_by(order_col).limit(limit)
-    )
-    pets = list(result.scalars().all())
-
-    _leaderboard_cache[cache_key] = (now, pets)
-    return pets
-
-
-async def get_pets_by_github_username(
-    db: AsyncSession, username: str, limit: int = 50
-) -> list[Pet]:
-    """Get all pets where repo_owner matches the given GitHub username, ordered by creation date."""
-    result = await db.execute(
-        select(Pet)
-        .where(Pet.repo_owner == username)
-        .order_by(Pet.created_at.asc())
-        .limit(limit)
-    )
-    return list(result.scalars().all())
-
-
-async def get_org_pets(db: AsyncSession, org_name: str) -> list[Pet]:
-    """Get all pets belonging to an org, case-insensitive, ordered by health desc."""
-    from sqlalchemy import func as sqlfunc
-
-    result = await db.execute(
-        select(Pet)
-        .where(sqlfunc.lower(Pet.repo_owner) == org_name.lower())
-        .order_by(Pet.health.desc())
-    )
-    return list(result.scalars().all())
-
-
-async def delete_pet(db: AsyncSession, pet: Pet) -> None:
-    """Delete a pet."""
-    await db.delete(pet)
-    await db.commit()
-
-
-async def feed_pet(db: AsyncSession, pet: Pet) -> Pet:
-    """Feed a pet to improve its health and mood."""
-    pet.health = min(100, pet.health + 10)
-    pet.last_fed_at = datetime.now(UTC)
-
-    if pet.health >= 80:
-        pet.mood = PetMood.HAPPY.value
-    elif pet.health >= 50:
-        pet.mood = PetMood.CONTENT.value
-
-    await db.commit()
-    await db.refresh(pet)
-    return pet
-
-
-async def select_skin(db: AsyncSession, pet: Pet, skin: PetSkin) -> Pet:
-    """Set the active skin on a pet."""
-    pet.skin = skin.value
-    await db.commit()
-    await db.refresh(pet)
-    return pet
-
-
-async def resurrect_pet(db: AsyncSession, pet: Pet) -> Pet:
-    """Reset a dead pet to egg state and increment generation."""
-    pet.is_dead = False
-    pet.died_at = None
-    pet.cause_of_death = None
-    pet.grace_period_started = None
-    pet.stage = PetStage.EGG.value
-    pet.health = 60
-    pet.experience = 0
-    pet.mood = PetMood.CONTENT.value
-    pet.generation += 1
-    await db.commit()
-    await db.refresh(pet)
-    return pet
-
-
-async def reset_pet(db: AsyncSession, pet: Pet) -> Pet:
-    """Reset all pet stats to initial state and increment generation."""
-    pet.stage = PetStage.EGG.value
-    pet.mood = PetMood.CONTENT.value
-    pet.health = 100
-    pet.experience = 0
-    pet.commit_streak = 0
-    pet.longest_streak = 0
-    pet.last_streak_date = None
-    pet.last_fed_at = None
-    pet.is_dead = False
-    pet.died_at = None
-    pet.cause_of_death = None
-    pet.grace_period_started = None
-    pet.generation = pet.generation + 1
-    await db.commit()
-    await db.refresh(pet)
-    return pet
-
-
-async def update_images_generated_at(db: AsyncSession, repo_owner: str, repo_name: str) -> None:
-    """Stamp the images_generated_at timestamp on a pet."""
-    await db.execute(
-        update(Pet)
-        .where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
-        .values(images_generated_at=func.now())
-    )
-    await db.commit()
-
-
-async def update_canonical_appearance(
-    db: AsyncSession, repo_owner: str, repo_name: str, canonical_appearance: str
-) -> None:
-    """Persist the canonical appearance string for a pet."""
-    await db.execute(
-        update(Pet)
-        .where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
-        .values(canonical_appearance=canonical_appearance)
-    )
-    await db.commit()
+from github_tamagotchi.repositories.pet import (
+    _LEADERBOARD_CACHE_TTL_SECONDS as _LEADERBOARD_CACHE_TTL_SECONDS,
+)
+from github_tamagotchi.repositories.pet import (
+    _leaderboard_cache as _leaderboard_cache,
+)
+from github_tamagotchi.repositories.pet import (
+    create_pet as create_pet,
+)
+from github_tamagotchi.repositories.pet import (
+    delete_pet as delete_pet,
+)
+from github_tamagotchi.repositories.pet import (
+    feed_pet as feed_pet,
+)
+from github_tamagotchi.repositories.pet import (
+    get_all as get_all,
+)
+from github_tamagotchi.repositories.pet import (
+    get_leaderboard as get_leaderboard,
+)
+from github_tamagotchi.repositories.pet import (
+    get_org_pets as get_org_pets,
+)
+from github_tamagotchi.repositories.pet import (
+    get_pet_by_repo as get_pet_by_repo,
+)
+from github_tamagotchi.repositories.pet import (
+    get_pets as get_pets,
+)
+from github_tamagotchi.repositories.pet import (
+    get_pets_by_github_username as get_pets_by_github_username,
+)
+from github_tamagotchi.repositories.pet import (
+    get_pets_with_owners as get_pets_with_owners,
+)
+from github_tamagotchi.repositories.pet import (
+    reset_pet as reset_pet,
+)
+from github_tamagotchi.repositories.pet import (
+    resurrect_pet as resurrect_pet,
+)
+from github_tamagotchi.repositories.pet import (
+    save as save,
+)
+from github_tamagotchi.repositories.pet import (
+    select_skin as select_skin,
+)
+from github_tamagotchi.repositories.pet import (
+    update_canonical_appearance as update_canonical_appearance,
+)
+from github_tamagotchi.repositories.pet import (
+    update_images_generated_at as update_images_generated_at,
+)

--- a/src/github_tamagotchi/crud/user.py
+++ b/src/github_tamagotchi/crud/user.py
@@ -1,46 +1,15 @@
-"""CRUD operations for User model."""
+"""Backwards-compatibility shim: re-exports from repositories.user.
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+All callers that import from ``crud.user`` continue to work unchanged.
+New code should import from ``repositories.user`` or ``services.user`` directly.
+"""
 
-from github_tamagotchi.models.user import User
-
-
-async def get_user_by_github_id(db: AsyncSession, github_id: int) -> User | None:
-    """Get a user by their GitHub ID."""
-    result = await db.execute(select(User).where(User.github_id == github_id))
-    return result.scalar_one_or_none()
-
-
-async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
-    """Get a user by their internal ID."""
-    result = await db.execute(select(User).where(User.id == user_id))
-    return result.scalar_one_or_none()
-
-
-async def create_or_update_user(
-    db: AsyncSession,
-    *,
-    github_id: int,
-    github_login: str,
-    github_avatar_url: str | None,
-    encrypted_token: str | None,
-) -> User:
-    """Create a new user or update an existing one on login."""
-    user = await get_user_by_github_id(db, github_id)
-    if user:
-        user.github_login = github_login
-        user.github_avatar_url = github_avatar_url
-        if encrypted_token is not None:
-            user.encrypted_token = encrypted_token
-    else:
-        user = User(
-            github_id=github_id,
-            github_login=github_login,
-            github_avatar_url=github_avatar_url,
-            encrypted_token=encrypted_token,
-        )
-        db.add(user)
-    await db.commit()
-    await db.refresh(user)
-    return user
+from github_tamagotchi.repositories.user import (
+    create_or_update_user as create_or_update_user,
+)
+from github_tamagotchi.repositories.user import (
+    get_user_by_github_id as get_user_by_github_id,
+)
+from github_tamagotchi.repositories.user import (
+    get_user_by_id as get_user_by_id,
+)

--- a/src/github_tamagotchi/exceptions.py
+++ b/src/github_tamagotchi/exceptions.py
@@ -1,0 +1,25 @@
+"""Domain exception hierarchy.
+
+Repositories catch SQLAlchemy errors and re-raise as one of these.
+Services and routes never see SQLAlchemy internals.
+"""
+
+
+class AppError(Exception):
+    """Base for all application domain errors."""
+
+
+class RepositoryError(AppError):
+    """A database operation failed unexpectedly."""
+
+
+class NotFoundError(RepositoryError):
+    """The requested record does not exist."""
+
+
+class ConflictError(RepositoryError):
+    """A uniqueness or integrity constraint was violated."""
+
+
+class ConstraintError(RepositoryError):
+    """A check or foreign-key constraint was violated."""

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -28,6 +28,7 @@ from github_tamagotchi import __version__
 from github_tamagotchi import metrics as metrics_service
 from github_tamagotchi.api.alerts import alert_router
 from github_tamagotchi.api.auth import auth_router, get_admin_user, get_optional_user
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.health import health_router
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.config import settings
@@ -481,6 +482,9 @@ app.mount("/mcp", mcp_app)
 
 # Mount static files
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+
+
+register_exception_handlers(app)
 
 
 @app.middleware("http")

--- a/src/github_tamagotchi/repositories/__init__.py
+++ b/src/github_tamagotchi/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Data access layer. All SQLAlchemy queries live here."""

--- a/src/github_tamagotchi/repositories/contributor.py
+++ b/src/github_tamagotchi/repositories/contributor.py
@@ -1,0 +1,146 @@
+"""Contributor repository: all ContributorRelationship model queries with exception translation."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.exceptions import ConflictError, RepositoryError
+from github_tamagotchi.models.contributor_relationship import ContributorRelationship
+
+
+async def get_contributors_for_pet(
+    db: AsyncSession, pet_id: int
+) -> list[ContributorRelationship]:
+    """Return all contributor relationships for a pet, ordered by score descending."""
+    try:
+        result = await db.execute(
+            select(ContributorRelationship)
+            .where(ContributorRelationship.pet_id == pet_id)
+            .order_by(ContributorRelationship.score.desc())
+        )
+        return list(result.scalars().all())
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def upsert_contributor_relationship(
+    db: AsyncSession,
+    pet_id: int,
+    github_username: str,
+    score: int,
+    standing: str,
+    last_activity: datetime | None,
+    good_deeds: list[Any],
+    sins: list[Any],
+) -> ContributorRelationship:
+    """Insert or update a contributor relationship record."""
+    try:
+        result = await db.execute(
+            select(ContributorRelationship).where(
+                ContributorRelationship.pet_id == pet_id,
+                ContributorRelationship.github_username == github_username,
+            )
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.score = score
+            existing.standing = standing
+            existing.last_activity = last_activity
+            existing.good_deeds = good_deeds
+            existing.sins = sins
+            return existing
+
+        relationship = ContributorRelationship(
+            pet_id=pet_id,
+            github_username=github_username,
+            score=score,
+            standing=standing,
+            last_activity=last_activity,
+            good_deeds=good_deeds,
+            sins=sins,
+        )
+        db.add(relationship)
+        return relationship
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def apply_score_delta(
+    db: AsyncSession,
+    pet_id: int,
+    github_username: str,
+    delta: int,
+    event_description: str,
+    now: datetime | None = None,
+) -> ContributorRelationship | None:
+    """Apply a score delta to an existing contributor relationship.
+
+    Used for real-time webhook updates between poll cycles.
+    Returns None if the relationship does not yet exist.
+    """
+    from datetime import UTC
+
+    from github_tamagotchi.models.contributor_relationship import ContributorStanding
+    from github_tamagotchi.services.contributor_relationships import calculate_standing
+
+    if now is None:
+        from datetime import UTC
+
+        now = datetime.now(UTC)
+
+    try:
+        result = await db.execute(
+            select(ContributorRelationship).where(
+                ContributorRelationship.pet_id == pet_id,
+                ContributorRelationship.github_username == github_username,
+            )
+        )
+        rel = result.scalar_one_or_none()
+        if rel is None:
+            # Create a minimal record for this contributor
+            rel = ContributorRelationship(
+                pet_id=pet_id,
+                github_username=github_username,
+                score=0,
+                standing=ContributorStanding.NEUTRAL,
+                last_activity=now,
+                good_deeds=[],
+                sins=[],
+            )
+            db.add(rel)
+
+        rel.score += delta
+        rel.last_activity = now
+
+        if delta > 0:
+            deeds = list(rel.good_deeds or [])
+            deeds.insert(0, event_description)
+            rel.good_deeds = deeds[:5]
+        else:
+            sins = list(rel.sins or [])
+            sins.insert(0, event_description)
+            rel.sins = sins[:5]
+
+        # Recalculate standing
+        rel.standing = calculate_standing(
+            score=rel.score,
+            is_top_scorer=False,  # Don't recalculate top scorer during webhook; poll will fix it
+            last_activity=rel.last_activity,
+            now=now,
+        )
+
+        return rel
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc

--- a/src/github_tamagotchi/repositories/milestone.py
+++ b/src/github_tamagotchi/repositories/milestone.py
@@ -1,0 +1,71 @@
+"""Milestone repository: all PetMilestone model queries with exception translation."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.exceptions import ConflictError, RepositoryError
+from github_tamagotchi.models.milestone import PetMilestone
+from github_tamagotchi.models.pet import Pet
+
+
+async def create_milestone(
+    db: AsyncSession,
+    pet: Pet,
+    old_stage: str,
+    new_stage: str,
+    experience: int,
+) -> PetMilestone:
+    """Record an evolution milestone for a pet."""
+    now = datetime.now(UTC)
+    created_at = pet.created_at
+    # Normalise to UTC-aware for subtraction
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+    age_days = max(0, int((now - created_at).total_seconds() / 86400))
+
+    milestone = PetMilestone(
+        pet_id=pet.id,
+        old_stage=old_stage,
+        new_stage=new_stage,
+        experience=experience,
+        age_days=age_days,
+    )
+    try:
+        db.add(milestone)
+        # Caller is responsible for commit
+        return milestone
+    except IntegrityError as exc:
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_latest_milestone(db: AsyncSession, pet_id: int) -> PetMilestone | None:
+    """Return the most recent evolution milestone for a pet, if any."""
+    try:
+        result = await db.execute(
+            select(PetMilestone)
+            .where(PetMilestone.pet_id == pet_id)
+            .order_by(PetMilestone.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_milestones(db: AsyncSession, pet_id: int, limit: int = 10) -> list[PetMilestone]:
+    """Return recent evolution milestones for a pet, newest first."""
+    try:
+        result = await db.execute(
+            select(PetMilestone)
+            .where(PetMilestone.pet_id == pet_id)
+            .order_by(PetMilestone.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc

--- a/src/github_tamagotchi/repositories/pet.py
+++ b/src/github_tamagotchi/repositories/pet.py
@@ -1,0 +1,334 @@
+"""Pet repository: all Pet model queries with exception translation."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select, update
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.exceptions import ConflictError, RepositoryError
+from github_tamagotchi.models.pet import Pet, PetMood, PetSkin, PetStage
+from github_tamagotchi.services.pet_logic import generate_personality
+
+# Simple in-memory leaderboard cache: stores (timestamp, data) per category
+_leaderboard_cache: dict[str, tuple[datetime, list[Pet]]] = {}
+_LEADERBOARD_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+async def create_pet(
+    db: AsyncSession,
+    repo_owner: str,
+    repo_name: str,
+    name: str,
+    user_id: int | None = None,
+    style: str = "kawaii",
+) -> Pet:
+    """Create a new pet with generated personality traits."""
+    personality = generate_personality(repo_owner, repo_name)
+    pet = Pet(
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        name=name,
+        user_id=user_id,
+        style=style,
+        personality_activity=personality.activity,
+        personality_sociability=personality.sociability,
+        personality_bravery=personality.bravery,
+        personality_tidiness=personality.tidiness,
+        personality_appetite=personality.appetite,
+    )
+    try:
+        db.add(pet)
+        await db.commit()
+        await db.refresh(pet)
+        return pet
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_pet_by_repo(db: AsyncSession, owner: str, repo: str) -> Pet | None:
+    """Get a pet by repository owner and name."""
+    try:
+        result = await db.execute(
+            select(Pet).where(Pet.repo_owner == owner, Pet.repo_name == repo)
+        )
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_pets(
+    db: AsyncSession, page: int = 1, per_page: int = 10, user_id: int | None = None
+) -> tuple[list[Pet], int]:
+    """Get pets with pagination, optionally filtered by user."""
+    offset = (page - 1) * per_page
+
+    base_query = select(Pet)
+    count_query = select(func.count()).select_from(Pet)
+    if user_id is not None:
+        base_query = base_query.where(Pet.user_id == user_id)
+        count_query = count_query.where(Pet.user_id == user_id)
+
+    try:
+        count_result = await db.execute(count_query)
+        total = count_result.scalar() or 0
+
+        result = await db.execute(
+            base_query.order_by(Pet.created_at.desc()).offset(offset).limit(per_page)
+        )
+        pets = list(result.scalars().all())
+
+        return pets, total
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_pets_with_owners(
+    db: AsyncSession, page: int = 1, per_page: int = 20
+) -> tuple[list[dict[str, object]], int]:
+    """Get all pets with their owner info, paginated."""
+    from github_tamagotchi.models.user import User
+
+    offset = (page - 1) * per_page
+
+    try:
+        count_result = await db.execute(select(func.count()).select_from(Pet))
+        total = count_result.scalar() or 0
+
+        result = await db.execute(
+            select(Pet, User)
+            .outerjoin(User, Pet.user_id == User.id)
+            .order_by(Pet.created_at.desc())
+            .offset(offset)
+            .limit(per_page)
+        )
+        rows = [{"pet": row.Pet, "owner": row.User} for row in result]
+        return rows, total
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_leaderboard(
+    db: AsyncSession, category: str, limit: int = 10
+) -> list[Pet]:
+    """Return top pets for the given leaderboard category, with hourly caching.
+
+    Categories:
+      - "most_experienced": top by experience (XP)
+      - "longest_streak": top by longest_streak
+    """
+    now = datetime.now(UTC)
+    cache_key = f"{category}:{limit}"
+    cached = _leaderboard_cache.get(cache_key)
+    if cached is not None:
+        cached_at, cached_data = cached
+        if (now - cached_at).total_seconds() < _LEADERBOARD_CACHE_TTL_SECONDS:
+            return cached_data
+
+    base_filter = Pet.leaderboard_opt_out.is_(False), Pet.is_dead.is_(False)
+
+    if category == "most_experienced":
+        order_col = Pet.experience.desc()
+    elif category == "longest_streak":
+        order_col = Pet.longest_streak.desc()
+    else:
+        return []
+
+    try:
+        result = await db.execute(
+            select(Pet).where(*base_filter).order_by(order_col).limit(limit)
+        )
+        pets = list(result.scalars().all())
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+    _leaderboard_cache[cache_key] = (now, pets)
+    return pets
+
+
+async def get_pets_by_github_username(
+    db: AsyncSession, username: str, limit: int = 50
+) -> list[Pet]:
+    """Get all pets where repo_owner matches the given GitHub username, ordered by creation date."""
+    try:
+        result = await db.execute(
+            select(Pet)
+            .where(Pet.repo_owner == username)
+            .order_by(Pet.created_at.asc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_org_pets(db: AsyncSession, org_name: str) -> list[Pet]:
+    """Get all pets belonging to an org, case-insensitive, ordered by health desc."""
+    from sqlalchemy import func as sqlfunc
+
+    try:
+        result = await db.execute(
+            select(Pet)
+            .where(sqlfunc.lower(Pet.repo_owner) == org_name.lower())
+            .order_by(Pet.health.desc())
+        )
+        return list(result.scalars().all())
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def delete_pet(db: AsyncSession, pet: Pet) -> None:
+    """Delete a pet."""
+    try:
+        await db.delete(pet)
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def feed_pet(db: AsyncSession, pet: Pet) -> Pet:
+    """Feed a pet to improve its health and mood."""
+    pet.health = min(100, pet.health + 10)
+    pet.last_fed_at = datetime.now(UTC)
+
+    if pet.health >= 80:
+        pet.mood = PetMood.HAPPY.value
+    elif pet.health >= 50:
+        pet.mood = PetMood.CONTENT.value
+
+    try:
+        await db.commit()
+        await db.refresh(pet)
+        return pet
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def select_skin(db: AsyncSession, pet: Pet, skin: PetSkin) -> Pet:
+    """Set the active skin on a pet."""
+    pet.skin = skin.value
+    try:
+        await db.commit()
+        await db.refresh(pet)
+        return pet
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def resurrect_pet(db: AsyncSession, pet: Pet) -> Pet:
+    """Reset a dead pet to egg state and increment generation."""
+    pet.is_dead = False
+    pet.died_at = None
+    pet.cause_of_death = None
+    pet.grace_period_started = None
+    pet.stage = PetStage.EGG.value
+    pet.health = 60
+    pet.experience = 0
+    pet.mood = PetMood.CONTENT.value
+    pet.generation += 1
+    try:
+        await db.commit()
+        await db.refresh(pet)
+        return pet
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def reset_pet(db: AsyncSession, pet: Pet) -> Pet:
+    """Reset all pet stats to initial state and increment generation."""
+    pet.stage = PetStage.EGG.value
+    pet.mood = PetMood.CONTENT.value
+    pet.health = 100
+    pet.experience = 0
+    pet.commit_streak = 0
+    pet.longest_streak = 0
+    pet.last_streak_date = None
+    pet.last_fed_at = None
+    pet.is_dead = False
+    pet.died_at = None
+    pet.cause_of_death = None
+    pet.grace_period_started = None
+    pet.generation = pet.generation + 1
+    try:
+        await db.commit()
+        await db.refresh(pet)
+        return pet
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def update_images_generated_at(db: AsyncSession, repo_owner: str, repo_name: str) -> None:
+    """Stamp the images_generated_at timestamp on a pet."""
+    try:
+        await db.execute(
+            update(Pet)
+            .where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
+            .values(images_generated_at=func.now())
+        )
+        await db.commit()
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def update_canonical_appearance(
+    db: AsyncSession, repo_owner: str, repo_name: str, canonical_appearance: str
+) -> None:
+    """Persist the canonical appearance string for a pet."""
+    try:
+        await db.execute(
+            update(Pet)
+            .where(Pet.repo_owner == repo_owner, Pet.repo_name == repo_name)
+            .values(canonical_appearance=canonical_appearance)
+        )
+        await db.commit()
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_all(db: AsyncSession, limit: int = 10000) -> list[Pet]:
+    """Return all pets up to the given limit."""
+    try:
+        result = await db.execute(select(Pet).limit(limit))
+        return list(result.scalars().all())
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def save(db: AsyncSession, pet: Pet) -> Pet:
+    """Commit pending field changes on a pet and refresh from DB."""
+    try:
+        await db.commit()
+        await db.refresh(pet)
+        return pet
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc

--- a/src/github_tamagotchi/repositories/user.py
+++ b/src/github_tamagotchi/repositories/user.py
@@ -1,0 +1,61 @@
+"""User repository: all User model queries with exception translation."""
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.exceptions import ConflictError, RepositoryError
+from github_tamagotchi.models.user import User
+
+
+async def get_user_by_github_id(db: AsyncSession, github_id: int) -> User | None:
+    """Get a user by their GitHub ID."""
+    try:
+        result = await db.execute(select(User).where(User.github_id == github_id))
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
+    """Get a user by their internal ID."""
+    try:
+        result = await db.execute(select(User).where(User.id == user_id))
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        raise RepositoryError(str(exc)) from exc
+
+
+async def create_or_update_user(
+    db: AsyncSession,
+    *,
+    github_id: int,
+    github_login: str,
+    github_avatar_url: str | None,
+    encrypted_token: str | None,
+) -> User:
+    """Create a new user or update an existing one on login."""
+    try:
+        user = await get_user_by_github_id(db, github_id)
+        if user:
+            user.github_login = github_login
+            user.github_avatar_url = github_avatar_url
+            if encrypted_token is not None:
+                user.encrypted_token = encrypted_token
+        else:
+            user = User(
+                github_id=github_id,
+                github_login=github_login,
+                github_avatar_url=github_avatar_url,
+                encrypted_token=encrypted_token,
+            )
+            db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return user
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(str(exc)) from exc
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise RepositoryError(str(exc)) from exc

--- a/src/github_tamagotchi/schemas/__init__.py
+++ b/src/github_tamagotchi/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Request/response schemas (Pydantic DTOs) for the API."""

--- a/src/github_tamagotchi/schemas/admin.py
+++ b/src/github_tamagotchi/schemas/admin.py
@@ -1,0 +1,40 @@
+"""Admin request/response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PetAdminSettingsUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=20)
+    blame_board_enabled: bool | None = None
+    contributor_badges_enabled: bool | None = None
+    leaderboard_opt_out: bool | None = None
+    hungry_after_days: int | None = Field(None, ge=1, le=30)
+    pr_review_sla_hours: int | None = Field(None, ge=1, le=336)
+    issue_response_sla_days: int | None = Field(None, ge=1, le=90)
+
+
+class ExcludedContributorItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    github_login: str
+    excluded_by: str
+    excluded_at: datetime
+
+
+class PetAdminResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    blame_board_enabled: bool
+    contributor_badges_enabled: bool
+    leaderboard_opt_out: bool
+    hungry_after_days: int
+    pr_review_sla_hours: int
+    issue_response_sla_days: int
+    excluded_contributors: list[ExcludedContributorItem]
+    is_dead: bool
+    generation: int

--- a/src/github_tamagotchi/schemas/info.py
+++ b/src/github_tamagotchi/schemas/info.py
@@ -1,0 +1,91 @@
+"""Pet information request/response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PetCharacteristics(BaseModel):
+    color: str
+    accent_color: str
+    body_type: str
+    feature: str
+
+
+class CommentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    author_name: str
+    body: str
+    created_at: datetime
+
+
+class CommentsListResponse(BaseModel):
+    comments: list[CommentResponse]
+
+
+class CommentCreate(BaseModel):
+    body: str = Field(..., min_length=1, max_length=500)
+
+
+class AchievementItem(BaseModel):
+    id: str
+    name: str
+    icon: str
+    description: str
+    unlocked: bool
+    unlocked_at: datetime | None
+
+
+class AchievementsResponse(BaseModel):
+    achievements: list[AchievementItem]
+
+
+class MilestoneItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    old_stage: str
+    new_stage: str
+    experience: int
+    age_days: int
+    created_at: datetime
+
+
+class MilestonesResponse(BaseModel):
+    milestones: list[MilestoneItem]
+
+
+class ContributorRelationshipItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    github_username: str
+    standing: str
+    score: int
+    last_activity: datetime | None
+    good_deeds: list[str]
+    sins: list[str]
+
+
+class ContributorRelationshipsResponse(BaseModel):
+    contributors: list[ContributorRelationshipItem]
+
+
+class BlameEntryItem(BaseModel):
+    issue: str
+    culprit: str
+    how_long: str
+
+
+class HeroEntryItem(BaseModel):
+    good_deed: str
+    hero: str
+    when: str
+
+
+class BlameBoardResponse(BaseModel):
+    is_healthy: bool
+    blame_board_enabled: bool
+    blame_entries: list[BlameEntryItem]
+    hero_entries: list[HeroEntryItem]

--- a/src/github_tamagotchi/schemas/pets.py
+++ b/src/github_tamagotchi/schemas/pets.py
@@ -1,0 +1,101 @@
+"""Pet request/response schemas."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from github_tamagotchi.services.image_generation import DEFAULT_STYLE
+
+
+class PetCreate(BaseModel):
+    repo_owner: str = Field(..., min_length=1, max_length=255)
+    repo_name: str = Field(..., min_length=1, max_length=255)
+    name: str | None = Field(None, min_length=1, max_length=20)
+    style: str = Field(DEFAULT_STYLE, min_length=1, max_length=30)
+
+
+class PetResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    repo_owner: str
+    repo_name: str
+    name: str
+    stage: str
+    mood: str
+    health: int
+    experience: int
+    skin: str
+    low_health_recoveries: int
+    style: str
+    badge_style: str
+    commit_streak: int
+    longest_streak: int
+    generation: int
+    is_dead: bool
+    died_at: object | None
+    cause_of_death: str | None
+    personality_activity: float | None
+    personality_sociability: float | None
+    personality_bravery: float | None
+    personality_tidiness: float | None
+    personality_appetite: float | None
+    created_at: object
+    updated_at: object
+    last_fed_at: object | None
+    last_checked_at: object | None
+    dependent_count: int
+    grace_period_started: object | None
+
+
+class PetListResponse(BaseModel):
+    items: list[PetResponse]
+    total: int
+    page: int
+    per_page: int
+    pages: int
+
+
+class FeedResponse(BaseModel):
+    message: str
+    pet: PetResponse
+
+
+class RepoItem(BaseModel):
+    full_name: str
+    owner: str
+    name: str
+    description: str | None
+    private: bool
+    has_pet: bool
+    pet_name: str | None
+
+
+class StyleUpdateRequest(BaseModel):
+    style: str = Field(..., min_length=1, max_length=30)
+
+
+class PetRenameRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=20)
+
+
+class BadgeStyleUpdateRequest(BaseModel):
+    badge_style: str = Field(..., min_length=1, max_length=20)
+
+
+class SkinInfo(BaseModel):
+    skin: str
+    unlocked: bool
+    unlock_condition: str
+
+
+class SkinSelectRequest(BaseModel):
+    skin: str = Field(..., min_length=1, max_length=20)
+
+
+class SkinSelectResponse(BaseModel):
+    message: str
+    pet: PetResponse
+
+
+class ImageGenerationResponse(BaseModel):
+    message: str
+    stages: list[str]

--- a/src/github_tamagotchi/schemas/social.py
+++ b/src/github_tamagotchi/schemas/social.py
@@ -1,0 +1,28 @@
+"""Social request/response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LeaderboardEntry(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    rank: int
+    pet_name: str
+    repo_owner: str
+    repo_name: str
+    stage: str
+    value: int
+
+
+class LeaderboardCategory(BaseModel):
+    id: str
+    title: str
+    description: str
+    entries: list[LeaderboardEntry]
+
+
+class LeaderboardResponse(BaseModel):
+    categories: list[LeaderboardCategory]
+    cached_at: datetime

--- a/src/github_tamagotchi/services/pet.py
+++ b/src/github_tamagotchi/services/pet.py
@@ -1,0 +1,129 @@
+"""Pet domain service.
+
+All business operations on pets flow through here.
+Routes call this module; this module calls repositories.
+"""
+
+import math
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.exceptions import ConflictError, NotFoundError
+from github_tamagotchi.models.pet import Pet, PetSkin
+from github_tamagotchi.repositories import pet as pet_repo
+
+
+async def get_or_raise(db: AsyncSession, owner: str, repo: str) -> Pet:
+    """Return the pet for a repo, or raise NotFoundError."""
+    pet = await pet_repo.get_pet_by_repo(db, owner, repo)
+    if pet is None:
+        raise NotFoundError(f"Pet not found for {owner}/{repo}")
+    return pet
+
+
+async def get_by_repo(db: AsyncSession, owner: str, repo: str) -> Pet | None:
+    return await pet_repo.get_pet_by_repo(db, owner, repo)
+
+
+async def get_list(
+    db: AsyncSession, page: int, per_page: int, user_id: int | None = None
+) -> tuple[list[Pet], int]:
+    return await pet_repo.get_pets(db, page=page, per_page=per_page, user_id=user_id)
+
+
+async def get_leaderboard(db: AsyncSession, category: str, limit: int = 10) -> list[Pet]:
+    return await pet_repo.get_leaderboard(db, category, limit=limit)
+
+
+async def get_by_username(db: AsyncSession, username: str, limit: int = 50) -> list[Pet]:
+    return await pet_repo.get_pets_by_github_username(db, username, limit=limit)
+
+
+async def create(
+    db: AsyncSession,
+    owner: str,
+    repo: str,
+    name: str,
+    user_id: int | None,
+    style: str,
+) -> Pet:
+    """Create a pet, raising ConflictError if one already exists for the repo."""
+    existing = await pet_repo.get_pet_by_repo(db, owner, repo)
+    if existing:
+        raise ConflictError(f"Pet already exists for {owner}/{repo}")
+    return await pet_repo.create_pet(db, owner, repo, name, user_id=user_id, style=style)
+
+
+async def delete(db: AsyncSession, pet: Pet) -> None:
+    await pet_repo.delete_pet(db, pet)
+
+
+async def feed(db: AsyncSession, pet: Pet) -> Pet:
+    return await pet_repo.feed_pet(db, pet)
+
+
+async def select_skin(db: AsyncSession, pet: Pet, skin: PetSkin) -> Pet:
+    return await pet_repo.select_skin(db, pet, skin)
+
+
+async def update_style(db: AsyncSession, pet: Pet, style: str) -> Pet:
+    pet.style = style
+    return await pet_repo.save(db, pet)
+
+
+async def rename(db: AsyncSession, pet: Pet, name: str) -> Pet:
+    pet.name = name
+    return await pet_repo.save(db, pet)
+
+
+async def update_badge_style(db: AsyncSession, pet: Pet, badge_style: str) -> Pet:
+    pet.badge_style = badge_style
+    return await pet_repo.save(db, pet)
+
+
+async def resurrect(db: AsyncSession, pet: Pet) -> Pet:
+    """Validate mourning period has elapsed, then resurrect the pet.
+
+    Raises ValueError if the pet is not dead or the mourning period has not elapsed.
+    Raises NotFoundError (via get_or_raise) if the pet doesn't exist.
+    """
+    if not pet.is_dead:
+        raise ValueError("Pet is not dead and cannot be resurrected")
+    if pet.died_at is None:
+        raise ValueError("Pet death timestamp is missing")
+    now = datetime.now(UTC)
+    died_at = pet.died_at
+    if died_at.tzinfo is None:
+        died_at = died_at.replace(tzinfo=UTC)
+    days_elapsed = (now - died_at).total_seconds() / 86400
+    mourning_days = 7
+    if days_elapsed < mourning_days:
+        days_remaining = math.ceil(mourning_days - days_elapsed)
+        day_word = "day" if days_remaining == 1 else "days"
+        raise ValueError(
+            f"Your pet must rest for {days_remaining} more {day_word} before resurrection"
+        )
+    return await pet_repo.resurrect_pet(db, pet)
+
+
+async def reset(db: AsyncSession, pet: Pet) -> Pet:
+    return await pet_repo.reset_pet(db, pet)
+
+
+async def update_images_generated_at(db: AsyncSession, owner: str, repo: str) -> None:
+    await pet_repo.update_images_generated_at(db, owner, repo)
+
+
+async def update_canonical_appearance(
+    db: AsyncSession, owner: str, repo: str, appearance: str
+) -> None:
+    await pet_repo.update_canonical_appearance(db, owner, repo, appearance)
+
+
+async def save(db: AsyncSession, pet: Pet) -> Pet:
+    return await pet_repo.save(db, pet)
+
+
+async def get_all(db: AsyncSession, limit: int = 10000) -> list[Pet]:
+    return await pet_repo.get_all(db, limit=limit)

--- a/tests/api/test_comments.py
+++ b/tests/api/test_comments.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from github_tamagotchi.api.auth import _create_jwt, auth_router
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.models.pet import Base
@@ -20,6 +21,7 @@ def create_comments_test_app() -> FastAPI:
     app.include_router(router)
     app.include_router(auth_router)
     app.dependency_overrides[get_session] = get_test_session
+    register_exception_handlers(app)
     return app
 
 

--- a/tests/api/test_naming_and_customization.py
+++ b/tests/api/test_naming_and_customization.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from github_tamagotchi.api.auth import _create_jwt, auth_router
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.models.pet import Base
@@ -20,6 +21,7 @@ def create_naming_test_app() -> FastAPI:
     app.include_router(router)
     app.include_router(auth_router)
     app.dependency_overrides[get_session] = get_test_session
+    register_exception_handlers(app)
     return app
 
 

--- a/tests/api/test_pet_admin.py
+++ b/tests/api/test_pet_admin.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from github_tamagotchi.api.auth import _create_jwt, auth_router
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.models.pet import Base, Pet
@@ -21,6 +22,7 @@ def create_admin_test_app() -> FastAPI:
     app.include_router(router)
     app.include_router(auth_router)
     app.dependency_overrides[get_session] = get_test_session
+    register_exception_handlers(app)
     return app
 
 

--- a/tests/api/test_resurrect.py
+++ b/tests/api/test_resurrect.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from github_tamagotchi.api.auth import _create_jwt, auth_router
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
 from github_tamagotchi.models.pet import Base, PetMood, PetStage
@@ -22,6 +23,7 @@ def create_resurrect_test_app() -> FastAPI:
     app.include_router(router)
     app.include_router(auth_router)
     app.dependency_overrides[get_session] = get_test_session
+    register_exception_handlers(app)
     return app
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from github_tamagotchi import __version__
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.health import health_router
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
@@ -60,6 +61,9 @@ def create_api_test_app() -> FastAPI:
 
     # Override the database session dependency
     test_app.dependency_overrides[get_session] = get_test_session
+
+    # Register domain exception → HTTP status handlers
+    register_exception_handlers(test_app)
 
     # Add root endpoint (production uses templates, test returns JSON)
     @test_app.get("/")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from github_tamagotchi.api.exception_handlers import register_exception_handlers
 from github_tamagotchi.api.health import health_router
 from github_tamagotchi.api.routes import router
 from github_tamagotchi.core.database import get_session
@@ -41,6 +42,7 @@ def create_e2e_app() -> FastAPI:
     app.include_router(router)
     app.include_router(health_router)
     app.dependency_overrides[get_session] = get_e2e_session
+    register_exception_handlers(app)
     return app
 
 


### PR DESCRIPTION
## Summary

- **`repositories/`** — all SQLAlchemy queries with exception translation: `IntegrityError → ConflictError`, `SQLAlchemyError → RepositoryError`. Database internals never leak to callers.
- **`services/pet.py`** — business logic layer. Routes call services; services call repositories. No route touches a repository directly.
- **`schemas/`** — Pydantic request/response models extracted from route files into `schemas/pets.py`, `schemas/info.py`, `schemas/social.py`, `schemas/admin.py`.
- **`exceptions.py`** — typed domain exception hierarchy (`NotFoundError`, `ConflictError`, `RepositoryError`).
- **`api/exception_handlers.py`** — maps domain exceptions to HTTP status codes (404/409/500) registered on any FastAPI app instance.
- **`crud/` shims** — re-export from `repositories/` for backwards compatibility with `main.py`, `webhook.py`, `mcp/server.py`, and existing tests.

## Test plan

- [x] All 1121 existing tests pass
- [x] `ruff check` passes
- [x] `mypy` passes (no issues in 76 source files)
- [x] Exception handlers registered on test apps so `ConflictError → 409`, `NotFoundError → 404` in tests