### PR TITLE
fix: correct nodeSelector to k3s1 (production cluster)

### DIFF
--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         version: blue
     spec:
       nodeSelector:
-        kubernetes.io/hostname: layer7-prod
+        kubernetes.io/hostname: k3s1
       imagePullSecrets:
         - name: ghcr-secret
       hostAliases:
@@ -185,7 +185,7 @@ spec:
         version: green
     spec:
       nodeSelector:
-        kubernetes.io/hostname: layer7-prod
+        kubernetes.io/hostname: k3s1
       imagePullSecrets:
         - name: ghcr-secret
       hostAliases:


### PR DESCRIPTION
## Summary
- Fix nodeSelector from `layer7-prod` to `k3s1` — the production KUBECONFIG points to a separate k3s cluster with nodes k3s1/k3s2
- k3s2 has broken DNS for cluster services; k3s1 (control-plane) works correctly
- Previous deploy failed with `FailedScheduling: 0/2 nodes matched selector`