### PR TITLE
feat: zero-downtime blue-green deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,44 @@ jobs:
           echo "$KUBECONFIG_DATA" > ~/.kube/config
           chmod 600 ~/.kube/config
 
-          # Pin both container and initContainer images to this exact build
           IMAGE="ghcr.io/${{ github.repository }}:${{ github.sha }}"
-          sed -i "s|ghcr.io/${{ github.repository }}:latest|${IMAGE}|g" k8s/deployment.yaml
+          NS="nijmegen-testing"
 
-          kubectl apply -f k8s/deployment.yaml
-          if ! kubectl rollout status deployment/github-tamagotchi-blue -n nijmegen-testing --timeout=900s; then
-            echo "=== POD DESCRIBE ===" && kubectl describe pods -n nijmegen-testing -l app=github-tamagotchi,version=blue
-            echo "=== INIT CONTAINER LOGS ===" && kubectl logs -n nijmegen-testing -l app=github-tamagotchi,version=blue -c migrate --tail=50 2>/dev/null || true
-            echo "=== APP CONTAINER LOGS ===" && kubectl logs -n nijmegen-testing -l app=github-tamagotchi,version=blue -c github-tamagotchi --tail=50 2>/dev/null || true
+          # Determine which color is live
+          ACTIVE=$(kubectl get service github-tamagotchi -n $NS \
+            -o jsonpath='{.spec.selector.version}')
+          if [ "$ACTIVE" = "blue" ]; then INACTIVE="green"; else INACTIVE="blue"; fi
+          echo "Active: $ACTIVE | Deploying to: $INACTIVE"
+
+          # Update the idle deployment's image (container + initContainer)
+          kubectl set image deployment/github-tamagotchi-$INACTIVE \
+            github-tamagotchi=$IMAGE migrate=$IMAGE -n $NS
+
+          # Scale idle deployment up
+          kubectl scale deployment/github-tamagotchi-$INACTIVE --replicas=1 -n $NS
+
+          # Wait for the new deployment to be fully healthy
+          if ! kubectl rollout status deployment/github-tamagotchi-$INACTIVE \
+               -n $NS --timeout=900s; then
+            echo "=== DEPLOY FAILED — traffic stays on $ACTIVE ==="
+            echo "=== POD DESCRIBE ==="
+            kubectl describe pods -n $NS -l app=github-tamagotchi,version=$INACTIVE
+            echo "=== INIT CONTAINER LOGS ==="
+            kubectl logs -n $NS -l app=github-tamagotchi,version=$INACTIVE \
+              -c migrate --tail=50 2>/dev/null || true
+            echo "=== APP CONTAINER LOGS ==="
+            kubectl logs -n $NS -l app=github-tamagotchi,version=$INACTIVE \
+              -c github-tamagotchi --tail=50 2>/dev/null || true
+            kubectl scale deployment/github-tamagotchi-$INACTIVE --replicas=0 -n $NS
             exit 1
           fi
+
+          # Atomic traffic switch
+          kubectl patch service github-tamagotchi -n $NS \
+            --type='json' \
+            -p="[{\"op\":\"replace\",\"path\":\"/spec/selector/version\",\"value\":\"$INACTIVE\"}]"
+          echo "Traffic switched to $INACTIVE"
+
+          # Scale down old deployment
+          kubectl scale deployment/github-tamagotchi-$ACTIVE --replicas=0 -n $NS
+          echo "Scaled down $ACTIVE — deploy complete"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -154,12 +154,12 @@ tasks:
       - ssh deployer@k3s1 "kubectl wait --for=condition=complete job/github-tamagotchi-init-minio -n nijmegen-testing --timeout=60s"
 
   k8s:deploy:
-    desc: Apply all k8s manifests and restart the deployment
+    desc: Apply all k8s manifests and scale up the blue deployment (initial setup)
     cmds:
       - task: k8s:secrets
       - task: k8s:init
       - cat k8s/deployment.yaml | ssh deployer@k3s1 "kubectl apply -f -"
-      - ssh deployer@k3s1 "kubectl rollout restart deployment/github-tamagotchi-blue -n nijmegen-testing"
+      - ssh deployer@k3s1 "kubectl scale deployment/github-tamagotchi-blue --replicas=1 -n nijmegen-testing"
       - ssh deployer@k3s1 "kubectl rollout status deployment/github-tamagotchi-blue -n nijmegen-testing --timeout=120s"
 
   k8s:status:
@@ -168,9 +168,9 @@ tasks:
       - ssh deployer@k3s1 "kubectl get pods -n nijmegen-testing -l app=github-tamagotchi -o wide"
 
   k8s:logs:
-    desc: Tail logs from the running pod
+    desc: Tail logs from the active pod (color detected dynamically)
     cmds:
-      - ssh deployer@k3s1 "kubectl logs -n nijmegen-testing -l app=github-tamagotchi,version=blue --tail=50"
+      - ssh deployer@k3s1 "ACTIVE=\$(kubectl get service github-tamagotchi -n nijmegen-testing -o jsonpath='{.spec.selector.version}'); kubectl logs -n nijmegen-testing -l app=github-tamagotchi,version=\$ACTIVE --tail=50 -f"
 
   # --- Cleanup ---
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   progressDeadlineSeconds: 900
   revisionHistoryLimit: 2
-  replicas: 1
+  # Replicas managed by deploy process — do not set here
+  replicas: 0
   selector:
     matchLabels:
       app: github-tamagotchi
@@ -150,6 +151,7 @@ metadata:
 spec:
   progressDeadlineSeconds: 900
   revisionHistoryLimit: 2
+  # Replicas managed by deploy process — do not set here
   replicas: 0
   selector:
     matchLabels:
@@ -317,4 +319,3 @@ spec:
   tls:
     - hosts:
         - tamagotchi.nijmegen.wiebe.xyz
-      secretName: tamagotchi-tls

--- a/specs/zero-downtime-deployments.md
+++ b/specs/zero-downtime-deployments.md
@@ -1,0 +1,67 @@
+# Zero-Downtime Deployments
+**Status**: Implemented
+**Created**: 2026-04-13
+
+## Overview
+The previous deploy strategy ran `kubectl apply` on the active deployment, causing 30–60 seconds of downtime while the init container ran migrations and the readiness probe passed. This spec describes the blue-green deployment strategy that eliminates that gap: a new image is deployed to the idle slot, brought fully healthy, and then traffic is flipped atomically.
+
+## Goals / Non-Goals
+
+**Goals**:
+- Zero downtime on every deploy (no dropped requests during image rollout)
+- Automatic rollback when the new deployment fails health checks
+- Diagnostics (pod describe + container logs) emitted on failure so root cause is easy to find
+- No external tooling beyond `kubectl` — works with the existing k3s + Traefik setup
+
+**Non-Goals**:
+- Database migration rollback — migrations are forward-only; this strategy does not address schema incompatibility between blue and green versions
+- Canary / traffic splitting — traffic flips 100% atomically
+- Multiple replicas per slot — each color runs at most one pod (sufficient for current traffic)
+
+## How It Works
+
+1. **Detect active color** — query the Service selector: `kubectl get service github-tamagotchi -o jsonpath='{.spec.selector.version}'`. Result is `blue` or `green`; the other is the inactive slot.
+
+2. **Update idle deployment** — use `kubectl set image` to point both the app container (`github-tamagotchi`) and the init container (`migrate`) to the new image SHA. This updates the pod template without scaling anything.
+
+3. **Scale idle deployment up** — `kubectl scale --replicas=1` on the inactive deployment. Kubernetes creates the pod, runs the init container (migrations), then starts the app container and waits for the readiness probe to pass.
+
+4. **Wait for healthy** — `kubectl rollout status --timeout=900s`. The 900-second budget covers slow migrations. The rollout only succeeds once the readiness probe at `/api/v1/health/ready` returns 200.
+
+5. **Atomic traffic switch** — `kubectl patch service` replaces `spec.selector.version` with the new color. Traefik picks up the endpoint change immediately; in-flight requests on the old pod complete normally thanks to the 30-second `terminationGracePeriodSeconds` and the 5-second `preStop` hook.
+
+6. **Scale down old deployment** — `kubectl scale --replicas=0` on the previously active color. The old pod terminates gracefully.
+
+## Failure Handling
+
+If `kubectl rollout status` times out or the pod enters `CrashLoopBackOff`:
+
+1. CI prints a diagnostic block: pod describe, init container logs, app container logs.
+2. CI scales the inactive deployment back to 0 replicas.
+3. CI exits with a non-zero code, failing the workflow — the PR/commit is flagged red.
+4. The Service selector is **never patched**, so traffic continues flowing to the previously active color throughout. There is no user-visible impact.
+
+## Deployment Procedure
+
+### Manual (initial setup / emergency)
+Use `task k8s:deploy` which:
+1. Applies secrets.
+2. Runs init jobs (database + MinIO provisioning).
+3. Applies the manifest (`kubectl apply -f k8s/deployment.yaml`), which is safe because `replicas: 0` in the file does not override the live replica count (the deploy process owns replicas exclusively).
+4. Scales blue to 1 and waits for rollout status (assumes blue is the baseline active color after initial setup).
+
+### Automated (CI on every merge to main)
+The `deploy` job in `.github/workflows/ci.yml`:
+1. Detects the active color from the live Service.
+2. Sets the new image on the inactive deployment.
+3. Scales inactive up and waits for healthy.
+4. Patches the Service selector (atomic flip).
+5. Scales the old deployment down.
+
+## Files
+
+| File | Role |
+|------|------|
+| `k8s/deployment.yaml` | Defines both blue and green Deployments (replicas: 0 — managed by deploy process), the Service, and the Ingress |
+| `.github/workflows/ci.yml` | `deploy` job implements the blue-green swap logic |
+| `Taskfile.yml` | `k8s:deploy` task for manual deploys; `k8s:logs` queries the active color dynamically |

--- a/specs/zero-downtime-deployments.md
+++ b/specs/zero-downtime-deployments.md
@@ -47,8 +47,10 @@ If `kubectl rollout status` times out or the pod enters `CrashLoopBackOff`:
 Use `task k8s:deploy` which:
 1. Applies secrets.
 2. Runs init jobs (database + MinIO provisioning).
-3. Applies the manifest (`kubectl apply -f k8s/deployment.yaml`), which is safe because `replicas: 0` in the file does not override the live replica count (the deploy process owns replicas exclusively).
+3. Applies the manifest (`kubectl apply -f k8s/deployment.yaml`). **Warning:** `kubectl apply` respects the `replicas: 0` values in the file and will scale both deployments to 0, taking down any running pods. Step 4 immediately restores service.
 4. Scales blue to 1 and waits for rollout status (assumes blue is the baseline active color after initial setup).
+
+**Do not run `kubectl apply -f k8s/deployment.yaml` directly** while a deployment is live — use `task k8s:deploy` which handles the re-scale, or scope the apply to a specific resource (e.g. `kubectl apply -f k8s/deployment.yaml --dry-run=server` to preview).
 
 ### Automated (CI on every merge to main)
 The `deploy` job in `.github/workflows/ci.yml`:
@@ -57,6 +59,27 @@ The `deploy` job in `.github/workflows/ci.yml`:
 3. Scales inactive up and waits for healthy.
 4. Patches the Service selector (atomic flip).
 5. Scales the old deployment down.
+
+## Known Pitfalls
+
+### TLS certificate configuration
+The Ingress uses Traefik's built-in ACME via the annotation:
+```yaml
+traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt
+```
+Traefik stores the cert in its own internal store — it does **not** write to a Kubernetes Secret. The `tls.secretName` field in the Ingress spec must be absent. If `secretName` is set, Traefik looks for a k8s Secret that doesn't exist and stops serving HTTPS, causing site-wide 503s. The correct TLS block is:
+```yaml
+tls:
+  - hosts:
+      - tamagotchi.nijmegen.wiebe.xyz
+```
+No `secretName`.
+
+### `kubectl apply` resets replicas
+The `replicas: 0` values in `k8s/deployment.yaml` are what the API server will enforce when `kubectl apply` runs. Applying the file while pods are live will immediately terminate them. Always use `task k8s:deploy` for manual deploys, which re-scales blue to 1 after applying.
+
+### Migrations run on the new slot only
+The init container runs `alembic upgrade head` before the app starts. Schema changes are applied to the database while the old slot is still serving traffic. Migrations must therefore be backwards-compatible with the currently-running code (i.e. additive-only, no column drops or renames until the old slot is gone).
 
 ## Files
 


### PR DESCRIPTION
## What

Replaces the current deploy strategy (kubectl apply + rollout restart on blue) with a proper blue-green swap that produces zero downtime on every deploy.

Also fixes a pre-existing TLS misconfiguration that was causing 503s on the live site: the Ingress had \`secretName: tamagotchi-tls\` in its TLS block, but Traefik's built-in ACME certresolver doesn't write to k8s secrets. Removing the \`secretName\` lets Traefik handle the cert exclusively via the \`certresolver\` annotation.

## Why

The old approach replaced the active pod in-place. During the ~30–60s window while the init container ran migrations and the readiness probe passed, the service had no healthy backends. The new strategy keeps the active color fully live until the inactive slot is confirmed healthy, then flips traffic atomically.

## Changes

**\`k8s/deployment.yaml\`**
- Remove \`secretName: tamagotchi-tls\` from Ingress TLS block (fixes live 503)
- Both deployments set to \`replicas: 0\` with comment — replicas are now exclusively managed by the deploy process, so \`kubectl apply\` is safe to run without accidentally killing live pods

**\`.github/workflows/ci.yml\`**
- Deploy step rewritten: detect active color → \`kubectl set image\` on idle → scale up → wait for health → \`kubectl patch service\` → scale old down
- Failure path: scale idle back to 0, emit diagnostics, exit 1 (traffic stays on active)
- Removes the \`sed\` image-pin hack

**\`Taskfile.yml\`**
- \`k8s:deploy\`: apply manifest + scale blue to 1 (replaces rollout restart)
- \`k8s:logs\`: dynamically reads active color instead of hardcoding blue

**\`specs/zero-downtime-deployments.md\`** — spec documenting the mechanism

## Test plan
- [ ] CI lint/test/e2e green on this PR
- [ ] Deploy step logic manually verified against cluster (deploy step only runs on main)
- [ ] Site confirmed reachable after TLS fix applied to cluster