### PR TITLE
feat: hide onboarding banner for pet owners, add register CTA

### DIFF
--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -1023,12 +1023,20 @@ async def pet_profile(
 
     contributor_relationships = await get_contributors_for_pet(session, pet.id)
 
+    user_has_pets = False
+    if user:
+        own_pets = await session.execute(
+            select(func.count()).select_from(Pet).where(Pet.user_id == user.id)
+        )
+        user_has_pets = (own_pets.scalar_one() or 0) > 0
+
     page_url = str(request.url)
     return templates.TemplateResponse(
         request,
         "pet_profile.html",
         {
             "user": user,
+            "user_has_pets": user_has_pets,
             "pet": pet,
             "age_days": age_days,
             "evolution_timeline": evolution_timeline,

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -44,7 +44,8 @@
     <main class="profile-page">
         <div class="container">
 
-            <!-- Onboarding banner: shown once per browser, dismissed via localStorage -->
+            {% if not user or not user_has_pets %}
+            <!-- Onboarding banner: shown once per browser for new visitors, hidden for pet owners -->
             <div id="onboarding-banner" style="display:none; margin-bottom: 1.25rem; padding: 1rem 1.25rem; border-radius: 10px; background: linear-gradient(135deg, rgba(99,102,241,0.18), rgba(139,92,246,0.12)); border: 1px solid rgba(139,92,246,0.45); position: relative;">
                 <button
                     onclick="dismissOnboardingBanner()"
@@ -54,7 +55,8 @@
                     onmouseout="this.style.color='rgba(255,255,255,0.55)'; this.style.background='none';"
                 >&#x2715;</button>
                 <strong style="color: #a78bfa; font-size: 1rem;">Meet your repo&#8217;s pet!</strong>
-                <span style="color: rgba(255,255,255,0.85); font-size: 0.95rem;"> This Tamagotchi lives off your repository&#8217;s health &#8212; commits feed it, CI passes make it dance, and neglect makes it hungry. Keep your repo active to help it thrive.</span>
+                <span style="color: rgba(255,255,255,0.85); font-size: 0.95rem;"> This Tamagotchi lives off your repository&#8217;s health &#8212; commits feed it, CI passes make it dance, and neglect makes it hungry.</span>
+                <a href="/register" style="color: #a78bfa; font-weight: 600; text-decoration: none; margin-left: 0.25rem;">Register your own repo &rarr;</a>
             </div>
             <script>
             (function () {
@@ -69,6 +71,7 @@
                 if (el) { el.style.display = 'none'; }
             }
             </script>
+            {% endif %}
 
             {% if days_until_death is not none %}
             <div style="margin-bottom: 1.25rem; padding: 1rem 1.25rem; border-radius: 10px; background: linear-gradient(135deg, rgba(239,68,68,0.15), rgba(249,115,22,0.10)); border: 1px solid rgba(239,68,68,0.5); display: flex; align-items: center; gap: 0.75rem;">


### PR DESCRIPTION
## Summary
- Closes #183: onboarding banner on pet profile now only shows for unauthenticated visitors or users without pets
- Added "Register your own repo" CTA link to the banner
- Note: #182 (badge embed snippet) was already implemented — Markdown/HTML snippets with copy buttons and live preview already exist on the pet profile page

## Test plan
- [ ] Visit a pet profile page as unauthenticated user — banner should appear
- [ ] Visit as authenticated user with registered pets — banner should NOT appear
- [ ] Visit as authenticated user with no pets — banner should appear
- [ ] Click "Register your own repo" link — should navigate to /register
- [ ] Dismiss banner — should stay dismissed via localStorage