### PR TITLE
fix: pin production pods to layer7-prod node

### DIFF
--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app: github-tamagotchi
         version: blue
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: layer7-prod
       imagePullSecrets:
         - name: ghcr-secret
       hostAliases:
@@ -182,6 +184,8 @@ spec:
         app: github-tamagotchi
         version: green
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: layer7-prod
       imagePullSecrets:
         - name: ghcr-secret
       hostAliases:


### PR DESCRIPTION
## Summary
- Add `nodeSelector: kubernetes.io/hostname: layer7-prod` to both blue and green production deployments
- k3s2 worker node has broken DNS resolution for cluster services — pods there fail with `socket.gaierror: Name or service not known` on DB connect
- This ensures pods land on layer7-prod where DNS, DB, and MinIO are all reachable

## Test plan
- Re-trigger production promotion and verify green pod starts on layer7-prod