### PR TITLE
feat: PWA installability with periodic health checks

### DIFF
--- a/alembic/versions/028_add_graveyard_fields.py
+++ b/alembic/versions/028_add_graveyard_fields.py
@@ -1,0 +1,52 @@
+"""Add graveyard fields to pets and grave_flower_ips table.
+
+Revision ID: 028
+Revises: 027
+Create Date: 2026-05-05
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "028"
+down_revision = "027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pets", sa.Column("eulogy", sa.String(280), nullable=True))
+    op.add_column(
+        "pets",
+        sa.Column("flower_count", sa.Integer, nullable=False, server_default="0"),
+    )
+
+    op.create_table(
+        "grave_flower_ips",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "pet_id",
+            sa.Integer,
+            sa.ForeignKey("pets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("ip_hash", sa.String(64), nullable=False),
+        sa.Column(
+            "last_flower_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("pet_id", "ip_hash", name="uq_grave_flower_ip"),
+    )
+    op.create_index(
+        "ix_grave_flower_ips_pet_id", "grave_flower_ips", ["pet_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_grave_flower_ips_pet_id", table_name="grave_flower_ips")
+    op.drop_table("grave_flower_ips")
+    op.drop_column("pets", "flower_count")
+    op.drop_column("pets", "eulogy")

--- a/src/github_tamagotchi/api/routes/__init__.py
+++ b/src/github_tamagotchi/api/routes/__init__.py
@@ -43,6 +43,7 @@ from github_tamagotchi.api.routes.v1.pets import (
 )
 from github_tamagotchi.api.routes.v1 import (
     admin,
+    graveyard,
     social,
     system,
     webhooks,
@@ -57,6 +58,7 @@ router.include_router(media.router)
 router.include_router(info.router)
 router.include_router(actions.router)
 router.include_router(admin.router)
+router.include_router(graveyard.router)
 router.include_router(social.router)
 router.include_router(system.router)
 router.include_router(webhooks.router)

--- a/src/github_tamagotchi/api/routes/v1/graveyard.py
+++ b/src/github_tamagotchi/api/routes/v1/graveyard.py
@@ -1,0 +1,138 @@
+"""API routes for the pet graveyard."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from github_tamagotchi.api.auth import get_optional_user
+from github_tamagotchi.api.dependencies import DbSession
+from github_tamagotchi.models.pet import Pet
+from github_tamagotchi.models.user import User
+from github_tamagotchi.repositories import graveyard as graveyard_repo
+
+router = APIRouter(prefix="/api/v1/graveyard", tags=["graveyard"])
+
+
+class FlowerResponse(BaseModel):
+    flower_count: int
+    added: bool
+
+
+class EulogyRequest(BaseModel):
+    eulogy: str
+
+
+class GraveSummary(BaseModel):
+    pet_name: str
+    repo_owner: str
+    repo_name: str
+    stage: str
+    died_at: str | None
+    cause_of_death: str | None
+    flower_count: int
+    eulogy: str | None
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("")
+async def list_graves(
+    session: DbSession,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=50),
+) -> dict[str, object]:
+    pets, total = await graveyard_repo.get_dead_pets(session, page, per_page)
+    return {
+        "graves": [_pet_to_summary(p) for p in pets],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+    }
+
+
+@router.get("/{username}")
+async def list_user_graves(
+    username: str,
+    session: DbSession,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=50),
+) -> dict[str, object]:
+    pets, total = await graveyard_repo.get_dead_pets_by_user(
+        session, username, page, per_page
+    )
+    if total == 0:
+        raise HTTPException(status_code=404, detail="No graves found for this user")
+    return {
+        "graves": [_pet_to_summary(p) for p in pets],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+    }
+
+
+@router.get("/{username}/{repo}")
+async def get_grave(username: str, repo: str, session: DbSession) -> dict[str, object]:
+    pet = await graveyard_repo.get_grave(session, username, repo)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Grave not found")
+    return {
+        "grave": _pet_to_summary(pet),
+        "created_at": pet.created_at.isoformat() if pet.created_at else None,
+        "generation": pet.generation,
+        "experience": pet.experience,
+        "longest_streak": pet.longest_streak,
+    }
+
+
+@router.post("/{username}/{repo}/flower")
+async def add_flower(
+    username: str,
+    repo: str,
+    request: Request,
+    session: DbSession,
+) -> FlowerResponse:
+    pet = await graveyard_repo.get_grave(session, username, repo)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Grave not found")
+    client_ip = request.client.host if request.client else "unknown"
+    added, count = await graveyard_repo.add_flower(session, pet.id, client_ip)
+    return FlowerResponse(flower_count=count, added=added)
+
+
+@router.put("/{username}/{repo}/eulogy")
+async def set_eulogy(
+    username: str,
+    repo: str,
+    body: EulogyRequest,
+    session: DbSession,
+    user: Annotated[User | None, Depends(get_optional_user)],
+) -> dict[str, object]:
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    pet = await graveyard_repo.get_grave(session, username, repo)
+    if not pet:
+        raise HTTPException(status_code=404, detail="Grave not found")
+    if not pet.user_id or pet.user_id != user.id:
+        raise HTTPException(
+            status_code=403, detail="Only the pet owner can set the eulogy"
+        )
+    if len(body.eulogy) > 280:
+        raise HTTPException(
+            status_code=400, detail="Eulogy must be 280 characters or less"
+        )
+    await graveyard_repo.update_eulogy(session, pet.id, body.eulogy)
+    return {"eulogy": body.eulogy[:280]}
+
+
+def _pet_to_summary(pet: Pet) -> dict[str, object]:
+    return {
+        "pet_name": pet.name,
+        "repo_owner": pet.repo_owner,
+        "repo_name": pet.repo_name,
+        "stage": pet.stage,
+        "died_at": pet.died_at.isoformat() if pet.died_at else None,
+        "cause_of_death": pet.cause_of_death,
+        "flower_count": pet.flower_count,
+        "eulogy": pet.eulogy,
+    }

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -65,7 +65,10 @@ from github_tamagotchi.services.pet_logic import (
     update_commit_streak,
     update_grace_period,
 )
-from github_tamagotchi.services.push_notifications import notify_unhappy_pets
+from github_tamagotchi.services.push_notifications import (
+    notify_dying_and_dead_pets,
+    notify_unhappy_pets,
+)
 
 # Configure structured logging before anything else logs
 configure_logging()
@@ -320,6 +323,7 @@ async def poll_repositories(triggered_by: str = "scheduler") -> None:
             # --- Web push notifications for unhappy pets ---
             if settings.vapid_private_key:
                 await notify_unhappy_pets(session)
+                await notify_dying_and_dead_pets(session)
 
             # --- Business metrics gauges ---
             now_ts = datetime.now(UTC)
@@ -959,6 +963,107 @@ async def org_overview(
             "neglected": neglected,
             "org_leaderboard": org_leaderboard,
         },
+    )
+
+
+@app.get("/graveyard", response_class=HTMLResponse)
+async def graveyard_page(
+    request: Request,
+    user: OptionalUser,
+    session: DbSession,
+    page: int = 1,
+) -> HTMLResponse:
+    """Public graveyard — all dead pets."""
+    from github_tamagotchi.repositories.graveyard import get_dead_pets
+
+    per_page = 20
+    graves, total = await get_dead_pets(session, page, per_page)
+    return templates.TemplateResponse(
+        request,
+        "graveyard.html",
+        {
+            "user": user,
+            "graves": graves,
+            "total": total,
+            "page": page,
+            "per_page": per_page,
+            "username": None,
+        },
+        headers={"Cache-Control": "public, max-age=300"},
+    )
+
+
+@app.get("/graveyard/{username}", response_class=HTMLResponse)
+async def graveyard_user_page(
+    request: Request,
+    username: str,
+    user: OptionalUser,
+    session: DbSession,
+    page: int = 1,
+) -> HTMLResponse:
+    """Personal graveyard for a user's dead pets."""
+    from github_tamagotchi.repositories.graveyard import get_dead_pets_by_user
+
+    per_page = 20
+    graves, total = await get_dead_pets_by_user(session, username, page, per_page)
+    return templates.TemplateResponse(
+        request,
+        "graveyard.html",
+        {
+            "user": user,
+            "graves": graves,
+            "total": total,
+            "page": page,
+            "per_page": per_page,
+            "username": username,
+        },
+        headers={"Cache-Control": "public, max-age=300"},
+    )
+
+
+@app.get("/graveyard/{username}/{repo_name}", response_class=HTMLResponse)
+async def graveyard_grave_page(
+    request: Request,
+    username: str,
+    repo_name: str,
+    user: OptionalUser,
+    session: DbSession,
+) -> HTMLResponse:
+    """Memorial page for a single dead pet."""
+    from github_tamagotchi.repositories.graveyard import get_grave
+    from github_tamagotchi.repositories.pet import get_pet_by_repo
+
+    pet = await get_grave(session, username, repo_name)
+    if not pet:
+        alive = await get_pet_by_repo(session, username, repo_name)
+        if alive:
+            return RedirectResponse(f"/pet/{username}/{repo_name}")
+        raise HTTPException(status_code=404, detail="Grave not found")
+
+    cause_labels = {
+        "neglect": "Died of neglect — the commits stopped coming",
+        "abandonment": "Abandoned — the repository went dark",
+    }
+    cause_label = cause_labels.get(pet.cause_of_death or "", pet.cause_of_death or "Cause unknown")
+
+    now = datetime.now(UTC)
+    age_days = (pet.died_at - pet.created_at).days if pet.died_at and pet.created_at else 0
+    would_be_days = (now - pet.created_at).days if pet.created_at else 0
+    is_owner = user is not None and pet.user_id is not None and user.id == pet.user_id
+
+    return templates.TemplateResponse(
+        request,
+        "graveyard_grave.html",
+        {
+            "user": user,
+            "pet": pet,
+            "cause_label": cause_label,
+            "age_days": age_days,
+            "would_be_days": would_be_days,
+            "is_owner": is_owner,
+            "base_url": str(request.base_url).rstrip("/"),
+        },
+        headers={"Cache-Control": "public, max-age=300"},
     )
 
 

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -640,6 +640,8 @@ async def pet_manifest(
         "short_name": short_name,
         "description": description,
         "start_url": f"/pet/{repo_owner}/{repo_name}",
+        "scope": "/",
+        "id": f"/pet/{repo_owner}/{repo_name}",
         "display": "standalone",
         "background_color": "#0f0f1a",
         "theme_color": "#6366f1",

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -1023,7 +1023,7 @@ async def graveyard_user_page(
     )
 
 
-@app.get("/graveyard/{username}/{repo_name}", response_class=HTMLResponse)
+@app.get("/graveyard/{username}/{repo_name}", response_class=HTMLResponse, response_model=None)
 async def graveyard_grave_page(
     request: Request,
     username: str,

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -1030,7 +1030,7 @@ async def graveyard_grave_page(
     repo_name: str,
     user: OptionalUser,
     session: DbSession,
-) -> HTMLResponse:
+) -> HTMLResponse | RedirectResponse:
     """Memorial page for a single dead pet."""
     from github_tamagotchi.repositories.graveyard import get_grave
     from github_tamagotchi.repositories.pet import get_pet_by_repo

--- a/src/github_tamagotchi/models/__init__.py
+++ b/src/github_tamagotchi/models/__init__.py
@@ -8,6 +8,7 @@ from github_tamagotchi.models.contributor_relationship import (
     ContributorStanding,
 )
 from github_tamagotchi.models.excluded_contributor import ExcludedContributor
+from github_tamagotchi.models.grave_flower_ip import GraveFlowerIp
 from github_tamagotchi.models.image_job import ImageGenerationJob, JobStatus
 from github_tamagotchi.models.job_run import JobRun
 from github_tamagotchi.models.milestone import PetMilestone
@@ -24,6 +25,7 @@ __all__ = [
     "ContributorRelationship",
     "ContributorStanding",
     "ExcludedContributor",
+    "GraveFlowerIp",
     "ImageGenerationJob",
     "JobRun",
     "JobStatus",

--- a/src/github_tamagotchi/models/grave_flower_ip.py
+++ b/src/github_tamagotchi/models/grave_flower_ip.py
@@ -1,0 +1,24 @@
+"""Rate-limiting model for grave flower reactions."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from github_tamagotchi.models.pet import Base
+
+
+class GraveFlowerIp(Base):
+    """Tracks per-IP rate limits for flower reactions on graves."""
+
+    __tablename__ = "grave_flower_ips"
+    __table_args__ = (UniqueConstraint("pet_id", "ip_hash", name="uq_grave_flower_ip"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    pet_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("pets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    ip_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    last_flower_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -182,6 +182,12 @@ class Pet(Base):
     # Canonical appearance description used for sprite sheet generation consistency
     canonical_appearance: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Graveyard
+    eulogy: Mapped[str | None] = mapped_column(String(280), nullable=True)
+    flower_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/repositories/graveyard.py
+++ b/src/github_tamagotchi/repositories/graveyard.py
@@ -1,0 +1,108 @@
+"""Repository functions for the pet graveyard."""
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.models.grave_flower_ip import GraveFlowerIp
+from github_tamagotchi.models.pet import Pet
+
+
+async def get_dead_pets(
+    db: AsyncSession, page: int = 1, per_page: int = 20
+) -> tuple[list[Pet], int]:
+    """Get paginated dead pets, most recent death first. Returns (pets, total_count)."""
+    count_q = select(func.count()).select_from(Pet).where(Pet.is_dead.is_(True))
+    total = (await db.execute(count_q)).scalar_one()
+
+    q = (
+        select(Pet)
+        .where(Pet.is_dead.is_(True))
+        .order_by(Pet.died_at.desc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+    )
+    result = await db.execute(q)
+    return list(result.scalars().all()), total
+
+
+async def get_dead_pets_by_user(
+    db: AsyncSession, username: str, page: int = 1, per_page: int = 20
+) -> tuple[list[Pet], int]:
+    """Get paginated dead pets for a specific user."""
+    base = Pet.is_dead.is_(True) & (Pet.repo_owner == username)
+    count_q = select(func.count()).select_from(Pet).where(base)
+    total = (await db.execute(count_q)).scalar_one()
+
+    q = (
+        select(Pet)
+        .where(base)
+        .order_by(Pet.died_at.desc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+    )
+    result = await db.execute(q)
+    return list(result.scalars().all()), total
+
+
+async def get_grave(db: AsyncSession, owner: str, repo: str) -> Pet | None:
+    """Get a single dead pet by owner/repo. Returns None if not found or not dead."""
+    q = select(Pet).where(
+        Pet.repo_owner == owner, Pet.repo_name == repo, Pet.is_dead.is_(True)
+    )
+    result = await db.execute(q)
+    return result.scalar_one_or_none()
+
+
+def hash_ip(ip: str) -> str:
+    """Hash an IP address for privacy-friendly storage."""
+    return hashlib.sha256(ip.encode()).hexdigest()
+
+
+async def add_flower(
+    db: AsyncSession, pet_id: int, ip: str
+) -> tuple[bool, int]:
+    """Add a flower reaction. Returns (was_added, new_count).
+
+    Rate-limited: one flower per IP per grave per 24 hours.
+    """
+    ip_h = hash_ip(ip)
+    cutoff = datetime.now(UTC) - timedelta(hours=24)
+
+    existing = await db.execute(
+        select(GraveFlowerIp).where(
+            GraveFlowerIp.pet_id == pet_id,
+            GraveFlowerIp.ip_hash == ip_h,
+        )
+    )
+    record = existing.scalar_one_or_none()
+
+    if record and record.last_flower_at > cutoff:
+        # Already placed today
+        pet = await db.get(Pet, pet_id)
+        return False, pet.flower_count if pet else 0
+
+    if record:
+        record.last_flower_at = datetime.now(UTC)
+    else:
+        db.add(GraveFlowerIp(pet_id=pet_id, ip_hash=ip_h))
+
+    # Increment flower count
+    pet = await db.get(Pet, pet_id)
+    if pet:
+        pet.flower_count += 1
+        await db.commit()
+        return True, pet.flower_count
+
+    await db.commit()
+    return False, 0
+
+
+async def update_eulogy(db: AsyncSession, pet_id: int, eulogy: str) -> None:
+    """Set the eulogy text on a dead pet."""
+    pet = await db.get(Pet, pet_id)
+    if pet:
+        pet.eulogy = eulogy[:280]
+        await db.commit()

--- a/src/github_tamagotchi/services/push_notifications.py
+++ b/src/github_tamagotchi/services/push_notifications.py
@@ -28,6 +28,11 @@ MOOD_MESSAGES: dict[str, str] = {
     PetMood.SICK: "is ill from stale dependencies. Time for an update!",
 }
 
+CAUSE_LABELS: dict[str, str] = {
+    "neglect": "neglect",
+    "abandonment": "abandonment",
+}
+
 MOOD_EMOJI: dict[str, str] = {
     PetMood.HUNGRY: "🍖",
     PetMood.WORRIED: "😟",
@@ -189,5 +194,110 @@ async def notify_unhappy_pets(session: AsyncSession) -> int:
 
     if sent > 0:
         logger.info("push_notifications_sent", count=sent)
+
+    return sent
+
+
+async def notify_dying_and_dead_pets(session: AsyncSession) -> int:
+    """Send push notifications for pets entering grace period or dying.
+
+    - Grace period: pet health is 0, grace_period_started is set, not yet dead
+    - Death: pet just died (died_at within the last poll interval)
+
+    Uses the same 4-hour cooldown as mood notifications.
+    """
+    if not settings.vapid_private_key:
+        return 0
+
+    cooldown_cutoff = datetime.now(UTC) - timedelta(hours=NOTIFY_COOLDOWN_HOURS)
+
+    # Pets in grace period (alive, health 0, grace period started)
+    grace_result = await session.execute(
+        select(PushSubscription)
+        .join(Pet, PushSubscription.pet_id == Pet.id)
+        .where(
+            Pet.is_dead.is_(False),
+            Pet.grace_period_started.isnot(None),
+            or_(
+                PushSubscription.last_notified_at.is_(None),
+                PushSubscription.last_notified_at < cooldown_cutoff,
+            ),
+        )
+    )
+    grace_subs = list(grace_result.scalars().all())
+
+    # Recently dead pets (died within last 24h to catch across poll intervals)
+    death_cutoff = datetime.now(UTC) - timedelta(hours=24)
+    death_result = await session.execute(
+        select(PushSubscription)
+        .join(Pet, PushSubscription.pet_id == Pet.id)
+        .where(
+            Pet.is_dead.is_(True),
+            Pet.died_at > death_cutoff,
+            or_(
+                PushSubscription.last_notified_at.is_(None),
+                PushSubscription.last_notified_at < cooldown_cutoff,
+            ),
+        )
+    )
+    death_subs = list(death_result.scalars().all())
+
+    all_subs = grace_subs + death_subs
+    if not all_subs:
+        return 0
+
+    pet_ids = list({sub.pet_id for sub in all_subs})
+    pets_result = await session.execute(select(Pet).where(Pet.id.in_(pet_ids)))
+    pets_by_id = {p.id: p for p in pets_result.scalars().all()}
+    grace_sub_ids = {sub.id for sub in grace_subs}
+
+    sent = 0
+    to_delete: list[PushSubscription] = []
+
+    for sub in all_subs:
+        pet = pets_by_id.get(sub.pet_id)
+        if not pet:
+            continue
+
+        is_grace = sub.id in grace_sub_ids and not pet.is_dead
+        if is_grace:
+            payload = {
+                "title": f"⚠️ {pet.name} is dying!",
+                "body": (
+                    f"{pet.name} has been at zero health for days. "
+                    "Push a commit to save it!"
+                ),
+                "icon": f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/image/{pet.stage}",
+                "url": f"/pet/{pet.repo_owner}/{pet.repo_name}",
+                "tag": f"pet-{pet.id}-grace",
+            }
+        else:
+            cause = CAUSE_LABELS.get(pet.cause_of_death or "", pet.cause_of_death or "unknown causes")
+            payload = {
+                "title": f"💀 {pet.name} has died",
+                "body": (
+                    f"Rest in peace, {pet.name}. "
+                    f"Died of {cause}. Visit the graveyard to pay respects."
+                ),
+                "icon": f"/api/v1/pets/{pet.repo_owner}/{pet.repo_name}/image/{pet.stage}",
+                "url": f"/graveyard/{pet.repo_owner}/{pet.repo_name}",
+                "tag": f"pet-{pet.id}-death",
+            }
+
+        send_result = await _send_to_subscription(sub, payload)
+        if send_result is True:
+            sub.last_notified_at = datetime.now(UTC)
+            sent += 1
+        elif send_result is None:
+            to_delete.append(sub)
+
+    for sub in to_delete:
+        await session.delete(sub)
+
+    if sent > 0 or to_delete:
+        await session.commit()
+
+    if sent > 0:
+        logger.info("death_notifications_sent", count=sent)
 
     return sent

--- a/src/github_tamagotchi/services/push_notifications.py
+++ b/src/github_tamagotchi/services/push_notifications.py
@@ -272,7 +272,8 @@ async def notify_dying_and_dead_pets(session: AsyncSession) -> int:
                 "tag": f"pet-{pet.id}-grace",
             }
         else:
-            cause = CAUSE_LABELS.get(pet.cause_of_death or "", pet.cause_of_death or "unknown causes")
+            raw = pet.cause_of_death or ""
+            cause = CAUSE_LABELS.get(raw, raw or "unknown causes")
             payload = {
                 "title": f"💀 {pet.name} has died",
                 "body": (

--- a/src/github_tamagotchi/static/css/style.css
+++ b/src/github_tamagotchi/static/css/style.css
@@ -1839,3 +1839,82 @@ details[open] .webhook-summary::before {
     color: var(--text);
     font-weight: 700;
 }
+
+/* --- PWA install banner --- */
+.pwa-install-banner {
+    position: fixed;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 70px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 900;
+    width: calc(100% - 2rem);
+    max-width: 480px;
+    animation: pwa-slide-up 0.3s ease-out;
+}
+
+@keyframes pwa-slide-up {
+    from { transform: translateX(-50%) translateY(100%); opacity: 0; }
+    to   { transform: translateX(-50%) translateY(0); opacity: 1; }
+}
+
+.pwa-install-content {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.pwa-install-icon {
+    font-size: 1.6rem;
+    flex-shrink: 0;
+}
+
+.pwa-install-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.pwa-install-text strong {
+    font-size: 0.9rem;
+    color: var(--text);
+}
+
+.pwa-install-text span {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+
+.pwa-install-btn {
+    padding: 0.4rem 1rem;
+    font-size: 0.82rem;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.pwa-install-dismiss {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.3rem;
+    cursor: pointer;
+    padding: 0.25rem;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.pwa-install-dismiss:hover {
+    color: var(--text);
+}
+
+@media (min-width: 769px) {
+    .pwa-install-banner {
+        bottom: 1.5rem;
+    }
+}

--- a/src/github_tamagotchi/static/manifest.json
+++ b/src/github_tamagotchi/static/manifest.json
@@ -1,8 +1,10 @@
 {
   "name": "GitHub Tamagotchi",
   "short_name": "Tamagotchi",
-  "description": "Virtual pets for your GitHub repositories.",
+  "description": "Virtual pets for your GitHub repositories. Keep coding to keep them happy!",
   "start_url": "/dashboard",
+  "scope": "/",
+  "id": "/",
   "display": "standalone",
   "background_color": "#0f0f1a",
   "theme_color": "#6366f1",
@@ -20,6 +22,26 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "My Pets",
+      "short_name": "Pets",
+      "url": "/dashboard",
+      "icons": [{"src": "/pwa/icon/192.png", "sizes": "192x192"}]
+    },
+    {
+      "name": "Leaderboard",
+      "short_name": "Top",
+      "url": "/leaderboard",
+      "icons": [{"src": "/pwa/icon/192.png", "sizes": "192x192"}]
+    },
+    {
+      "name": "Graveyard",
+      "short_name": "Graveyard",
+      "url": "/graveyard",
+      "icons": [{"src": "/pwa/icon/192.png", "sizes": "192x192"}]
     }
   ]
 }

--- a/src/github_tamagotchi/static/sw.js
+++ b/src/github_tamagotchi/static/sw.js
@@ -1,6 +1,20 @@
-const CACHE_NAME = 'tamagotchi-v1';
-const STATIC_ASSETS = ['/static/css/style.css'];
+const CACHE_VERSION = 2;
+const CACHE_NAME = 'tamagotchi-v' + CACHE_VERSION;
 
+const STATIC_ASSETS = [
+    '/static/css/style.css',
+    '/pwa/icon/192.png',
+    '/pwa/icon/512.png',
+];
+
+const CACHEABLE_PATHS = [
+    '/dashboard',
+    '/leaderboard',
+    '/graveyard',
+    '/register',
+];
+
+// --- Install: pre-cache static assets ---
 self.addEventListener('install', (event) => {
     event.waitUntil(
         caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
@@ -8,24 +22,57 @@ self.addEventListener('install', (event) => {
     self.skipWaiting();
 });
 
+// --- Activate: clean old caches, claim clients ---
 self.addEventListener('activate', (event) => {
     event.waitUntil(
         caches.keys().then((keys) =>
             Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-        )
+        ).then(() => self.clients.claim())
     );
-    self.clients.claim();
 });
 
+// --- Fetch: network-first for pages, cache-first for static assets ---
 self.addEventListener('fetch', (event) => {
     const url = new URL(event.request.url);
-    if (STATIC_ASSETS.includes(url.pathname)) {
+
+    if (event.request.method !== 'GET') return;
+
+    // Static assets: cache-first
+    if (STATIC_ASSETS.includes(url.pathname) || url.pathname.startsWith('/static/')) {
         event.respondWith(
-            caches.match(event.request).then((cached) => cached || fetch(event.request))
+            caches.match(event.request).then((cached) => {
+                if (cached) return cached;
+                return fetch(event.request).then((response) => {
+                    if (response.ok) {
+                        const clone = response.clone();
+                        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+                    }
+                    return response;
+                });
+            })
         );
+        return;
+    }
+
+    // HTML pages: network-first, fall back to cache
+    if (event.request.headers.get('Accept')?.includes('text/html') &&
+        CACHEABLE_PATHS.some((p) => url.pathname === p || url.pathname.startsWith(p + '/'))) {
+        event.respondWith(
+            fetch(event.request)
+                .then((response) => {
+                    if (response.ok) {
+                        const clone = response.clone();
+                        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+                    }
+                    return response;
+                })
+                .catch(() => caches.match(event.request))
+        );
+        return;
     }
 });
 
+// --- Push notifications ---
 self.addEventListener('push', (event) => {
     let data = {};
     try {
@@ -48,6 +95,7 @@ self.addEventListener('push', (event) => {
     event.waitUntil(self.registration.showNotification(title, options));
 });
 
+// --- Notification click: focus or open the target URL ---
 self.addEventListener('notificationclick', (event) => {
     event.notification.close();
     const targetUrl = event.notification.data?.url || '/';
@@ -65,3 +113,59 @@ self.addEventListener('notificationclick', (event) => {
         })
     );
 });
+
+// --- Periodic background sync: check pet health ---
+self.addEventListener('periodicsync', (event) => {
+    if (event.tag === 'check-pet-health') {
+        event.waitUntil(checkPetHealth());
+    }
+});
+
+async function checkPetHealth() {
+    try {
+        const response = await fetch('/api/v1/me/pets?per_page=100');
+        if (!response.ok) return;
+
+        const data = await response.json();
+        const pets = data.pets || [];
+
+        for (const pet of pets) {
+            if (pet.is_dead) continue;
+
+            if (pet.health <= 0 && pet.grace_period_started) {
+                await self.registration.showNotification(
+                    `⚠️ ${pet.name} is dying!`,
+                    {
+                        body: `${pet.name} has been at zero health. Push a commit to save it!`,
+                        icon: `/api/v1/pets/${pet.repo_owner}/${pet.repo_name}/image/${pet.stage}`,
+                        badge: '/pwa/icon/192.png',
+                        data: { url: `/pet/${pet.repo_owner}/${pet.repo_name}` },
+                        tag: `pet-${pet.repo_owner}-${pet.repo_name}-health`,
+                        renotify: false,
+                    }
+                );
+            } else if (pet.health < 40) {
+                const moods = {
+                    hungry: '🍖',
+                    worried: '😟',
+                    lonely: '😢',
+                    sick: '🤒',
+                };
+                const emoji = moods[pet.mood] || '😔';
+                await self.registration.showNotification(
+                    `${emoji} ${pet.name} needs attention`,
+                    {
+                        body: `Health: ${pet.health}%. Your pet is ${pet.mood || 'unhappy'}.`,
+                        icon: `/api/v1/pets/${pet.repo_owner}/${pet.repo_name}/image/${pet.stage}`,
+                        badge: '/pwa/icon/192.png',
+                        data: { url: `/pet/${pet.repo_owner}/${pet.repo_name}` },
+                        tag: `pet-${pet.repo_owner}-${pet.repo_name}-health`,
+                        renotify: false,
+                    }
+                );
+            }
+        }
+    } catch {
+        // Network error or not authenticated — silently ignore
+    }
+}

--- a/src/github_tamagotchi/templates/_nav.html
+++ b/src/github_tamagotchi/templates/_nav.html
@@ -7,6 +7,7 @@
             <a href="/register" {% if (active_page | default('')) == 'register' %}class="nav-active"{% endif %}>Register</a>
             {% endif %}
             <a href="/leaderboard" {% if (active_page | default('')) == 'leaderboard' %}class="nav-active"{% endif %}>Leaderboard</a>
+            <a href="/graveyard" {% if (active_page | default('')) == 'graveyard' %}class="nav-active"{% endif %}>Graveyard</a>
             {% if user and user.is_admin %}
             <a href="/admin" {% if (active_page | default('')) == 'admin' %}class="nav-active"{% endif %}>Admin</a>
             {% endif %}

--- a/src/github_tamagotchi/templates/_pwa_head.html
+++ b/src/github_tamagotchi/templates/_pwa_head.html
@@ -9,6 +9,51 @@
 <script>
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('/sw.js', { scope: '/' })
+        .then(function (reg) {
+            // Register periodic background sync for pet health checks
+            if ('periodicSync' in reg) {
+                navigator.permissions.query({ name: 'periodic-background-sync' }).then(function (status) {
+                    if (status.state === 'granted') {
+                        reg.periodicSync.register('check-pet-health', {
+                            minInterval: 4 * 60 * 60 * 1000 // 4 hours
+                        }).catch(function () {});
+                    }
+                }).catch(function () {});
+            }
+        })
         .catch(function (err) { console.warn('SW registration failed:', err); });
 }
+
+// --- PWA install prompt ---
+var _deferredInstallPrompt = null;
+
+window.addEventListener('beforeinstallprompt', function (e) {
+    e.preventDefault();
+    _deferredInstallPrompt = e;
+    try { if (sessionStorage.getItem('pwa-install-dismissed')) return; } catch {}
+    var banner = document.getElementById('pwa-install-banner');
+    if (banner) banner.style.display = '';
+});
+
+window.addEventListener('appinstalled', function () {
+    _deferredInstallPrompt = null;
+    var banner = document.getElementById('pwa-install-banner');
+    if (banner) banner.style.display = 'none';
+});
+
+window.installPwa = function () {
+    if (!_deferredInstallPrompt) return;
+    _deferredInstallPrompt.prompt();
+    _deferredInstallPrompt.userChoice.then(function (result) {
+        _deferredInstallPrompt = null;
+        var banner = document.getElementById('pwa-install-banner');
+        if (banner) banner.style.display = 'none';
+    });
+};
+
+window.dismissInstallBanner = function () {
+    var banner = document.getElementById('pwa-install-banner');
+    if (banner) banner.style.display = 'none';
+    try { sessionStorage.setItem('pwa-install-dismissed', '1'); } catch {}
+};
 </script>

--- a/src/github_tamagotchi/templates/_pwa_install_banner.html
+++ b/src/github_tamagotchi/templates/_pwa_install_banner.html
@@ -1,0 +1,12 @@
+<!-- PWA install banner (hidden by default, shown via beforeinstallprompt) -->
+<div id="pwa-install-banner" class="pwa-install-banner" style="display:none;">
+    <div class="pwa-install-content">
+        <span class="pwa-install-icon">📱</span>
+        <div class="pwa-install-text">
+            <strong>Install GitHub Tamagotchi</strong>
+            <span>Get notified when your pets need attention</span>
+        </div>
+        <button class="cta-button pwa-install-btn" onclick="installPwa()">Install</button>
+        <button class="pwa-install-dismiss" onclick="dismissInstallBanner()" aria-label="Dismiss">&times;</button>
+    </div>
+</div>

--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -11,11 +11,16 @@
     {% set active_page = "dashboard" %}
     {% include "_nav.html" %}
 
+    {% include "_pwa_install_banner.html" %}
+
     <main style="padding-top: 5rem; min-height: 80vh;">
         <div class="container">
-            <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem;">
+            <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem; flex-wrap: wrap; gap: 0.5rem;">
                 <h1 style="font-size: 1.75rem; font-weight: 700;">My Pets</h1>
-                <a href="/register" class="cta-button" style="padding: 0.5rem 1.25rem; font-size: 0.9rem;">+ Register Repo</a>
+                <div style="display: flex; gap: 0.5rem; align-items: center;">
+                    <button id="notify-all-btn" style="display:none; padding: 0.45rem 0.9rem; font-size: 0.82rem; background: var(--surface-light); border: 1px solid var(--border); border-radius: 8px; color: var(--text); cursor: pointer; white-space: nowrap;" onclick="toggleAllNotifications()">🔔 Get notified</button>
+                    <a href="/register" class="cta-button" style="padding: 0.5rem 1.25rem; font-size: 0.9rem;">+ Register Repo</a>
+                </div>
             </div>
 
             {% if pets %}
@@ -121,6 +126,118 @@
             fetch('/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ pet.stage }}/animated', { priority: 'low' }).catch(function(){});
             {% endif %}{% endfor %}
         });
+
+        // --- Notifications for all pets ---
+        var PETS = [{% for pet in pets %}{% if not pet.is_dead %}{ owner: {{ pet.repo_owner | tojson }}, name: {{ pet.repo_name | tojson }} },{% endif %}{% endfor %}];
+        var notifyAllBtn = document.getElementById('notify-all-btn');
+
+        (function initNotifyAll() {
+            if (!notifyAllBtn || PETS.length === 0) return;
+            if (!('Notification' in window) || !('serviceWorker' in navigator) || !('PushManager' in window)) return;
+            notifyAllBtn.style.display = '';
+
+            if (Notification.permission === 'denied') {
+                notifyAllBtn.textContent = '🔕 Blocked';
+                notifyAllBtn.disabled = true;
+                notifyAllBtn.style.opacity = '0.5';
+                return;
+            }
+
+            navigator.serviceWorker.ready.then(function (reg) {
+                return reg.pushManager.getSubscription();
+            }).then(function (sub) {
+                if (sub) {
+                    notifyAllBtn.textContent = '🔔 Notifications on';
+                    notifyAllBtn.dataset.state = 'enabled';
+                } else {
+                    notifyAllBtn.dataset.state = 'disabled';
+                }
+            }).catch(function () {});
+        })();
+
+        function urlBase64ToUint8Array(b64) {
+            var padding = '='.repeat((4 - b64.length % 4) % 4);
+            var base64 = (b64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+            var raw = atob(base64);
+            var arr = new Uint8Array(raw.length);
+            for (var i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+            return arr;
+        }
+
+        async function toggleAllNotifications() {
+            if (!notifyAllBtn) return;
+            var state = notifyAllBtn.dataset.state;
+
+            if (state === 'enabled') {
+                notifyAllBtn.textContent = '…';
+                notifyAllBtn.disabled = true;
+                try {
+                    var reg = await navigator.serviceWorker.ready;
+                    var sub = await reg.pushManager.getSubscription();
+                    if (sub) {
+                        for (var pet of PETS) {
+                            await fetch('/api/v1/push/subscribe', {
+                                method: 'DELETE',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ endpoint: sub.endpoint, pet_owner: pet.owner, pet_name: pet.name })
+                            });
+                        }
+                        await sub.unsubscribe();
+                    }
+                    notifyAllBtn.textContent = '🔔 Get notified';
+                    notifyAllBtn.dataset.state = 'disabled';
+                } catch {
+                    notifyAllBtn.textContent = '🔔 Notifications on';
+                }
+                notifyAllBtn.disabled = false;
+                return;
+            }
+
+            notifyAllBtn.textContent = '…';
+            notifyAllBtn.disabled = true;
+            try {
+                var permission = await Notification.requestPermission();
+                if (permission !== 'granted') {
+                    notifyAllBtn.textContent = permission === 'denied' ? '🔕 Blocked' : '🔔 Get notified';
+                    notifyAllBtn.disabled = permission === 'denied';
+                    notifyAllBtn.style.opacity = permission === 'denied' ? '0.5' : '1';
+                    notifyAllBtn.dataset.state = permission === 'denied' ? 'blocked' : 'disabled';
+                    return;
+                }
+                var keyResp = await fetch('/api/v1/push/vapid-public-key');
+                var keyData = await keyResp.json();
+                if (!keyData.publicKey) {
+                    notifyAllBtn.textContent = '🔔 Get notified';
+                    notifyAllBtn.disabled = false;
+                    return;
+                }
+                var reg = await navigator.serviceWorker.ready;
+                var sub = await reg.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey: urlBase64ToUint8Array(keyData.publicKey)
+                });
+                var subJson = sub.toJSON();
+                for (var pet of PETS) {
+                    await fetch('/api/v1/push/subscribe', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            endpoint: subJson.endpoint,
+                            p256dh: subJson.keys.p256dh,
+                            auth: subJson.keys.auth,
+                            pet_owner: pet.owner,
+                            pet_name: pet.name
+                        })
+                    });
+                }
+                notifyAllBtn.textContent = '🔔 Notifications on';
+                notifyAllBtn.dataset.state = 'enabled';
+            } catch {
+                notifyAllBtn.textContent = '🔔 Get notified';
+                notifyAllBtn.dataset.state = 'disabled';
+            }
+            notifyAllBtn.disabled = false;
+        }
 
         async function deletePet(owner, repo, cardId) {
             if (!confirm(`Delete pet for ${owner}/${repo}? This cannot be undone.`)) return;

--- a/src/github_tamagotchi/templates/graveyard.html
+++ b/src/github_tamagotchi/templates/graveyard.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if username %}{{ username }}'s Graveyard{% else %}The Graveyard{% endif %} — GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    {% include "_pwa_head.html" %}
+    <style>
+        .graveyard-hero {
+            text-align: center;
+            padding: 5rem 1rem 2rem;
+        }
+        .graveyard-hero h1 {
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+        }
+        .graveyard-hero p {
+            color: var(--text-muted);
+            font-size: 1rem;
+            max-width: 520px;
+            margin: 0 auto;
+        }
+        .graves-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 1.25rem;
+            padding-bottom: 3rem;
+        }
+        .grave-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 1.5rem;
+            text-decoration: none;
+            color: inherit;
+            transition: transform 0.15s, box-shadow 0.15s;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+        .grave-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        }
+        .grave-card-header {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+        .grave-sprite {
+            font-size: 2rem;
+            filter: grayscale(1) brightness(0.8);
+            opacity: 0.7;
+        }
+        .grave-name {
+            font-weight: 700;
+            font-size: 1.05rem;
+        }
+        .grave-repo {
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+        .grave-cause {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            font-style: italic;
+        }
+        .grave-meta {
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 1rem;
+            padding: 2rem 0;
+        }
+        .pagination a {
+            padding: 0.5rem 1.25rem;
+            border-radius: 8px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            color: inherit;
+            text-decoration: none;
+            font-size: 0.9rem;
+        }
+        .pagination a:hover {
+            background: var(--primary);
+            color: #fff;
+        }
+    </style>
+</head>
+<body>
+    {% set active_page = "graveyard" %}
+    {% include "_nav.html" %}
+
+    <main>
+        <div class="graveyard-hero">
+            {% if username %}
+            <h1>&#x1FAA6; {{ username }}'s Graveyard</h1>
+            <p>{{ total }} departed pet{{ "s" if total != 1 else "" }}.</p>
+            {% else %}
+            <h1>&#x1FAA6; The Graveyard</h1>
+            <p>A memorial for pets that didn't make it. Every project has a story, even the ones that ended.</p>
+            {% endif %}
+        </div>
+
+        <div class="container">
+            {% if graves %}
+            <div class="graves-grid">
+                {% for pet in graves %}
+                <a href="/graveyard/{{ pet.repo_owner }}/{{ pet.repo_name }}" class="grave-card">
+                    <div class="grave-card-header">
+                        <span class="grave-sprite">
+                            {% if pet.stage == "egg" %}&#x1F95A;
+                            {% elif pet.stage == "baby" %}&#x1F423;
+                            {% elif pet.stage == "child" %}&#x1F425;
+                            {% elif pet.stage == "teen" %}&#x1F426;
+                            {% elif pet.stage == "adult" %}&#x1F989;
+                            {% elif pet.stage == "elder" %}&#x1F985;
+                            {% else %}&#x1F95A;{% endif %}
+                        </span>
+                        <div>
+                            <div class="grave-name">{{ pet.name }}</div>
+                            <div class="grave-repo">{{ pet.repo_owner }}/{{ pet.repo_name }}</div>
+                        </div>
+                    </div>
+                    <div class="grave-cause">
+                        {% if pet.cause_of_death == "neglect" %}Died of neglect — the commits stopped coming
+                        {% elif pet.cause_of_death == "abandonment" %}Abandoned — the repository went dark
+                        {% elif pet.cause_of_death %}{{ pet.cause_of_death }}
+                        {% else %}Cause unknown{% endif %}
+                    </div>
+                    <div class="grave-meta">
+                        <span>{% if pet.died_at %}Died {{ pet.died_at.strftime('%b %d, %Y') }}{% endif %}</span>
+                        <span>&#x1F338; {{ pet.flower_count }}</span>
+                    </div>
+                </a>
+                {% endfor %}
+            </div>
+
+            {% if total > per_page %}
+            <div class="pagination">
+                {% if page > 1 %}
+                <a href="?page={{ page - 1 }}">&larr; Newer</a>
+                {% endif %}
+                {% if page * per_page < total %}
+                <a href="?page={{ page + 1 }}">Older &rarr;</a>
+                {% endif %}
+            </div>
+            {% endif %}
+
+            {% else %}
+            <div style="text-align: center; padding: 3rem 1rem; color: var(--text-muted);">
+                <p style="font-size: 2rem; margin-bottom: 1rem;">&#x1F331;</p>
+                <p>No graves yet. All pets are still alive!</p>
+            </div>
+            {% endif %}
+        </div>
+    </main>
+</body>
+</html>

--- a/src/github_tamagotchi/templates/graveyard_grave.html
+++ b/src/github_tamagotchi/templates/graveyard_grave.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>In Memory of {{ pet.name }} — GitHub Tamagotchi</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    {% include "_pwa_head.html" %}
+
+    <!-- OG tags for social sharing -->
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="In Memory of {{ pet.name }} ({{ pet.repo_owner }}/{{ pet.repo_name }})">
+    <meta property="og:description" content="{{ cause_label }}. Lived {{ age_days }} day{{ 's' if age_days != 1 else '' }} and reached {{ pet.stage | upper }} stage.">
+    <meta property="og:url" content="{{ base_url }}/graveyard/{{ pet.repo_owner }}/{{ pet.repo_name }}">
+    <meta property="og:image" content="{{ base_url }}/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ pet.stage }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="In Memory of {{ pet.name }}">
+    <meta name="twitter:description" content="{{ cause_label }}. Would have been {{ would_be_days }} days old today.">
+
+    <style>
+        .memorial {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 5rem 1rem 3rem;
+            text-align: center;
+        }
+        .memorial-sprite {
+            width: 160px;
+            height: 160px;
+            margin: 0 auto 1.5rem;
+            border-radius: 16px;
+            overflow: hidden;
+            filter: grayscale(0.85) brightness(0.85);
+            opacity: 0.85;
+        }
+        .memorial-sprite img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
+        .memorial h1 {
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+        .memorial-repo {
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            margin-bottom: 1.5rem;
+        }
+        .memorial-repo a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+        .headstone {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            padding: 2rem;
+            margin-bottom: 1.5rem;
+            text-align: center;
+        }
+        .headstone-dates {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-bottom: 1rem;
+        }
+        .headstone-cause {
+            font-style: italic;
+            color: var(--text-muted);
+            margin-bottom: 1rem;
+        }
+        .headstone-eulogy {
+            font-size: 1.1rem;
+            line-height: 1.5;
+            margin-bottom: 1rem;
+            padding: 0 1rem;
+        }
+        .headstone-would-be {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+        .memorial-stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 1rem;
+            margin-bottom: 2rem;
+        }
+        .memorial-stat {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+        }
+        .memorial-stat-value {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+        .memorial-stat-label {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .flower-section {
+            margin-bottom: 2rem;
+        }
+        .flower-btn {
+            background: none;
+            border: 2px solid var(--border);
+            border-radius: 50px;
+            padding: 0.6rem 1.5rem;
+            font-size: 1.1rem;
+            cursor: pointer;
+            transition: all 0.2s;
+            color: inherit;
+        }
+        .flower-btn:hover {
+            border-color: #f9a8d4;
+            background: rgba(249, 168, 212, 0.1);
+            transform: scale(1.05);
+        }
+        .flower-btn:disabled {
+            opacity: 0.5;
+            cursor: default;
+            transform: none;
+        }
+        .flower-count {
+            font-size: 1rem;
+            color: var(--text-muted);
+            margin-top: 0.5rem;
+        }
+        .petal-fall {
+            position: relative;
+            overflow: hidden;
+        }
+        .petal-fall::before {
+            content: '';
+            position: absolute;
+            top: -10px;
+            left: 0;
+            right: 0;
+            height: 4px;
+            background: linear-gradient(90deg, transparent, #f9a8d4, #fbbf24, #f9a8d4, transparent);
+            border-radius: 2px;
+        }
+        .eulogy-edit {
+            margin-top: 1rem;
+        }
+        .eulogy-edit textarea {
+            width: 100%;
+            padding: 0.75rem;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--surface);
+            color: inherit;
+            font-family: inherit;
+            font-size: 0.95rem;
+            resize: vertical;
+            min-height: 60px;
+            max-height: 120px;
+        }
+        .eulogy-edit-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.5rem;
+            margin-top: 0.5rem;
+        }
+        .eulogy-chars {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            text-align: right;
+        }
+        .memorial-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            justify-content: center;
+            margin-top: 2rem;
+        }
+        .memorial-links a {
+            padding: 0.5rem 1.25rem;
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            text-decoration: none;
+            color: inherit;
+            font-size: 0.9rem;
+            transition: background 0.15s;
+        }
+        .memorial-links a:hover {
+            background: rgba(255,255,255,0.05);
+        }
+    </style>
+</head>
+<body>
+    {% set active_page = "graveyard" %}
+    {% include "_nav.html" %}
+
+    <main class="memorial">
+        <div class="memorial-sprite">
+            <img src="/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ pet.stage }}"
+                 alt="{{ pet.name }}"
+                 onerror="this.parentElement.innerHTML='<span style=&quot;font-size:5rem;line-height:160px;&quot;>&#x1FAA6;</span>'">
+        </div>
+
+        <h1>{{ pet.name }}</h1>
+        <div class="memorial-repo">
+            <a href="https://github.com/{{ pet.repo_owner }}/{{ pet.repo_name }}" target="_blank" rel="noopener">
+                {{ pet.repo_owner }}/{{ pet.repo_name }}
+            </a>
+            {% if pet.generation > 1 %}<span style="opacity:0.6;"> &middot; Gen {{ pet.generation }}</span>{% endif %}
+        </div>
+
+        <div class="headstone {% if pet.flower_count > 100 %}petal-fall{% endif %}">
+            <div class="headstone-dates">
+                {% if pet.created_at %}{{ pet.created_at.strftime('%b %d, %Y') }}{% endif %}
+                &mdash;
+                {% if pet.died_at %}{{ pet.died_at.strftime('%b %d, %Y') }}{% endif %}
+            </div>
+
+            <div class="headstone-cause">{{ cause_label }}</div>
+
+            {% if pet.eulogy %}
+            <div class="headstone-eulogy">"{{ pet.eulogy }}"</div>
+            {% endif %}
+
+            <div class="headstone-would-be">
+                Would have been {{ would_be_days }} day{{ 's' if would_be_days != 1 else '' }} old today
+            </div>
+        </div>
+
+        {% if is_owner and not pet.eulogy %}
+        <div class="eulogy-edit" id="eulogy-section">
+            <button class="btn btn-primary" onclick="document.getElementById('eulogy-form').style.display='block'; this.style.display='none';" style="font-size:0.85rem; padding:0.4rem 1rem;">
+                Write an epitaph
+            </button>
+            <div id="eulogy-form" style="display:none;">
+                <textarea id="eulogy-text" maxlength="280" placeholder="Here lies my todo app, killed by scope creep..."></textarea>
+                <div class="eulogy-chars"><span id="eulogy-count">0</span>/280</div>
+                <div class="eulogy-edit-actions">
+                    <button class="btn btn-primary" onclick="saveEulogy()" style="font-size:0.85rem; padding:0.4rem 1rem;">Save</button>
+                </div>
+            </div>
+        </div>
+        {% elif is_owner and pet.eulogy %}
+        <div class="eulogy-edit" id="eulogy-section">
+            <button class="btn" onclick="editEulogy()" style="font-size:0.8rem; padding:0.3rem 0.75rem; opacity:0.6;">Edit epitaph</button>
+            <div id="eulogy-form" style="display:none;">
+                <textarea id="eulogy-text" maxlength="280">{{ pet.eulogy }}</textarea>
+                <div class="eulogy-chars"><span id="eulogy-count">{{ pet.eulogy | length }}</span>/280</div>
+                <div class="eulogy-edit-actions">
+                    <button class="btn btn-primary" onclick="saveEulogy()" style="font-size:0.85rem; padding:0.4rem 1rem;">Save</button>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="memorial-stats">
+            <div class="memorial-stat">
+                <div class="memorial-stat-value">{{ age_days }}</div>
+                <div class="memorial-stat-label">Days lived</div>
+            </div>
+            <div class="memorial-stat">
+                <div class="memorial-stat-value">{{ pet.stage | capitalize }}</div>
+                <div class="memorial-stat-label">Stage reached</div>
+            </div>
+            <div class="memorial-stat">
+                <div class="memorial-stat-value">{{ pet.experience }}</div>
+                <div class="memorial-stat-label">XP earned</div>
+            </div>
+            <div class="memorial-stat">
+                <div class="memorial-stat-value">{{ pet.longest_streak }}</div>
+                <div class="memorial-stat-label">Best streak</div>
+            </div>
+        </div>
+
+        <div class="flower-section">
+            <button class="flower-btn" id="flower-btn" onclick="placeFlower()">
+                &#x1F338; Leave flowers
+            </button>
+            <div class="flower-count" id="flower-count">
+                {{ pet.flower_count }} flower{{ 's' if pet.flower_count != 1 else '' }} left
+            </div>
+        </div>
+
+        <div class="memorial-links">
+            <a href="/graveyard/{{ pet.repo_owner }}">{{ pet.repo_owner }}'s graveyard</a>
+            <a href="/graveyard">All graves</a>
+            {% if is_owner %}
+            <a href="/pet/{{ pet.repo_owner }}/{{ pet.repo_name }}">Pet profile</a>
+            {% endif %}
+        </div>
+    </main>
+
+    <script>
+    async function placeFlower() {
+        const btn = document.getElementById('flower-btn');
+        btn.disabled = true;
+        try {
+            const res = await fetch('/api/v1/graveyard/{{ pet.repo_owner }}/{{ pet.repo_name }}/flower', {
+                method: 'POST'
+            });
+            const data = await res.json();
+            document.getElementById('flower-count').textContent =
+                data.flower_count + ' flower' + (data.flower_count !== 1 ? 's' : '') + ' left';
+            if (!data.added) {
+                btn.textContent = '\u{1F338} Already left today';
+            } else {
+                btn.textContent = '\u{1F338} Flowers left!';
+            }
+        } catch (e) {
+            btn.textContent = '\u{1F338} Leave flowers';
+            btn.disabled = false;
+        }
+    }
+
+    const eulogyText = document.getElementById('eulogy-text');
+    if (eulogyText) {
+        eulogyText.addEventListener('input', function() {
+            document.getElementById('eulogy-count').textContent = this.value.length;
+        });
+    }
+
+    function editEulogy() {
+        document.getElementById('eulogy-form').style.display = 'block';
+        event.target.style.display = 'none';
+    }
+
+    async function saveEulogy() {
+        const text = document.getElementById('eulogy-text').value;
+        try {
+            const res = await fetch('/api/v1/graveyard/{{ pet.repo_owner }}/{{ pet.repo_name }}/eulogy', {
+                method: 'PUT',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({eulogy: text})
+            });
+            if (res.ok) {
+                location.reload();
+            }
+        } catch (e) { /* ignore */ }
+    }
+    </script>
+</body>
+</html>

--- a/src/github_tamagotchi/templates/landing.html
+++ b/src/github_tamagotchi/templates/landing.html
@@ -23,6 +23,7 @@
 <body>
     {% set active_page = "landing" %}
     {% include "_nav.html" %}
+    {% include "_pwa_install_banner.html" %}
 
     <!-- Hero Section -->
     <section class="hero">

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -39,6 +39,7 @@
 </head>
 <body>
     {% include "_nav.html" %}
+    {% include "_pwa_install_banner.html" %}
 
     <!-- Profile -->
     <main class="profile-page">


### PR DESCRIPTION
## Summary
- **Enhanced service worker**: periodic background sync (`check-pet-health` every 4h) polls `/api/v1/me/pets` and shows notifications for unhappy/dying pets. Network-first page caching for offline support.
- **Install prompt**: floating banner on dashboard, landing, and pet profile pages. Dismissible per session, auto-hides after install. Uses `beforeinstallprompt` API.
- **Dashboard notifications**: "Get notified" button subscribes to push notifications for all living pets at once.
- **Manifest improvements**: added `scope`, `id`, and app shortcuts for quick access to dashboard/leaderboard/graveyard.

## Test plan
- [ ] Visit dashboard on Android Chrome — install banner should appear
- [ ] Click "Install" to add to home screen as standalone app
- [ ] Dismiss banner — should not reappear in same session
- [ ] Click "Get notified" on dashboard — prompts for notification permission, subscribes all pets
- [ ] Verify service worker registers and caches static assets
- [ ] Verify offline access to cached pages (dashboard, leaderboard, graveyard)
- [ ] Check periodic sync registration in DevTools > Application > Periodic Sync