### PR TITLE
feat: stricter Pydantic typing across schemas and config

### DIFF
--- a/src/github_tamagotchi/core/config.py
+++ b/src/github_tamagotchi/core/config.py
@@ -1,5 +1,8 @@
 """Application configuration."""
 
+from typing import Literal
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -43,7 +46,7 @@ class Settings(BaseSettings):
 
     # Image generation
     image_generation_enabled: bool = True
-    image_generation_provider: str = "openrouter"  # "openrouter" or "comfyui"
+    image_generation_provider: Literal["openrouter", "comfyui"] = "openrouter"
 
     # OpenRouter
     openrouter_api_key: str | None = None
@@ -62,7 +65,7 @@ class Settings(BaseSettings):
 
     # Server
     host: str = "0.0.0.0"
-    port: int = 8000
+    port: int = Field(default=8000, ge=1, le=65535)
 
     # Admin
     admin_github_logins: list[str] = ["webwiebe"]
@@ -81,6 +84,25 @@ class Settings(BaseSettings):
     alert_dying_pets_pct: float = 0.10
     alert_death_spike_count: int = 5
     alert_check_interval_minutes: int = 5
+
+    @field_validator(
+        "oauth_redirect_uri",
+        "comfyui_url",
+        "base_url",
+        "alert_slack_webhook",
+        "alert_discord_webhook",
+        mode="before",
+    )
+    @classmethod
+    def validate_url_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        from urllib.parse import urlparse
+
+        parsed = urlparse(v)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError(f"Invalid URL format: {v!r}")
+        return v
 
 
 settings = Settings()

--- a/src/github_tamagotchi/schemas/admin.py
+++ b/src/github_tamagotchi/schemas/admin.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class PetAdminSettingsUpdate(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     name: str | None = Field(None, min_length=1, max_length=20)
     blame_board_enabled: bool | None = None
     contributor_badges_enabled: bool | None = None

--- a/src/github_tamagotchi/schemas/pets.py
+++ b/src/github_tamagotchi/schemas/pets.py
@@ -1,11 +1,15 @@
 """Pet request/response schemas."""
 
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from github_tamagotchi.services.image_generation import DEFAULT_STYLE
 
 
 class PetCreate(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     repo_owner: str = Field(..., min_length=1, max_length=255)
     repo_name: str = Field(..., min_length=1, max_length=255)
     name: str | None = Field(None, min_length=1, max_length=20)
@@ -31,19 +35,19 @@ class PetResponse(BaseModel):
     longest_streak: int
     generation: int
     is_dead: bool
-    died_at: object | None
+    died_at: datetime | None
     cause_of_death: str | None
-    personality_activity: float | None
-    personality_sociability: float | None
-    personality_bravery: float | None
-    personality_tidiness: float | None
-    personality_appetite: float | None
-    created_at: object
-    updated_at: object
-    last_fed_at: object | None
-    last_checked_at: object | None
+    personality_activity: float | None = Field(None, ge=0.0, le=1.0)
+    personality_sociability: float | None = Field(None, ge=0.0, le=1.0)
+    personality_bravery: float | None = Field(None, ge=0.0, le=1.0)
+    personality_tidiness: float | None = Field(None, ge=0.0, le=1.0)
+    personality_appetite: float | None = Field(None, ge=0.0, le=1.0)
+    created_at: datetime
+    updated_at: datetime
+    last_fed_at: datetime | None
+    last_checked_at: datetime | None
     dependent_count: int
-    grace_period_started: object | None
+    grace_period_started: datetime | None
 
 
 class PetListResponse(BaseModel):
@@ -70,14 +74,20 @@ class RepoItem(BaseModel):
 
 
 class StyleUpdateRequest(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     style: str = Field(..., min_length=1, max_length=30)
 
 
 class PetRenameRequest(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     name: str = Field(..., min_length=1, max_length=20)
 
 
 class BadgeStyleUpdateRequest(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     badge_style: str = Field(..., min_length=1, max_length=20)
 
 
@@ -88,6 +98,8 @@ class SkinInfo(BaseModel):
 
 
 class SkinSelectRequest(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     skin: str = Field(..., min_length=1, max_length=20)
 
 


### PR DESCRIPTION
## Summary

- **`PetResponse` datetime fields** — replaced 6 `object`/`object | None` fields with `datetime`/`datetime | None`, improving IDE support and OpenAPI docs
- **Personality trait bounds** — `personality_*` fields constrained to `[0.0, 1.0]` via `Field(ge=0.0, le=1.0)`
- **`validate_assignment=True`** — added to all input/request schemas (`PetCreate`, `StyleUpdateRequest`, `PetRenameRequest`, `BadgeStyleUpdateRequest`, `SkinSelectRequest`, `PetAdminSettingsUpdate`)
- **`image_generation_provider`** — typed as `Literal["openrouter", "comfyui"]` instead of `str`, catching invalid values at startup
- **Port constraint** — `port` field constrained to valid TCP range (`ge=1, le=65535`)
- **URL format validation** — `@field_validator` on all URL config fields (`oauth_redirect_uri`, `comfyui_url`, `base_url`, webhook URLs) verifies scheme+netloc without changing field types

## Test plan

- [x] All 1121 existing tests pass
- [x] `ruff check` passes
- [x] `mypy` passes

> Chains off `refactor/repository-pattern` which adds the `schemas/` package.