### PR TITLE
fix: award XP for releases and contributors to prevent egg stall

### DIFF
--- a/src/github_tamagotchi/services/pet_logic.py
+++ b/src/github_tamagotchi/services/pet_logic.py
@@ -133,14 +133,19 @@ def calculate_experience(health: RepoHealth) -> int:
     """Calculate experience gained from repo activity."""
     exp = 0
 
-    # Experience from activity
     if health.last_ci_success:
         exp += 10
     if health.last_commit_at:
         now = datetime.now(UTC)
         hours_since_commit = (now - health.last_commit_at).total_seconds() / 3600
         if hours_since_commit < 24:
-            exp += 20  # Recent commit
+            exp += 20
+
+    # Releases and contributors mirror health_delta — repos that ship
+    # code and attract contributors should evolve even when the commit
+    # API call fails or the last push was >24 h ago.
+    exp += min(health.release_count_30d * 2, 10)
+    exp += min(health.contributor_count, 5)
 
     return exp
 

--- a/tests/unit/test_pet_logic.py
+++ b/tests/unit/test_pet_logic.py
@@ -635,6 +635,79 @@ class TestCalculateExperience:
         )
         assert calculate_experience(health) == 0
 
+    def test_experience_from_releases(self) -> None:
+        """Should gain experience from recent releases."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=3,
+        )
+        assert calculate_experience(health) == 6  # 3 * 2
+
+    def test_experience_from_contributors(self) -> None:
+        """Should gain experience from contributors."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            contributor_count=4,
+        )
+        assert calculate_experience(health) == 4
+
+    def test_experience_releases_capped(self) -> None:
+        """Release XP should be capped at 10."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=20,
+        )
+        assert calculate_experience(health) == 10
+
+    def test_experience_contributors_capped(self) -> None:
+        """Contributor XP should be capped at 5."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            contributor_count=100,
+        )
+        assert calculate_experience(health) == 5
+
+    def test_active_repo_without_recent_commit_gains_xp(self) -> None:
+        """Regression test: active repos should gain XP even when last_commit_at
+        is None (e.g. API failure) if they have releases/contributors."""
+        health = RepoHealth(
+            last_commit_at=None,
+            open_prs_count=0,
+            oldest_pr_age_hours=None,
+            open_issues_count=0,
+            oldest_issue_age_days=None,
+            last_ci_success=False,
+            has_stale_dependencies=False,
+            release_count_30d=2,
+            contributor_count=3,
+        )
+        # 2 * 2 (releases) + 3 (contributors) = 7
+        assert calculate_experience(health) == 7
+
 
 class TestGetNextStage:
     """Tests for get_next_stage function."""


### PR DESCRIPTION
## Summary
- Fixes #184: active repos stuck as eggs with 0 XP
- `calculate_experience` now awards XP for releases (+2 per release in last 30d, capped at 10) and contributors (+1 per contributor, capped at 5), matching how `calculate_health_delta` already works
- Root cause: repos could reach health=100 from releases/contributors alone, but XP only came from recent commits and CI — if the commit API failed or the last push was >24h ago, XP stayed at 0

## Test plan
- [x] 5 new unit tests covering release XP, contributor XP, caps, and the regression scenario
- [x] All 1145 tests pass
- [ ] After deploy, trigger a poll and verify previously-stuck eggs gain XP