### PR TITLE
fix: use standard OTel env vars for OTLP export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,12 +36,12 @@ MINIO_SECURE=false
 HOST=0.0.0.0
 PORT=8000
 
-# OpenTelemetry / SpanBarn
+# OpenTelemetry
 OTEL_ENABLED=false
-OTEL_ENDPOINT=https://spanbarn.wiebe.xyz/v1/traces
+OTEL_EXPORTER_OTLP_ENDPOINT=https://spanbarn.wiebe.xyz
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <your-api-key>
 OTEL_SERVICE_NAME=github-tamagotchi
 OTEL_TRACES_SAMPLE_RATE=1.0
-SPANBARN_API_KEY=
 
 # FunnelBarn analytics (client-side, safe to expose)
 FUNNELBARN_API_KEY=

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -141,13 +141,15 @@ spec:
                   key: vapid-public-key
             - name: OTEL_ENABLED
               value: "true"
-            - name: OTEL_ENDPOINT
-              value: "https://spanbarn.wiebe.xyz/v1/traces"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "https://spanbarn.wiebe.xyz"
             - name: SPANBARN_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: spanbarn-api-key
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: "Authorization=Bearer $(SPANBARN_API_KEY)"
           resources:
             requests:
               memory: "128Mi"
@@ -317,13 +319,15 @@ spec:
                   key: vapid-public-key
             - name: OTEL_ENABLED
               value: "true"
-            - name: OTEL_ENDPOINT
-              value: "https://spanbarn.wiebe.xyz/v1/traces"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "https://spanbarn.wiebe.xyz"
             - name: SPANBARN_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: spanbarn-api-key
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: "Authorization=Bearer $(SPANBARN_API_KEY)"
           resources:
             requests:
               memory: "128Mi"

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -140,13 +140,15 @@ spec:
                   key: vapid-public-key
             - name: OTEL_ENABLED
               value: "true"
-            - name: OTEL_ENDPOINT
-              value: "https://spanbarn.wiebe.xyz/v1/traces"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "https://spanbarn.wiebe.xyz"
             - name: SPANBARN_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: spanbarn-api-key
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: "Authorization=Bearer $(SPANBARN_API_KEY)"
           resources:
             requests:
               memory: "128Mi"
@@ -315,13 +317,15 @@ spec:
                   key: vapid-public-key
             - name: OTEL_ENABLED
               value: "true"
-            - name: OTEL_ENDPOINT
-              value: "https://spanbarn.wiebe.xyz/v1/traces"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "https://spanbarn.wiebe.xyz"
             - name: SPANBARN_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: github-tamagotchi-secrets
                   key: spanbarn-api-key
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: "Authorization=Bearer $(SPANBARN_API_KEY)"
           resources:
             requests:
               memory: "128Mi"

--- a/src/github_tamagotchi/core/config.py
+++ b/src/github_tamagotchi/core/config.py
@@ -70,12 +70,10 @@ class Settings(BaseSettings):
     # Admin
     admin_github_logins: list[str] = ["webwiebe"]
 
-    # OpenTelemetry / SpanBarn
+    # OpenTelemetry
     otel_enabled: bool = False
-    otel_endpoint: str = "https://spanbarn.wiebe.xyz/v1/traces"
     otel_service_name: str = "github-tamagotchi"
     otel_traces_sample_rate: float = 1.0
-    spanbarn_api_key: str | None = None
 
     # Sentry
     sentry_dsn: str | None = None

--- a/src/github_tamagotchi/core/telemetry.py
+++ b/src/github_tamagotchi/core/telemetry.py
@@ -47,14 +47,7 @@ def init_telemetry(app: FastAPI) -> None:
     sampler = TraceIdRatioBased(settings.otel_traces_sample_rate)
     _provider = TracerProvider(resource=resource, sampler=sampler)
 
-    headers: dict[str, str] = {}
-    if settings.spanbarn_api_key:
-        headers["Authorization"] = f"Bearer {settings.spanbarn_api_key}"
-
-    exporter = OTLPSpanExporter(
-        endpoint=settings.otel_endpoint,
-        headers=headers,
-    )
+    exporter = OTLPSpanExporter()
     _provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(_provider)
 
@@ -65,9 +58,12 @@ def init_telemetry(app: FastAPI) -> None:
 
     HTTPXClientInstrumentor().instrument()
 
+    endpoint = os.getenv(
+        "OTEL_EXPORTER_OTLP_ENDPOINT", ""
+    )
     logger.info(
         "OpenTelemetry initialized",
-        endpoint=settings.otel_endpoint,
+        endpoint=endpoint,
         sample_rate=settings.otel_traces_sample_rate,
     )
 


### PR DESCRIPTION
## Summary
- Switch from programmatic exporter config to standard OTel env vars
- `OTEL_EXPORTER_OTLP_ENDPOINT` (base URL, SDK appends `/v1/traces`)
- `OTEL_EXPORTER_OTLP_HEADERS` (standard auth header format)
- Remove custom `otel_endpoint` and `spanbarn_api_key` config settings
- Let the SDK handle endpoint/header resolution natively

## Test plan
- [ ] CI passes
- [ ] Spans export successfully to SpanBarn