### PR TITLE
fix: target production deploy to layer7 cluster

### DIFF
--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         version: blue
     spec:
       nodeSelector:
-        kubernetes.io/hostname: k3s1
+        kubernetes.io/hostname: layer7-prod
       imagePullSecrets:
         - name: ghcr-secret
       hostAliases:
@@ -185,7 +185,7 @@ spec:
         version: green
     spec:
       nodeSelector:
-        kubernetes.io/hostname: k3s1
+        kubernetes.io/hostname: layer7-prod
       imagePullSecrets:
         - name: ghcr-secret
       hostAliases:


### PR DESCRIPTION
## Summary
- Revert nodeSelector to `layer7-prod` — production runs on layer7, not k3s1
- Updated `KUBECONFIG_PROD` secret to point to layer7's k3s API
- Updated `PROD_DATABASE_URL` back to cluster-internal `postgresql.nijmegen-prod.svc.cluster.local`
- Cleaned up accidental `tamagotchi-production` namespace on k3s1