### PR TITLE
feat: add BugBarn alongside Sentry for error tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Deploy to k3s
         env:
           KUBECONFIG_DATA: ${{ secrets.KUBECONFIG }}
+          BUGBARN_API_KEY: ${{ secrets.BUGBARN_API_KEY_TESTING }}
         run: |
           mkdir -p ~/.kube
           echo "$KUBECONFIG_DATA" > ~/.kube/config
@@ -115,6 +116,11 @@ jobs:
 
           IMAGE="ghcr.io/${{ github.repository }}:${{ github.sha }}"
           NS="nijmegen-testing"
+
+          # Inject BugBarn API key into the k8s secret
+          kubectl patch secret github-tamagotchi-secrets -n $NS \
+            --type='merge' \
+            -p="{\"stringData\":{\"bugbarn-api-key\":\"$BUGBARN_API_KEY\"}}"
 
           # Determine which color is live
           ACTIVE=$(kubectl get service github-tamagotchi -n $NS \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install uv for fast dependency management
+# Install git (needed for git+ dependencies) and uv
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 RUN pip install uv
 
 # Copy all source files needed for build

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -114,6 +114,13 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: sentry-dsn
+            - name: BUGBARN_ENDPOINT
+              value: "https://bugbarn.test.wiebe.xyz"
+            - name: BUGBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: github-tamagotchi-secrets
+                  key: bugbarn-api-key
           resources:
             requests:
               memory: "128Mi"
@@ -256,6 +263,13 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: sentry-dsn
+            - name: BUGBARN_ENDPOINT
+              value: "https://bugbarn.test.wiebe.xyz"
+            - name: BUGBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: github-tamagotchi-secrets
+                  key: bugbarn-api-key
           resources:
             requests:
               memory: "128Mi"

--- a/k8s/secrets.yaml.example
+++ b/k8s/secrets.yaml.example
@@ -10,3 +10,4 @@ stringData:
   openrouter-api-key: "sk-or-v1-xxxxxxxxxxxxxxxxxxxx"
   minio-access-key: "your-minio-access-key"
   minio-secret-key: "your-minio-secret-key"
+  bugbarn-api-key: "your-bugbarn-api-key"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "cryptography>=42.0.0",
     "Pillow>=10.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
-    "bugbarn>=0.1.0",
+    "bugbarn-python @ git+https://github.com/webwiebe/bugbarn.git#subdirectory=sdks/python",
     "prometheus-client>=0.24.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "cryptography>=42.0.0",
     "Pillow>=10.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
+    "bugbarn>=0.1.0",
     "prometheus-client>=0.24.1",
 ]
 
@@ -62,6 +63,10 @@ warn_required_dynamic_aliases = true
 
 [[tool.mypy.overrides]]
 module = ["apscheduler.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["bugbarn"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/github_tamagotchi/core/config.py
+++ b/src/github_tamagotchi/core/config.py
@@ -73,6 +73,10 @@ class Settings(BaseSettings):
     # Sentry
     sentry_dsn: str | None = None
 
+    # BugBarn
+    bugbarn_endpoint: str | None = None
+    bugbarn_api_key: str | None = None
+
     # Alerting
     alerting_enabled: bool = True
     alert_slack_webhook: str | None = None
@@ -91,6 +95,7 @@ class Settings(BaseSettings):
         "base_url",
         "alert_slack_webhook",
         "alert_discord_webhook",
+        "bugbarn_endpoint",
         mode="before",
     )
     @classmethod

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated
 
+import bugbarn
 import sentry_sdk
 import structlog
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request
@@ -427,6 +428,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
         logger.info("Sentry initialized")
 
+    if settings.bugbarn_endpoint and settings.bugbarn_api_key:
+        bugbarn.init(
+            endpoint=settings.bugbarn_endpoint,
+            api_key=settings.bugbarn_api_key,
+            release=__version__,
+            environment=os.getenv("ENVIRONMENT", "production"),
+        )
+        logger.info("BugBarn initialized")
+
     set_start_time()
 
     # Start scheduler for periodic polling
@@ -488,6 +498,16 @@ app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="stat
 
 
 register_exception_handlers(app)
+
+
+@app.middleware("http")
+async def bugbarn_middleware(request: Request, call_next: object) -> Response:
+    """Forward unhandled exceptions to BugBarn; Sentry's middleware handles it upstream."""
+    try:
+        return await call_next(request)  # type: ignore[operator]
+    except Exception as exc:
+        bugbarn.capture_exception(exc)
+        raise
 
 
 @app.middleware("http")

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -504,7 +504,7 @@ register_exception_handlers(app)
 async def bugbarn_middleware(request: Request, call_next: object) -> Response:
     """Forward unhandled exceptions to BugBarn; Sentry's middleware handles it upstream."""
     try:
-        return await call_next(request)  # type: ignore[operator]
+        return await call_next(request)  # type: ignore[operator,no-any-return]
     except Exception as exc:
         bugbarn.capture_exception(exc)
         raise


### PR DESCRIPTION
## Summary
- Adds `bugbarn` as a parallel error tracker alongside the existing Sentry integration
- Both trackers receive the same exceptions; Sentry is untouched
- BugBarn is only initialised when `BUGBARN_ENDPOINT` and `BUGBARN_API_KEY` are set

## Changes
- `pyproject.toml`: Added `bugbarn>=0.1.0` dependency and mypy override for missing stubs
- `core/config.py`: Added `bugbarn_endpoint` and `bugbarn_api_key` settings (with URL validation on endpoint)
- `main.py`: BugBarn init in `lifespan` alongside Sentry; `bugbarn_middleware` captures unhandled exceptions
- `k8s/deployment.yaml`: Added `BUGBARN_ENDPOINT` (`https://bugbarn.test.wiebe.xyz`) and `BUGBARN_API_KEY` env vars to both blue/green deployments
- `k8s/secrets.yaml.example`: Added `bugbarn-api-key` field
- `.github/workflows/ci.yml`: Deploy step patches the k8s secret with `BUGBARN_API_KEY_TESTING` before rolling out

## Testing
- [ ] All tests pass
- [ ] Ruff lint passes
- [ ] After deploy: trigger a test exception and verify it appears in both Sentry and the BugBarn dashboard

## Notes
The `bugbarn` package is not yet published to PyPI — CI will fail on `install dependencies` until the package is available. The mypy override suppresses the missing-stubs error in the meantime.

Closes #191