### PR TITLE
feat: styled HTML error pages for browser requests

### DIFF
--- a/src/github_tamagotchi/api/exception_handlers.py
+++ b/src/github_tamagotchi/api/exception_handlers.py
@@ -4,6 +4,7 @@ import structlog
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 from fastapi.templating import Jinja2Templates
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from github_tamagotchi.core import bugbarn as bb
 from github_tamagotchi.exceptions import ConflictError, NotFoundError, RepositoryError
@@ -54,12 +55,16 @@ def register_exception_handlers(
             return _error_html(request, templates, 500, "Something went wrong")
         return JSONResponse(status_code=500, content={"detail": "Internal error"})
 
-    @app.exception_handler(HTTPException)
-    async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
+    async def _handle_http_exc(
+        request: Request, exc: HTTPException | StarletteHTTPException,
+    ) -> Response:
         if _wants_html(request) and exc.status_code >= 400:
-            msg = exc.detail or "An error occurred"
+            msg = str(exc.detail) if exc.detail else "An error occurred"
             return _error_html(request, templates, exc.status_code, msg)
         return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    app.exception_handler(StarletteHTTPException)(_handle_http_exc)
+    app.exception_handler(HTTPException)(_handle_http_exc)
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception) -> Response:

--- a/src/github_tamagotchi/templates/error.html
+++ b/src/github_tamagotchi/templates/error.html
@@ -6,16 +6,77 @@
     <title>{{ status_code }} — GitHub Tamagotchi</title>
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
+    <style>
+        .error-page {
+            min-height: 70vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 2rem;
+        }
+        .error-content {
+            max-width: 480px;
+        }
+        .error-pet {
+            font-size: 5rem;
+            line-height: 1;
+            margin-bottom: 1rem;
+            animation: error-bounce 2s ease-in-out infinite;
+        }
+        @keyframes error-bounce {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-10px); }
+        }
+        .error-code {
+            font-size: 6rem;
+            font-weight: 800;
+            line-height: 1;
+            margin: 0 0 0.5rem;
+            background: linear-gradient(135deg, var(--primary), var(--primary-dark, #7c3aed));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+        .error-message {
+            font-size: 1.25rem;
+            opacity: 0.7;
+            margin-bottom: 2rem;
+        }
+        .error-hint {
+            font-size: 0.9rem;
+            opacity: 0.5;
+            margin-bottom: 2rem;
+        }
+    </style>
 </head>
 <body>
     {% set user = None %}
     {% set active_page = "" %}
     {% include "_nav.html" %}
 
-    <section class="hero" style="min-height: 60vh; display: flex; align-items: center;">
-        <div class="container" style="text-align: center;">
-            <h1 style="font-size: 4rem; margin-bottom: 0.5rem;">{{ status_code }}</h1>
-            <p style="font-size: 1.25rem; opacity: 0.8; margin-bottom: 2rem;">{{ message }}</p>
+    <section class="error-page">
+        <div class="error-content">
+            <div class="error-pet">
+                {% if status_code == 404 %}
+                    &#x1F50D;
+                {% elif status_code == 403 %}
+                    &#x1F512;
+                {% elif status_code == 500 %}
+                    &#x1F635;
+                {% elif status_code == 503 %}
+                    &#x1F6A7;
+                {% else %}
+                    &#x1F63F;
+                {% endif %}
+            </div>
+            <h1 class="error-code">{{ status_code }}</h1>
+            <p class="error-message">{{ message }}</p>
+            {% if status_code == 404 %}
+            <p class="error-hint">The pet you're looking for might have wandered off.</p>
+            {% elif status_code == 503 %}
+            <p class="error-hint">We're taking a short nap. Try again in a moment.</p>
+            {% endif %}
             <a href="/" class="btn btn-primary">Back to home</a>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Registers `StarletteHTTPException` handler so unmatched routes return styled HTML instead of raw `{"detail":"Not Found"}`
- Content negotiation preserved: browsers get HTML, API clients get JSON
- Error page includes status-specific icons and contextual hints (e.g. "The pet you're looking for might have wandered off" for 404s)

## Test plan
- [x] All 1140 tests pass
- [x] Verified locally: `/pets/webwiebe/funnelbarn` returns styled HTML with Accept: text/html
- [x] Verified locally: API routes and non-HTML Accept headers still return JSON