### PR TITLE
fix: use internal MinIO endpoint and prefer GHCR PAT

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -86,11 +86,12 @@ jobs:
 
           kubectl apply -f k8s/staging/ingress.yaml
 
-          # Recreate ghcr-secret with current workflow token (ephemeral tokens expire)
+          # Recreate ghcr-secret (prefer long-lived PAT over ephemeral workflow token)
+          GHCR_TOKEN="${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}"
           kubectl create secret docker-registry ghcr-secret -n $NS \
             --docker-server=ghcr.io \
             --docker-username=${{ github.actor }} \
-            --docker-password=${{ secrets.GITHUB_TOKEN }} \
+            --docker-password="$GHCR_TOKEN" \
             --dry-run=client -o yaml | kubectl apply -f -
 
           # Ensure secrets exist and inject all values from CI secrets

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -123,11 +123,12 @@ jobs:
           kubectl apply -f k8s/production/deployment.yaml
           kubectl apply -f k8s/production/ingress.yaml
 
-          # Recreate ghcr-secret with current workflow token (ephemeral tokens expire)
+          # Recreate ghcr-secret (prefer long-lived PAT over ephemeral workflow token)
+          GHCR_TOKEN="${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}"
           kubectl create secret docker-registry ghcr-secret -n $NS \
             --docker-server=ghcr.io \
             --docker-username=${{ github.actor }} \
-            --docker-password=${{ secrets.GITHUB_TOKEN }} \
+            --docker-password="$GHCR_TOKEN" \
             --dry-run=client -o yaml | kubectl apply -f -
 
           # Ensure app secrets exist

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -77,9 +77,9 @@ spec:
             - name: OPENROUTER_MODEL
               value: "google/gemini-2.5-flash-image"
             - name: MINIO_ENDPOINT
-              value: "s3.wiebe.xyz"
+              value: "minio.production.svc.cluster.local:9000"
             - name: MINIO_SECURE
-              value: "true"
+              value: "false"
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -243,9 +243,9 @@ spec:
             - name: OPENROUTER_MODEL
               value: "google/gemini-2.5-flash-image"
             - name: MINIO_ENDPOINT
-              value: "s3.wiebe.xyz"
+              value: "minio.production.svc.cluster.local:9000"
             - name: MINIO_SECURE
-              value: "true"
+              value: "false"
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Switch production MinIO endpoint from `s3.wiebe.xyz` (external) to `minio.production.svc.cluster.local:9000` (internal cluster DNS). External endpoint has a duplicate ingress conflict routing to the wrong MinIO instance.
- Update deploy workflows to prefer `GHCR_PAT` secret (long-lived) over ephemeral `GITHUB_TOKEN` for the k8s `ghcr-secret`, preventing ImagePullBackOff on pod restarts.

## Test plan
- [x] Verified fix live on production via `kubectl set env` — images now serve correctly (200, no magenta)
- [ ] Create `GHCR_PAT` repo secret with `read:packages` scope for durable image pull auth