### PR TITLE
fix: PWA install banner positioning on mobile

### DIFF
--- a/src/github_tamagotchi/static/css/style.css
+++ b/src/github_tamagotchi/static/css/style.css
@@ -1844,17 +1844,17 @@ details[open] .webhook-summary::before {
 .pwa-install-banner {
     position: fixed;
     bottom: calc(env(safe-area-inset-bottom, 0px) + 70px);
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 900;
-    width: calc(100% - 2rem);
+    left: 1rem;
+    right: 1rem;
+    margin: 0 auto;
     max-width: 480px;
+    z-index: 900;
     animation: pwa-slide-up 0.3s ease-out;
 }
 
 @keyframes pwa-slide-up {
-    from { transform: translateX(-50%) translateY(100%); opacity: 0; }
-    to   { transform: translateX(-50%) translateY(0); opacity: 1; }
+    from { transform: translateY(100%); opacity: 0; }
+    to   { transform: translateY(0); opacity: 1; }
 }
 
 .pwa-install-content {
@@ -1902,11 +1902,16 @@ details[open] .webhook-summary::before {
     background: none;
     border: none;
     color: var(--text-muted);
-    font-size: 1.3rem;
+    font-size: 1.4rem;
     cursor: pointer;
-    padding: 0.25rem;
+    padding: 0.5rem;
     line-height: 1;
     flex-shrink: 0;
+    min-width: 44px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .pwa-install-dismiss:hover {


### PR DESCRIPTION
## Summary
- Fix PWA install banner rendering flush-left and clipped on mobile
- Root cause: `left: 50%; transform: translateX(-50%)` centering conflicted with the `pwa-slide-up` animation (both used `transform`), causing the banner to lose horizontal centering
- Switch to `left/right/margin: auto` centering which doesn't need `transform`
- Increase dismiss button tap target to 44px minimum

## Test plan
- [ ] Open landing page on mobile, verify install banner is centered and fully visible
- [ ] Verify slide-up animation works smoothly
- [ ] Verify dismiss button is easy to tap
- [ ] Check desktop positioning (bottom-right area)