### PR TITLE
fix: ruff import ordering in media.py

### DIFF
--- a/src/github_tamagotchi/api/routes/v1/pets/media.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/media.py
@@ -3,7 +3,6 @@
 from typing import Annotated
 
 import structlog
-
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
Fix import block ordering after switching from stdlib logging to structlog.