### PR TITLE
fix: strip whitespace from Fernet encryption key

### DIFF
--- a/src/github_tamagotchi/core/config.py
+++ b/src/github_tamagotchi/core/config.py
@@ -96,6 +96,26 @@ class Settings(BaseSettings):
     vapid_public_key: str | None = None   # base64url-encoded uncompressed EC public key
     vapid_contact_email: str = "admin@example.com"
 
+    @field_validator("token_encryption_key", mode="before")
+    @classmethod
+    def validate_token_encryption_key(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        import base64
+
+        v = v.strip()
+        try:
+            decoded = base64.urlsafe_b64decode(v)
+        except Exception as exc:
+            raise ValueError(
+                "token_encryption_key must be a url-safe base64 string"
+            ) from exc
+        if len(decoded) != 32:
+            raise ValueError(
+                f"token_encryption_key must decode to 32 bytes, got {len(decoded)}"
+            )
+        return v
+
     @field_validator(
         "oauth_redirect_uri",
         "comfyui_url",

--- a/src/github_tamagotchi/services/token_encryption.py
+++ b/src/github_tamagotchi/services/token_encryption.py
@@ -10,7 +10,7 @@ def _get_fernet() -> Fernet:
     key = settings.token_encryption_key
     if not key:
         raise ValueError("token_encryption_key is not configured")
-    return Fernet(key.encode())
+    return Fernet(key.strip().encode())
 
 
 def encrypt_token(token: str) -> str:

--- a/tests/unit/test_token_encryption.py
+++ b/tests/unit/test_token_encryption.py
@@ -30,6 +30,15 @@ class TestTokenEncryption:
             with pytest.raises(ValueError, match="token_encryption_key"):
                 encrypt_token("some-token")
 
+    def test_key_with_whitespace_works(self) -> None:
+        with patch("github_tamagotchi.services.token_encryption.settings") as mock_settings:
+            mock_settings.token_encryption_key = f"  {self.key}\n"
+            original = "ghp_whitespace_test"
+            encrypted = encrypt_token(original)
+        with patch("github_tamagotchi.services.token_encryption.settings") as mock_settings:
+            mock_settings.token_encryption_key = self.key
+            assert decrypt_token(encrypted) == original
+
     def test_decrypt_with_wrong_key_raises(self) -> None:
         with patch("github_tamagotchi.services.token_encryption.settings") as mock_settings:
             mock_settings.token_encryption_key = self.key


### PR DESCRIPTION
## Summary
- Fixes `ValueError: Fernet key must be 32 url-safe base64-encoded bytes` in production OAuth callback
- Root cause: k8s secret mounting introduces trailing newline to `TOKEN_ENCRYPTION_KEY`
- Added `.strip()` in `_get_fernet()` and a startup validator on the settings class to fail fast on misconfigured keys

## Changes
- `src/github_tamagotchi/services/token_encryption.py` — strip whitespace from key before use
- `src/github_tamagotchi/core/config.py` — add `field_validator` that validates key format at startup
- `tests/unit/test_token_encryption.py` — add test for whitespace-padded keys

## Testing
- [x] All unit tests pass
- [x] Config validator tested with None, valid key, padded key, and invalid key
- [x] Lint passes

BugBarn: issue-000032