### PR TITLE
fix: production domain and MinIO endpoint

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -113,6 +113,8 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: token-encryption-key
+            - name: BASE_URL
+              value: "https://tamagotchi.nijmegen.wiebe.xyz"
             - name: OAUTH_REDIRECT_URI
               value: "https://tamagotchi.nijmegen.wiebe.xyz/auth/callback"
             - name: SENTRY_DSN
@@ -278,6 +280,8 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: token-encryption-key
+            - name: BASE_URL
+              value: "https://tamagotchi.nijmegen.wiebe.xyz"
             - name: OAUTH_REDIRECT_URI
               value: "https://tamagotchi.nijmegen.wiebe.xyz/auth/callback"
             - name: SENTRY_DSN

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -77,7 +77,9 @@ spec:
             - name: OPENROUTER_MODEL
               value: "google/gemini-2.5-flash-image"
             - name: MINIO_ENDPOINT
-              value: "minio.nijmegen-prod.svc.cluster.local:9000"
+              value: "s3.wiebe.xyz"
+            - name: MINIO_SECURE
+              value: "true"
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -90,8 +92,6 @@ spec:
                   key: minio-secret-key
             - name: MINIO_BUCKET
               value: "tamagotchi-production"
-            - name: MINIO_SECURE
-              value: "false"
             - name: GITHUB_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -112,6 +112,8 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: token-encryption-key
+            - name: BASE_URL
+              value: "https://tamagotchi.webwiebe.nl"
             - name: OAUTH_REDIRECT_URI
               value: "https://tamagotchi.webwiebe.nl/auth/callback"
             - name: SENTRY_DSN
@@ -241,7 +243,9 @@ spec:
             - name: OPENROUTER_MODEL
               value: "google/gemini-2.5-flash-image"
             - name: MINIO_ENDPOINT
-              value: "minio.nijmegen-prod.svc.cluster.local:9000"
+              value: "s3.wiebe.xyz"
+            - name: MINIO_SECURE
+              value: "true"
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -254,8 +258,6 @@ spec:
                   key: minio-secret-key
             - name: MINIO_BUCKET
               value: "tamagotchi-production"
-            - name: MINIO_SECURE
-              value: "false"
             - name: GITHUB_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -276,6 +278,8 @@ spec:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: token-encryption-key
+            - name: BASE_URL
+              value: "https://tamagotchi.webwiebe.nl"
             - name: OAUTH_REDIRECT_URI
               value: "https://tamagotchi.webwiebe.nl/auth/callback"
             - name: SENTRY_DSN

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -741,9 +741,9 @@ async def register_complete_page(
     """Success page shown after pet registration with embed code."""
     if not user:
         return RedirectResponse(url="/auth/github", status_code=302)
-    base_url = str(request.base_url).rstrip("/")
-    embed_image_url = f"{base_url}/api/v1/pets/{owner}/{repo}/badge.svg"
-    pet_page_url = f"{base_url}/pet/{owner}/{repo}"
+    base = settings.base_url.rstrip("/")
+    embed_image_url = f"{base}/api/v1/pets/{owner}/{repo}/badge.svg"
+    pet_page_url = f"{base}/pet/{owner}/{repo}"
     embed_code = f"[![{pet_name}]({embed_image_url})]({pet_page_url})"
     return templates.TemplateResponse(
         request,


### PR DESCRIPTION
## Summary
- Use `settings.base_url` for embed code URLs (fixes wrong domain in README instructions)
- Add `BASE_URL=https://tamagotchi.webwiebe.nl` env var to production deployment
- Fix MinIO endpoint from internal DNS (`minio.nijmegen-prod.svc.cluster.local`) to external `s3.wiebe.xyz` with TLS (production runs on layer7, can't reach nijmegen cluster)
- Set `PROD_MINIO_ACCESS_KEY` and `PROD_MINIO_SECRET_KEY` GitHub Actions secrets

## Test plan
- [ ] Merge and promote to production
- [ ] Re-login and register a pet — embed code should show `tamagotchi.webwiebe.nl`
- [ ] Pet image should load from MinIO (no more InvalidAccessKeyId errors)