### PR TITLE
fix: always refresh ghcr-secret with current token on deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -85,11 +85,12 @@ jobs:
 
           kubectl apply -f k8s/staging/ingress.yaml
 
-          # Ensure ghcr-secret exists (copy from nijmegen-testing if needed)
-          kubectl get secret ghcr-secret -n $NS 2>/dev/null || \
-            kubectl get secret ghcr-secret -n nijmegen-testing -o json \
-              | jq '.metadata.namespace = "nijmegen-staging" | del(.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp)' \
-              | kubectl apply -f -
+          # Recreate ghcr-secret with current workflow token (ephemeral tokens expire)
+          kubectl create secret docker-registry ghcr-secret -n $NS \
+            --docker-server=ghcr.io \
+            --docker-username=${{ github.actor }} \
+            --docker-password=${{ secrets.GITHUB_TOKEN }} \
+            --dry-run=client -o yaml | kubectl apply -f -
 
           # Ensure secrets exist and inject all values from CI secrets
           kubectl get secret github-tamagotchi-secrets -n $NS 2>/dev/null || \

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -121,12 +121,12 @@ jobs:
           kubectl apply -f k8s/production/deployment.yaml
           kubectl apply -f k8s/production/ingress.yaml
 
-          # Ensure ghcr-secret exists for image pulls
-          kubectl get secret ghcr-secret -n $NS 2>/dev/null || \
-            kubectl create secret docker-registry ghcr-secret -n $NS \
-              --docker-server=ghcr.io \
-              --docker-username=${{ github.actor }} \
-              --docker-password=${{ secrets.GITHUB_TOKEN }}
+          # Recreate ghcr-secret with current workflow token (ephemeral tokens expire)
+          kubectl create secret docker-registry ghcr-secret -n $NS \
+            --docker-server=ghcr.io \
+            --docker-username=${{ github.actor }} \
+            --docker-password=${{ secrets.GITHUB_TOKEN }} \
+            --dry-run=client -o yaml | kubectl apply -f -
 
           # Ensure app secrets exist
           kubectl get secret github-tamagotchi-secrets -n $NS 2>/dev/null || \


### PR DESCRIPTION
## Summary
- Always recreate ghcr-secret using `--dry-run=client -o yaml | kubectl apply -f -` instead of only creating if missing
- Fixes 403 Forbidden on image pull when pods land on nodes without cached images (the ephemeral GITHUB_TOKEN in the old secret was expired)
- Applied to both staging and production workflows

## Test plan
- Re-trigger production promotion and verify green pod pulls image successfully