### PR TITLE
feat: FunnelBarn analytics + BugBarn client-side logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ MINIO_SECURE=false
 HOST=0.0.0.0
 PORT=8000
 
+# FunnelBarn analytics (client-side, safe to expose)
+FUNNELBARN_API_KEY=
+
 # Alerting
 ALERTING_ENABLED=false
 ALERT_SLACK_WEBHOOK=

--- a/src/github_tamagotchi/core/config.py
+++ b/src/github_tamagotchi/core/config.py
@@ -73,6 +73,9 @@ class Settings(BaseSettings):
     # Sentry
     sentry_dsn: str | None = None
 
+    # FunnelBarn analytics (client-side, public key)
+    funnelbarn_api_key: str | None = None
+
     # BugBarn
     bugbarn_endpoint: str | None = None
     bugbarn_api_key: str | None = None

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -76,6 +76,10 @@ configure_logging()
 # Set up paths for templates and static files
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+templates.env.globals["funnelbarn_api_key"] = settings.funnelbarn_api_key
+templates.env.globals["bugbarn_endpoint"] = settings.bugbarn_endpoint
+templates.env.globals["bugbarn_api_key"] = settings.bugbarn_api_key
+templates.env.globals["bugbarn_project"] = settings.bugbarn_project
 
 logger = structlog.get_logger()
 

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -609,6 +609,16 @@ async def service_worker() -> Response:
     )
 
 
+@app.get("/manifest.json", include_in_schema=False)
+async def root_manifest() -> Response:
+    """Serve the root PWA manifest."""
+    manifest_path = BASE_DIR / "static" / "manifest.json"
+    return Response(
+        content=manifest_path.read_text(),
+        media_type="application/manifest+json",
+    )
+
+
 @app.get("/pet/{repo_owner}/{repo_name}/manifest.json", include_in_schema=False)
 async def pet_manifest(
     repo_owner: str,

--- a/src/github_tamagotchi/services/openrouter.py
+++ b/src/github_tamagotchi/services/openrouter.py
@@ -18,9 +18,11 @@ from github_tamagotchi.services.image_generation import (
 )
 from github_tamagotchi.services.sprite_sheet import (
     SpriteSheetResult,
+    analyze_sprite_sheet,
     build_sprite_sheet_prompt,
     extract_frames,
     get_canonical_appearance_description,
+    reorder_frames_by_analysis,
 )
 
 logger = structlog.get_logger()
@@ -186,17 +188,22 @@ class OpenRouterService:
                     error="No image data in OpenRouter sprite sheet response",
                 )
 
-            frames = extract_frames(image_data)
+            raw_frames = extract_frames(image_data)
             appearance_desc = canonical_appearance or get_canonical_appearance_description(
                 owner, repo
             )
+
+            analysis = await analyze_sprite_sheet(image_data, self.api_key or "")
+            frames = reorder_frames_by_analysis(raw_frames, analysis) if analysis else raw_frames
 
             logger.info(
                 "Sprite sheet generated",
                 owner=owner,
                 repo=repo,
                 stage=stage,
-                frame_count=len(frames),
+                raw_frame_count=len(raw_frames),
+                reordered_frame_count=len(frames),
+                vision_analysis=bool(analysis),
             )
             return SpriteSheetResult(
                 success=True,

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -1,9 +1,13 @@
 """Sprite sheet generation, frame extraction, and animated GIF composition."""
 
+import base64
 import io
+import json
+import re
 from collections import deque
 from dataclasses import dataclass, field
 
+import httpx
 import structlog
 from PIL import Image
 
@@ -18,9 +22,9 @@ logger = structlog.get_logger()
 
 # Sprite sheet grid layout
 SPRITE_COLS = 3
-SPRITE_ROWS = 2
+SPRITE_ROWS = 3
 
-# Frame index constants
+# Frame index constants — the canonical order we want
 FRAME_IDLE = 0
 FRAME_BLINK = 1
 FRAME_HAPPY = 2
@@ -36,7 +40,12 @@ SPRITE_FRAMES: list[tuple[int, str, str]] = [
     (FRAME_SAD, "sad", "sad frown, single teardrop on cheek, slightly slumped posture"),
     (FRAME_SICK, "sick", "sickly green tinge, droopy half-closed eyes, unsteady outline"),
     (FRAME_SLEEPING, "sleeping", "eyes closed, small zzz bubble floating above, resting"),
+    (6, "eating", "mouth open, small food particle nearby, chewing expression"),
+    (7, "excited", "wide eyes, jumping pose, exclamation sparkle"),
+    (8, "angry", "furrowed brows, puffed cheeks, small angry vein mark"),
 ]
+
+FRAME_NAMES = [name for _, name, _ in SPRITE_FRAMES]
 
 # Frame display durations in milliseconds
 FRAME_DURATIONS: dict[int, int] = {
@@ -134,7 +143,7 @@ def build_sprite_sheet_prompt(
     negative = (
         style_def.get("negative", NEGATIVE_PROMPT)
         + ", multiple different characters, text labels, numbers, digits, numerals, "
-        "annotations, captions, 3x3 grid, 9 cells, extra rows, extra columns, "
+        "annotations, captions, extra rows, extra columns, "
         "uneven cells, misaligned grid, inconsistent character design, white background"
     )
 
@@ -260,6 +269,111 @@ def extract_frames(
             frames.append(out.getvalue())
 
     return frames
+
+
+VISION_MODEL = "google/gemini-2.0-flash-001"
+VISION_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+async def analyze_sprite_sheet(
+    sprite_sheet_bytes: bytes,
+    api_key: str,
+) -> list[dict[str, str | int | bool]]:
+    """Use a vision model to analyze a sprite sheet and identify each cell's content.
+
+    Returns a list of dicts, one per grid cell (left-to-right, top-to-bottom):
+        [{"index": 0, "empty": False, "emotion": "idle"}, ...]
+
+    The emotion field is one of the FRAME_NAMES values, or "unknown".
+    """
+    b64 = base64.b64encode(sprite_sheet_bytes).decode()
+    data_uri = f"data:image/png;base64,{b64}"
+
+    emotion_list = ", ".join(FRAME_NAMES)
+    prompt = (
+        "This is a pixel art sprite sheet arranged as a 3x3 grid (9 cells). "
+        "Analyze each cell from left-to-right, top-to-bottom (cells 0-8). "
+        "For each cell, determine:\n"
+        "1. Whether it contains a character (not empty)\n"
+        f"2. Which emotion best matches from: {emotion_list}\n\n"
+        "Respond with ONLY a JSON array of 9 objects, no other text:\n"
+        '[{"index": 0, "empty": false, "emotion": "idle"}, ...]\n'
+        "If a cell is empty or has no character, set empty=true and emotion=\"unknown\"."
+    )
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": VISION_MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ],
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(VISION_API_URL, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        text = data["choices"][0]["message"]["content"]
+        match = re.search(r"\[.*\]", text, re.DOTALL)
+        if not match:
+            logger.warning("vision_analysis_no_json", response_text=text[:200])
+            return []
+
+        cells = json.loads(match.group())
+        logger.info("vision_analysis_complete", cells=cells)
+        return cells
+    except Exception:
+        logger.exception("vision_analysis_failed")
+        return []
+
+
+def reorder_frames_by_analysis(
+    raw_frames: list[bytes],
+    analysis: list[dict[str, str | int | bool]],
+) -> list[bytes]:
+    """Reorder extracted frames to match canonical FRAME_* order using vision analysis.
+
+    Maps each analyzed cell to the canonical frame index by emotion name.
+    Falls back to the first non-empty frame for any emotion not found.
+    """
+    if not analysis or len(raw_frames) != len(analysis):
+        return raw_frames[:len(SPRITE_FRAMES)]
+
+    emotion_to_frame_idx: dict[str, int] = {
+        name: idx for idx, name, _ in SPRITE_FRAMES
+    }
+
+    available: dict[int, bytes] = {}
+    first_nonempty: bytes | None = None
+
+    for cell, frame_data in zip(analysis, raw_frames, strict=False):
+        if cell.get("empty", False):
+            continue
+        if first_nonempty is None:
+            first_nonempty = frame_data
+
+        emotion = str(cell.get("emotion", "unknown")).lower()
+        canonical_idx = emotion_to_frame_idx.get(emotion)
+        if canonical_idx is not None and canonical_idx not in available:
+            available[canonical_idx] = frame_data
+
+    fallback = first_nonempty or raw_frames[0]
+    ordered: list[bytes] = []
+    for idx, _, _ in SPRITE_FRAMES:
+        ordered.append(available.get(idx, fallback))
+
+    return ordered
 
 
 def _rgba_to_gif_frame(img: Image.Image) -> tuple[Image.Image, int]:

--- a/src/github_tamagotchi/services/sprite_sheet.py
+++ b/src/github_tamagotchi/services/sprite_sheet.py
@@ -330,7 +330,7 @@ async def analyze_sprite_sheet(
             logger.warning("vision_analysis_no_json", response_text=text[:200])
             return []
 
-        cells = json.loads(match.group())
+        cells: list[dict[str, str | int | bool]] = json.loads(match.group())
         logger.info("vision_analysis_complete", cells=cells)
         return cells
     except Exception:

--- a/src/github_tamagotchi/static/js/analytics.js
+++ b/src/github_tamagotchi/static/js/analytics.js
@@ -1,0 +1,198 @@
+/**
+ * FunnelBarn analytics — typed event definitions and safe tracking helpers.
+ * BugBarn client-side logging — ships warnings/errors to BugBarn logs API.
+ *
+ * Every tracked event is defined in FB_EVENTS. Callers use:
+ *   fbTrack(FB_EVENTS.PET_FED, { owner: '…', repo: '…' })
+ *
+ * If the SDK fails to load or throws, a warning is sent to BugBarn.
+ * Calls before the SDK is ready are queued and replayed once it loads.
+ */
+
+// ── BugBarn client-side logger ──────────────────────────────────────────────
+
+var _bbLogQueue = [];
+var _bbFlushTimer = null;
+
+function _bbFlush() {
+    var cfg = window.__bugbarn;
+    if (!cfg || !cfg.endpoint || !cfg.apiKey) return;
+    var batch = _bbLogQueue.splice(0);
+    if (batch.length === 0) return;
+
+    var url = cfg.endpoint.replace(/\/+$/, '') + '/api/v1/logs';
+    var body = JSON.stringify({ logs: batch });
+    try {
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'x-bugbarn-api-key': cfg.apiKey,
+                'x-bugbarn-project': cfg.project
+            },
+            body: body,
+            keepalive: true
+        }).catch(function() {});
+    } catch (e) {}
+}
+
+function _bbEnqueue(entry) {
+    _bbLogQueue.push(entry);
+    if (_bbFlushTimer) clearTimeout(_bbFlushTimer);
+    _bbFlushTimer = setTimeout(_bbFlush, 2000);
+}
+
+function bbLog(level, message, extra) {
+    var entry = {
+        timestamp: new Date().toISOString(),
+        level: level,
+        event: message,
+        source: 'client',
+        url: window.location.href,
+        user_agent: navigator.userAgent
+    };
+    if (extra) {
+        for (var k in extra) {
+            if (extra.hasOwnProperty(k)) entry[k] = extra[k];
+        }
+    }
+    _bbEnqueue(entry);
+}
+
+window.addEventListener('beforeunload', _bbFlush);
+
+// Global error handler
+window.addEventListener('error', function(e) {
+    bbLog('warning', 'unhandled_error', {
+        error_message: e.message,
+        filename: e.filename,
+        lineno: e.lineno,
+        colno: e.colno
+    });
+});
+
+// Global promise rejection handler
+window.addEventListener('unhandledrejection', function(e) {
+    bbLog('warning', 'unhandled_promise_rejection', {
+        error_message: e.reason ? (e.reason.message || String(e.reason)) : 'unknown'
+    });
+});
+
+// ── FunnelBarn event definitions ────────────────────────────────────────────
+
+var FB_EVENTS = Object.freeze({
+    // Auth
+    LOGIN_STARTED:        'login_started',
+    LOGOUT:               'logout',
+
+    // Registration
+    REPO_SELECTED:        'repo_selected',
+    PET_ADOPTED:          'pet_adopted',
+    REGISTRATION_COMPLETE:'registration_complete',
+
+    // Pet actions
+    PET_FED:              'pet_fed',
+    PET_RESURRECTED:      'pet_resurrected',
+    PET_DELETED:          'pet_deleted',
+
+    // Social / sharing
+    COMMENT_POSTED:       'comment_posted',
+    LINK_COPIED:          'link_copied',
+    BADGE_EMBED_COPIED:   'badge_embed_copied',
+    EMBED_COPIED:         'embed_copied',
+    SHARED_TWITTER:       'shared_twitter',
+    MILESTONE_SHARED_TWITTER: 'milestone_shared_twitter',
+    MILESTONE_LINK_COPIED:'milestone_link_copied',
+
+    // Graveyard
+    FLOWER_PLACED:        'flower_placed',
+    EULOGY_SAVED:         'eulogy_saved',
+
+    // PWA
+    PWA_INSTALL_PROMPTED: 'pwa_install_prompted',
+    PWA_INSTALLED:        'pwa_installed',
+    PWA_INSTALL_DISMISSED:'pwa_install_dismissed',
+
+    // Push notifications
+    PUSH_SUBSCRIBED:      'push_subscribed',
+    PUSH_SUBSCRIBED_ALL:  'push_subscribed_all',
+
+    // Onboarding
+    ONBOARDING_DISMISSED: 'onboarding_dismissed',
+
+    // Pet admin
+    PET_SETTINGS_SAVED:   'pet_settings_saved',
+    CONTRIBUTOR_EXCLUDED:  'contributor_excluded',
+    CONTRIBUTOR_UNEXCLUDED:'contributor_unexcluded',
+    ADMIN_PET_RESET:      'admin_pet_reset',
+    ADMIN_PET_DELETED:    'admin_pet_deleted',
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function fbPetProps(owner, repo, extra) {
+    var props = { owner: owner, repo: repo };
+    if (extra) {
+        for (var k in extra) {
+            if (extra.hasOwnProperty(k)) props[k] = extra[k];
+        }
+    }
+    return props;
+}
+
+// SDK loads with defer — queue calls until it's ready, then replay.
+var _fbQueue = [];
+var _fbReady = false;
+var _fbSdkExpected = false;
+var _fbSdkWarnSent = false;
+
+window.fbTrack = function(name, props) {
+    if (_fbReady && window.FunnelBarn) {
+        try { FunnelBarn.track(name, props); } catch(e) {
+            bbLog('warning', 'funnelbarn_track_error', { event_name: name, error_message: e.message });
+        }
+    } else if (_fbSdkExpected) {
+        _fbQueue.push({ type: 'track', name: name, props: props });
+    }
+};
+
+window.fbIdentify = function(userId) {
+    if (_fbReady && window.FunnelBarn) {
+        try { FunnelBarn.identify(userId); } catch(e) {
+            bbLog('warning', 'funnelbarn_identify_error', { error_message: e.message });
+        }
+    } else if (_fbSdkExpected) {
+        _fbQueue.push({ type: 'identify', userId: userId });
+    }
+};
+
+// Called once the page (and deferred scripts) have loaded.
+// If the SDK script tag is present but FunnelBarn isn't on window, it failed.
+function _fbInit() {
+    _fbSdkExpected = !!document.querySelector('script[data-api-key][src*="funnelbarn"]');
+    if (!_fbSdkExpected) return;
+
+    if (window.FunnelBarn) {
+        _fbReady = true;
+        for (var i = 0; i < _fbQueue.length; i++) {
+            var item = _fbQueue[i];
+            try {
+                if (item.type === 'track') FunnelBarn.track(item.name, item.props);
+                else if (item.type === 'identify') FunnelBarn.identify(item.userId);
+            } catch(e) {
+                bbLog('warning', 'funnelbarn_replay_error', { event_name: item.name, error_message: e.message });
+            }
+        }
+        _fbQueue = [];
+    } else {
+        bbLog('warning', 'funnelbarn_sdk_failed_to_load', {
+            queued_events: _fbQueue.length
+        });
+    }
+}
+
+if (document.readyState === 'complete') {
+    _fbInit();
+} else {
+    window.addEventListener('load', _fbInit);
+}

--- a/src/github_tamagotchi/templates/_nav.html
+++ b/src/github_tamagotchi/templates/_nav.html
@@ -111,6 +111,7 @@
     var btn = document.getElementById('logout-btn');
     if (btn) {
         btn.addEventListener('click', async function () {
+            fbTrack(FB_EVENTS.LOGOUT);
             await fetch('/auth/logout', { method: 'POST' });
             window.location.href = '/';
         });
@@ -120,10 +121,16 @@
     var mobileLogout = document.getElementById('more-logout-btn');
     if (mobileLogout) {
         mobileLogout.addEventListener('click', async function () {
+            fbTrack(FB_EVENTS.LOGOUT);
             await fetch('/auth/logout', { method: 'POST' });
             window.location.href = '/';
         });
     }
+
+    // Track login clicks
+    document.querySelectorAll('a[href="/auth/github"]').forEach(function (link) {
+        link.addEventListener('click', function () { fbTrack(FB_EVENTS.LOGIN_STARTED); });
+    });
 })();
 
 function openMoreSheet() {

--- a/src/github_tamagotchi/templates/_pwa_head.html
+++ b/src/github_tamagotchi/templates/_pwa_head.html
@@ -1,3 +1,18 @@
+<!-- FunnelBarn analytics -->
+<script>
+window.__bugbarn = {
+    endpoint: {{ (bugbarn_endpoint or '') | tojson }},
+    apiKey: {{ (bugbarn_api_key or '') | tojson }},
+    project: {{ (bugbarn_project or '') | tojson }}
+};
+</script>
+<script src="/static/js/analytics.js"></script>
+{% if funnelbarn_api_key %}
+<script src="https://funnelbarn.wiebe.xyz/sdk.js" data-api-key="{{ funnelbarn_api_key }}" defer></script>
+{% if user %}
+<script>document.addEventListener('DOMContentLoaded', function() { fbIdentify({{ user.github_login | tojson }}); });</script>
+{% endif %}
+{% endif %}
 <!-- PWA: manifest, theme, and service worker registration -->
 <link rel="manifest" href="{{ pwa_manifest_url | default('/manifest.json') }}">
 <meta name="theme-color" content="#6366f1">
@@ -32,13 +47,14 @@ window.addEventListener('beforeinstallprompt', function (e) {
     _deferredInstallPrompt = e;
     try { if (sessionStorage.getItem('pwa-install-dismissed')) return; } catch {}
     var banner = document.getElementById('pwa-install-banner');
-    if (banner) banner.style.display = '';
+    if (banner) { banner.style.display = ''; fbTrack(FB_EVENTS.PWA_INSTALL_PROMPTED); }
 });
 
 window.addEventListener('appinstalled', function () {
     _deferredInstallPrompt = null;
     var banner = document.getElementById('pwa-install-banner');
     if (banner) banner.style.display = 'none';
+    fbTrack(FB_EVENTS.PWA_INSTALLED);
 });
 
 window.installPwa = function () {
@@ -55,5 +71,6 @@ window.dismissInstallBanner = function () {
     var banner = document.getElementById('pwa-install-banner');
     if (banner) banner.style.display = 'none';
     try { sessionStorage.setItem('pwa-install-dismissed', '1'); } catch {}
+    fbTrack(FB_EVENTS.PWA_INSTALL_DISMISSED);
 };
 </script>

--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -232,6 +232,7 @@
                 }
                 notifyAllBtn.textContent = '🔔 Notifications on';
                 notifyAllBtn.dataset.state = 'enabled';
+                fbTrack(FB_EVENTS.PUSH_SUBSCRIBED_ALL, { pet_count: PETS.length });
             } catch {
                 notifyAllBtn.textContent = '🔔 Get notified';
                 notifyAllBtn.dataset.state = 'disabled';
@@ -243,6 +244,7 @@
             if (!confirm(`Delete pet for ${owner}/${repo}? This cannot be undone.`)) return;
             const resp = await fetch(`/api/v1/pets/${owner}/${repo}`, { method: 'DELETE' });
             if (resp.ok) {
+                fbTrack(FB_EVENTS.PET_DELETED, fbPetProps(owner, repo));
                 document.getElementById(cardId).remove();
                 const grid = document.querySelector('.feature-grid');
                 if (grid && grid.children.length === 0) location.reload();

--- a/src/github_tamagotchi/templates/graveyard_grave.html
+++ b/src/github_tamagotchi/templates/graveyard_grave.html
@@ -307,6 +307,7 @@
                 btn.textContent = '\u{1F338} Already left today';
             } else {
                 btn.textContent = '\u{1F338} Flowers left!';
+                fbTrack(FB_EVENTS.FLOWER_PLACED, fbPetProps({{ pet.repo_owner | tojson }}, {{ pet.repo_name | tojson }}));
             }
         } catch (e) {
             btn.textContent = '\u{1F338} Leave flowers';
@@ -335,6 +336,7 @@
                 body: JSON.stringify({eulogy: text})
             });
             if (res.ok) {
+                fbTrack(FB_EVENTS.EULOGY_SAVED, fbPetProps({{ pet.repo_owner | tojson }}, {{ pet.repo_name | tojson }}));
                 location.reload();
             }
         } catch (e) { /* ignore */ }

--- a/src/github_tamagotchi/templates/pet_admin.html
+++ b/src/github_tamagotchi/templates/pet_admin.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin — {{ pet.name }} | GitHub Tamagotchi</title>
     <link rel="stylesheet" href="/static/css/style.css">
+    <script>
+    window.__bugbarn = {
+        endpoint: {{ (bugbarn_endpoint or '') | tojson }},
+        apiKey: {{ (bugbarn_api_key or '') | tojson }},
+        project: {{ (bugbarn_project or '') | tojson }}
+    };
+    </script>
+    <script src="/static/js/analytics.js"></script>
     <style>
         .admin-section {
             background: var(--surface);
@@ -456,6 +464,7 @@
             dirty = false;
             saveBar.classList.remove('visible');
             showToast('Settings saved');
+            fbTrack(FB_EVENTS.PET_SETTINGS_SAVED, fbPetProps(REPO_OWNER, REPO_NAME));
         } catch (e) {
             showToast('Save failed', true);
         }
@@ -476,6 +485,7 @@
         }
         document.getElementById('exclude-login').value = '';
         showToast(`@${login} excluded`);
+        fbTrack(FB_EVENTS.CONTRIBUTOR_EXCLUDED, fbPetProps(REPO_OWNER, REPO_NAME, { login: login }));
         // Reload page to refresh the table
         location.reload();
     }
@@ -491,6 +501,7 @@
         const row = document.getElementById(`row-${login}`);
         if (row) row.remove();
         showToast(`@${login} exclusion removed`);
+        fbTrack(FB_EVENTS.CONTRIBUTOR_UNEXCLUDED, fbPetProps(REPO_OWNER, REPO_NAME, { login: login }));
     }
 
     // --- Danger zone ---
@@ -501,6 +512,7 @@
             async () => {
                 const res = await fetch(`${API_BASE}/reset`, { method: 'POST' });
                 if (!res.ok) { showToast('Reset failed', true); return; }
+                fbTrack(FB_EVENTS.ADMIN_PET_RESET, fbPetProps(REPO_OWNER, REPO_NAME));
                 showToast('Pet reset. Starting fresh...');
                 setTimeout(() => location.href = `/pet/${REPO_OWNER}/${REPO_NAME}`, 1500);
             }
@@ -514,6 +526,7 @@
             async () => {
                 const res = await fetch(API_BASE, { method: 'DELETE' });
                 if (!res.ok) { showToast('Delete failed', true); return; }
+                fbTrack(FB_EVENTS.ADMIN_PET_DELETED, fbPetProps(REPO_OWNER, REPO_NAME));
                 showToast('Pet deleted.');
                 setTimeout(() => location.href = '/dashboard', 1500);
             }

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -70,6 +70,7 @@
                 localStorage.setItem('tamagotchi_onboarding_dismissed', '1');
                 var el = document.getElementById('onboarding-banner');
                 if (el) { el.style.display = 'none'; }
+                fbTrack(FB_EVENTS.ONBOARDING_DISMISSED);
             }
             </script>
             {% endif %}
@@ -244,6 +245,7 @@
                             target="_blank"
                             rel="noopener"
                             class="share-btn share-twitter"
+                            onclick="fbTrack(FB_EVENTS.SHARED_TWITTER, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}))"
                         >&#120143; Share</a>
                         <button class="share-btn share-copy" id="copy-link-btn" data-url="{{ page_url }}">&#128279; Copy link</button>
                         <a href="/pet/{{ repo_owner }}/{{ repo_name }}/insights" class="share-btn">&#128200; Insights</a>
@@ -479,6 +481,7 @@
                     const original = copyBtn.textContent;
                     copyBtn.innerHTML = '✓ Copied!';
                     setTimeout(() => { copyBtn.innerHTML = '&#128279; Copy link'; }, 2000);
+                    fbTrack(FB_EVENTS.LINK_COPIED, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}));
                 });
             });
         }
@@ -492,6 +495,7 @@
                     const orig = btn.innerHTML;
                     btn.innerHTML = '&#10003; Copied!';
                     setTimeout(() => { btn.innerHTML = orig; }, 2000);
+                    fbTrack(FB_EVENTS.BADGE_EMBED_COPIED, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}));
                 });
             });
         });
@@ -573,6 +577,7 @@
                     }
                     commentBody.value = '';
                     commentChars.textContent = '0 / 500';
+                    fbTrack(FB_EVENTS.COMMENT_POSTED, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}));
                     await loadComments();
                 } catch {
                     commentError.textContent = 'Network error. Please try again.';
@@ -610,6 +615,7 @@
                     const healthValue = document.getElementById('health-value');
                     if (healthBar) healthBar.style.width = newHealth + '%';
                     if (healthValue) healthValue.textContent = newHealth + '%';
+                    fbTrack(FB_EVENTS.PET_FED, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}, { new_health: newHealth }));
                     feedFeedback.style.color = '#4caf50';
                     feedFeedback.textContent = 'Fed! +10 health ❤️';
                     feedFeedback.style.display = 'inline';
@@ -648,6 +654,7 @@
                         resurrectBtn.innerHTML = '&#10024; Resurrect {{ pet.name }}';
                         return;
                     }
+                    fbTrack(FB_EVENTS.PET_RESURRECTED, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}));
                     window.location.reload();
                 } catch (e) {
                     resurrectError.textContent = 'Network error, please try again.';
@@ -686,12 +693,16 @@
                 );
                 const pageUrl = encodeURIComponent('{{ page_url }}');
                 tweetBtn.href = `https://twitter.com/intent/tweet?text=${tweetText}&url=${pageUrl}`;
+                tweetBtn.addEventListener('click', () => {
+                    fbTrack(FB_EVENTS.MILESTONE_SHARED_TWITTER, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}, { new_stage: m.new_stage }));
+                });
 
                 copyBtn.addEventListener('click', () => {
                     navigator.clipboard.writeText('{{ page_url }}').then(() => {
                         const orig = copyBtn.innerHTML;
                         copyBtn.innerHTML = '✓ Copied!';
                         setTimeout(() => { copyBtn.innerHTML = orig; }, 2000);
+                        fbTrack(FB_EVENTS.MILESTONE_LINK_COPIED, fbPetProps({{ repo_owner | tojson }}, {{ repo_name | tojson }}));
                     });
                 });
 
@@ -935,6 +946,7 @@
                             })
                         });
                         setNotifyState('enabled');
+                        fbTrack(FB_EVENTS.PUSH_SUBSCRIBED, fbPetProps(PET_OWNER, PET_NAME));
                     } catch (e) {
                         setNotifyState('disabled');
                     }

--- a/src/github_tamagotchi/templates/register.html
+++ b/src/github_tamagotchi/templates/register.html
@@ -223,6 +223,7 @@
             document.getElementById('create-form').style.display = 'block';
             document.getElementById('create-error').style.display = 'none';
             document.getElementById('create-form').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            fbTrack(FB_EVENTS.REPO_SELECTED, fbPetProps(owner, name));
         }
 
         function clearSelection() {
@@ -264,6 +265,7 @@
                     const data = await resp.json();
                     throw new Error(data.detail || 'Failed to create pet');
                 }
+                fbTrack(FB_EVENTS.PET_ADOPTED, fbPetProps(selectedRepo.owner, selectedRepo.name, { pet_name: petName, style: selectedStyle }));
                 const params = new URLSearchParams({
                     owner: selectedRepo.owner,
                     repo: selectedRepo.name,

--- a/src/github_tamagotchi/templates/register_complete.html
+++ b/src/github_tamagotchi/templates/register_complete.html
@@ -70,6 +70,7 @@
 
     <script>
         document.getElementById('webhook-url').textContent = window.location.origin + '/api/v1/webhooks/github';
+        fbTrack(FB_EVENTS.REGISTRATION_COMPLETE, fbPetProps({{ owner | tojson }}, {{ repo | tojson }}, { pet_name: {{ pet_name | tojson }} }));
 
         function copyEmbed() {
             const code = document.getElementById('embed-code').textContent;
@@ -81,6 +82,7 @@
                     btn.textContent = 'Copy';
                     btn.classList.remove('copied');
                 }, 2000);
+                fbTrack(FB_EVENTS.EMBED_COPIED, fbPetProps({{ owner | tojson }}, {{ repo | tojson }}));
             });
         }
 


### PR DESCRIPTION
## Summary
- Integrate FunnelBarn analytics SDK with typed event constants (`FB_EVENTS`) and context builder (`fbPetProps`) across all 12 user-facing templates
- Add BugBarn client-side log shipping for unhandled JS errors, promise rejections, and SDK failures (warn level)
- Queue analytics calls until SDK loads (deferred), replay on ready, warn to BugBarn if SDK fails to load
- New `FUNNELBARN_API_KEY` config setting; BugBarn endpoint/key/project exposed as Jinja2 globals for client use

## Events tracked
Auth (login/logout), pet lifecycle (adopt/feed/resurrect/delete), social (comments, share twitter, copy link, badge embed), graveyard (flowers, eulogy), PWA (install prompt/install/dismiss), push notifications, onboarding, admin actions

## Test plan
- [ ] Verify pages load without errors when `FUNNELBARN_API_KEY` is unset (no-op)
- [ ] Verify events fire when key is configured
- [ ] Verify BugBarn receives warn-level logs when SDK script fails to load
- [ ] Verify unhandled JS errors appear in BugBarn at warn level