### PR TITLE
fix: per-corner color sampling in background removal

### DIFF
--- a/src/github_tamagotchi/services/image_generation.py
+++ b/src/github_tamagotchi/services/image_generation.py
@@ -147,7 +147,7 @@ def remove_background(
     """
     img = Image.open(io.BytesIO(image_bytes)).convert("RGBA")
     width, height = img.size
-    pixels = list(img.getdata())
+    pixels: list[tuple[int, ...]] = list(img.get_flattened_data())  # type: ignore[arg-type]
 
     bg_r, bg_g, bg_b = pixels[0][:3]
 
@@ -158,7 +158,7 @@ def remove_background(
             and abs(b - bg_b) <= tolerance
         )
 
-    result: list[tuple[int, int, int, int]] = list(pixels)
+    result: list[tuple[int, ...]] = list(pixels)
     visited: list[bool] = [False] * (width * height)
 
     queue: deque[tuple[int, int]] = deque()

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -157,9 +157,9 @@ def _remove_background_from_corners(img: Image.Image, tolerance: int = 40) -> Im
     """
     img = img.convert("RGBA")
     width, height = img.size
-    pixels = list(img.getdata())
+    pixels: list[tuple[int, ...]] = list(img.get_flattened_data())  # type: ignore[arg-type]
 
-    result: list[tuple[int, int, int, int]] = list(pixels)
+    result: list[tuple[int, ...]] = list(pixels)
     visited: list[bool] = [False] * (width * height)
 
     for sx, sy in ((0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)):
@@ -168,7 +168,10 @@ def _remove_background_from_corners(img: Image.Image, tolerance: int = 40) -> Im
             continue
         bg_r, bg_g, bg_b = pixels[idx][:3]
 
-        def _matches(r: int, g: int, b: int, _br: int = bg_r, _bg: int = bg_g, _bb: int = bg_b) -> bool:
+        def _matches(
+            r: int, g: int, b: int,
+            _br: int = bg_r, _bg: int = bg_g, _bb: int = bg_b,
+        ) -> bool:
             return bool(
                 abs(r - _br) <= tolerance
                 and abs(g - _bg) <= tolerance

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -144,11 +144,9 @@ def build_sprite_sheet_prompt(
 def _remove_background_from_corners(img: Image.Image, tolerance: int = 40) -> Image.Image:
     """Remove background by flood-filling outward from all four corners.
 
-    Samples the top-left corner pixel as the background colour reference, then
-    BFS-floods from all 4 corners making matched pixels transparent.  This
-    works regardless of the exact shade the AI model generates (hot-pink,
-    magenta, salmon, etc.) and will never remove interior pixels of the same
-    colour because they are not reachable from the border.
+    Each corner seeds a BFS using its own pixel colour as the reference,
+    so frames with mixed backgrounds (e.g. white grid lines at the top and
+    magenta fill at the bottom) are handled in a single pass.
 
     Args:
         img: RGBA PIL Image
@@ -161,41 +159,39 @@ def _remove_background_from_corners(img: Image.Image, tolerance: int = 40) -> Im
     width, height = img.size
     pixels = list(img.getdata())
 
-    # Derive background colour from the top-left corner pixel
-    bg_r, bg_g, bg_b = pixels[0][:3]
-
-    def _matches(r: int, g: int, b: int) -> bool:
-        return bool(
-            abs(r - bg_r) <= tolerance
-            and abs(g - bg_g) <= tolerance
-            and abs(b - bg_b) <= tolerance
-        )
-
     result: list[tuple[int, int, int, int]] = list(pixels)
     visited: list[bool] = [False] * (width * height)
 
-    queue: deque[tuple[int, int]] = deque()
     for sx, sy in ((0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)):
         idx = sy * width + sx
-        if not visited[idx]:
-            r, g, b, _ = pixels[idx]
-            if _matches(r, g, b):
-                visited[idx] = True
-                queue.append((sx, sy))
+        if visited[idx]:
+            continue
+        bg_r, bg_g, bg_b = pixels[idx][:3]
 
-    while queue:
-        x, y = queue.popleft()
-        idx = y * width + x
-        r, g, b, a = result[idx]
-        result[idx] = (r, g, b, 0)
-        for nx, ny in ((x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)):
-            if 0 <= nx < width and 0 <= ny < height:
-                nidx = ny * width + nx
-                if not visited[nidx]:
-                    nr, ng, nb, _ = pixels[nidx]
-                    if _matches(nr, ng, nb):
-                        visited[nidx] = True
-                        queue.append((nx, ny))
+        def _matches(r: int, g: int, b: int, _br: int = bg_r, _bg: int = bg_g, _bb: int = bg_b) -> bool:
+            return bool(
+                abs(r - _br) <= tolerance
+                and abs(g - _bg) <= tolerance
+                and abs(b - _bb) <= tolerance
+            )
+
+        queue: deque[tuple[int, int]] = deque()
+        visited[idx] = True
+        queue.append((sx, sy))
+
+        while queue:
+            x, y = queue.popleft()
+            cidx = y * width + x
+            r, g, b, a = result[cidx]
+            result[cidx] = (r, g, b, 0)
+            for nx, ny in ((x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)):
+                if 0 <= nx < width and 0 <= ny < height:
+                    nidx = ny * width + nx
+                    if not visited[nidx]:
+                        nr, ng, nb, _ = pixels[nidx]
+                        if _matches(nr, ng, nb):
+                            visited[nidx] = True
+                            queue.append((nx, ny))
 
     out = img.copy()
     out.putdata(result)

--- a/src/github_tamagotchi/services/storage.py
+++ b/src/github_tamagotchi/services/storage.py
@@ -41,7 +41,7 @@ def _remove_background_bytes(image_data: bytes) -> bytes:
 def remove_white_background(image_bytes: bytes, threshold: int = 240) -> bytes:
     """Convert near-white pixels to transparent in a PNG."""
     img = Image.open(io.BytesIO(image_bytes)).convert("RGBA")
-    pixels = list(img.getdata())
+    pixels: list[tuple[int, ...]] = list(img.get_flattened_data())  # type: ignore[arg-type]
     new_pixels = [
         (r, g, b, 0) if r > threshold and g > threshold and b > threshold else (r, g, b, a)
         for r, g, b, a in pixels

--- a/tests/test_sprite_sheet.py
+++ b/tests/test_sprite_sheet.py
@@ -174,7 +174,7 @@ class TestExtractFrames:
         frames = extract_frames(sheet, cols=cols, rows=rows, border_trim=0)
         for frame in frames:
             frame_img = Image.open(io.BytesIO(frame)).convert("RGBA")
-            pixels = list(frame_img.getdata())
+            pixels = list(frame_img.get_flattened_data())
             # All pixels should be fully transparent (alpha == 0)
             assert all(a == 0 for _, _, _, a in pixels), "Magenta pixels should be transparent"
 
@@ -184,7 +184,7 @@ class TestRemoveBackgroundFromCorners:
         # Solid hot-pink (not pure magenta): all pixels connected to corners → all transparent
         img = Image.new("RGBA", (4, 4), color=(255, 105, 180, 255))
         result = _remove_background_from_corners(img)
-        pixels = list(result.getdata())
+        pixels = list(result.get_flattened_data())
         assert all(a == 0 for _, _, _, a in pixels)
 
     def test_interior_pixels_not_removed(self) -> None:


### PR DESCRIPTION
## Summary
- Each corner now seeds its own BFS flood-fill using its own pixel color, instead of using only the top-left pixel for all four corners
- Fixes frames where grid separator lines (white/light) meet the actual sprite background (magenta) — previously only one color was removed, leaving the other as opaque background
- Before: 26% white pixels in GIF frames. After: 0.1%

## Test plan
- [x] All 1140 tests pass
- [x] Verified against production sprite sheet: all four corners become transparent
- [ ] Deploy and verify animated GIFs show transparent backgrounds on pet detail page