### PR TITLE
fix: sprite sheet display issues

### DIFF
--- a/src/github_tamagotchi/api/routes/v1/pets/media.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/media.py
@@ -290,6 +290,45 @@ async def get_pet_animated_gif(
     )
 
 
+@router.get(
+    "/pets/{repo_owner}/{repo_name}/image/{stage}/frame/{frame_index}",
+    responses={
+        200: {"content": {"image/png": {}}, "description": "Individual sprite frame"},
+        404: {"description": "Frame not found"},
+    },
+)
+async def get_pet_frame(
+    repo_owner: str,
+    repo_name: str,
+    stage: str,
+    frame_index: int,
+    storage: StorageDep,
+) -> Response:
+    """Get an individual frame from a pet's sprite sheet."""
+    valid_stages = [s.value for s in PetStage]
+    if stage not in valid_stages:
+        raise HTTPException(status_code=400, detail=f"Invalid stage. Must be one of: {', '.join(valid_stages)}")
+    if frame_index < 0 or frame_index > 5:
+        raise HTTPException(status_code=400, detail="frame_index must be 0-5")
+    if not _api_routes.settings.minio_endpoint:
+        raise HTTPException(status_code=503, detail="Image storage not configured")
+
+    try:
+        frame_data = await storage.get_frame(repo_owner, repo_name, stage, frame_index)
+    except Exception as e:
+        logger.error("Failed to get frame from storage: %s", e)
+        raise HTTPException(status_code=503, detail="Storage service unavailable") from None
+
+    if not frame_data:
+        raise HTTPException(status_code=404, detail="Frame not found")
+
+    return Response(
+        content=frame_data,
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
 @router.post(
     "/pets/{repo_owner}/{repo_name}/generate-images",
     response_model=ImageGenerationResponse,

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -1395,10 +1395,12 @@ async def admin_sprites(
     )
     pets = pets_result.scalars().all()
     stages = [s.value for s in PetStage]
+    from github_tamagotchi.services.sprite_sheet import SPRITE_FRAMES
+    frame_names = [name for _, name, _ in SPRITE_FRAMES]
     return templates.TemplateResponse(
         request,
         "admin_sprites.html",
-        {"user": user, "pets": pets, "stages": stages},
+        {"user": user, "pets": pets, "stages": stages, "frame_names": frame_names},
     )
 
 

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -131,7 +131,8 @@ def build_sprite_sheet_prompt(
 
     negative = (
         style_def.get("negative", NEGATIVE_PROMPT)
-        + ", multiple different characters, text labels, cut off frames, "
+        + ", multiple different characters, text labels, numbers, digits, numerals, "
+        "annotations, grid lines, cell borders, cut off frames, "
         "misaligned grid, inconsistent character design"
     )
 

--- a/src/github_tamagotchi/templates/admin_sprites.html
+++ b/src/github_tamagotchi/templates/admin_sprites.html
@@ -61,27 +61,32 @@
                         </div>
                     </div>
 
-                    <!-- Full sprite sheet row -->
-                    <div style="display: flex; gap: 0.75rem; overflow-x: auto; padding-bottom: 0.25rem;">
-                        {% for stage in stages %}
-                        <div style="display: flex; flex-direction: column; align-items: center; gap: 0.4rem; min-width: 80px;">
-                            <div style="background: var(--surface-light); border-radius: 6px; overflow: hidden;
-                                        width: 80px; height: 80px; display: flex; align-items: center; justify-content: center;">
-                                <img
-                                    src="/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ stage }}"
-                                    alt="{{ stage }}"
-                                    style="max-width: 100%; max-height: 100%; object-fit: contain; display: block;"
-                                    onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
-                                />
-                                <span style="display:none; color: var(--text-muted); font-size: 0.7rem; text-align: center;">—</span>
-                            </div>
-                            <span style="font-size: 0.75rem; color: var(--text-muted);
-                                         {% if pet.stage == stage %}font-weight: 600; color: var(--primary);{% endif %}">
-                                {{ stage }}
-                            </span>
+                    <!-- Stages with all frames -->
+                    {% for stage in stages %}
+                    <div style="margin-bottom: 1rem;">
+                        <div style="font-size: 0.8rem; font-weight: 600; margin-bottom: 0.4rem;
+                                    {% if pet.stage == stage %}color: var(--primary);{% else %}color: var(--text-muted);{% endif %}">
+                            {{ stage }}
                         </div>
-                        {% endfor %}
+                        <div style="display: flex; gap: 0.5rem; overflow-x: auto; padding-bottom: 0.25rem;">
+                            {% for frame_name in frame_names %}
+                            <div style="display: flex; flex-direction: column; align-items: center; gap: 0.25rem; min-width: 64px;">
+                                <div style="background: var(--surface-light); border-radius: 6px; overflow: hidden;
+                                            width: 64px; height: 64px; display: flex; align-items: center; justify-content: center;">
+                                    <img
+                                        src="/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ stage }}/frame/{{ loop.index0 }}"
+                                        alt="{{ stage }} {{ frame_name }}"
+                                        style="max-width: 100%; max-height: 100%; object-fit: contain; display: block; image-rendering: pixelated;"
+                                        onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
+                                    />
+                                    <span style="display:none; color: var(--text-muted); font-size: 0.6rem; text-align: center;">—</span>
+                                </div>
+                                <span style="font-size: 0.65rem; color: var(--text-muted);">{{ frame_name }}</span>
+                            </div>
+                            {% endfor %}
+                        </div>
                     </div>
+                    {% endfor %}
                 </div>
                 {% endfor %}
             </div>

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -86,14 +86,14 @@
                     {% if pet.is_dead %}
                     <div class="pet-emoji-fallback" style="display:flex; font-size: 4rem;">&#129680;</div>
                     {% else %}
-                    <img
-                        src="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}"
-                        data-animated="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}/animated"
-                        alt="{{ pet.name }}"
+                    <div
                         class="profile-sprite"
                         id="profile-pet"
-                        onerror="this.style.display='none'; document.getElementById('pet-emoji-fallback').style.display='flex'; this.onerror=null;"
-                    >
+                        role="img"
+                        aria-label="{{ pet.name }}"
+                        data-sprite-url="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}"
+                        data-animated="/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/image/{{ pet.stage }}/animated"
+                    ></div>
                     <div id="pet-emoji-fallback" class="pet-emoji-fallback" style="display:none;">&#128049;</div>
                     <div class="pet-shadow"></div>
                     <div class="status-badge mood-{{ pet.mood }}">{{ pet.mood | capitalize }}</div>
@@ -449,9 +449,26 @@
     </footer>
 
     <script>
-        // Bounce animation
+        // Sprite sheet cutout: show only the idle frame (top-left cell of 3x2 grid)
         const pet = document.getElementById('profile-pet');
         if (pet) {
+            const spriteUrl = pet.dataset.spriteUrl;
+            if (spriteUrl) {
+                const spriteImg = new Image();
+                spriteImg.onload = function () {
+                    pet.style.backgroundImage = 'url(' + spriteUrl + ')';
+                    pet.style.backgroundSize = '300% 200%';
+                    pet.style.backgroundPosition = '0% 0%';
+                    pet.style.backgroundRepeat = 'no-repeat';
+                    pet.style.imageRendering = 'pixelated';
+                };
+                spriteImg.onerror = function () {
+                    pet.style.display = 'none';
+                    document.getElementById('pet-emoji-fallback').style.display = 'flex';
+                };
+                spriteImg.src = spriteUrl;
+            }
+
             function animatePet() {
                 pet.classList.add('bounce');
                 setTimeout(() => pet.classList.remove('bounce'), 500);
@@ -459,10 +476,14 @@
             }
             animatePet();
 
-            // Lazy-swap to animated GIF once loaded; static image is already shown
+            // Lazy-swap to animated GIF once loaded
             if (pet.dataset.animated) {
                 const animImg = new Image();
-                animImg.onload = function () { pet.src = animImg.src; };
+                animImg.onload = function () {
+                    pet.style.backgroundImage = 'url(' + animImg.src + ')';
+                    pet.style.backgroundSize = 'contain';
+                    pet.style.backgroundPosition = 'center';
+                };
                 animImg.src = pet.dataset.animated;
             }
         }


### PR DESCRIPTION
## Summary
- **Pet profile page**: Uses CSS background-position to show only the idle frame (top-left cell) from the 3x2 sprite sheet, eliminating grid lines and neighboring sprites bleeding through
- **Admin sprites page**: Now shows all 6 frames (idle, blink, happy, sad, sick, sleeping) per stage per pet, via a new individual frame endpoint
- **Image generation prompt**: Strengthened negative prompt to prevent numbers, digits, grid lines, and annotations from appearing in generated sprite sheets

## Test plan
- [ ] Visit pet profile page — should show a clean single frame, no grid lines
- [ ] Animated GIF still loads after a moment and replaces the static frame
- [ ] Admin /admin/sprites shows all 6 frames per stage with labels
- [ ] Regenerate a pet's sprites — new images should not contain numbers or grid lines