### PR TITLE
fix: add root span to image queue worker

### DIFF
--- a/src/github_tamagotchi/services/image_queue.py
+++ b/src/github_tamagotchi/services/image_queue.py
@@ -430,9 +430,15 @@ async def run_worker(
                 job = await get_next_pending_job(session)
 
                 if job:
-                    await process_job(session, job)
+                    with _tracer.start_as_current_span(
+                        "image_queue.worker_cycle",
+                        attributes={
+                            "worker.job_id": str(job.id),
+                            "worker.pet_id": str(job.pet_id),
+                        },
+                    ):
+                        await process_job(session, job)
                 else:
-                    # No pending jobs, wait before polling again
                     await asyncio.sleep(interval)
 
         except asyncio.CancelledError:


### PR DESCRIPTION
## Summary
- Image queue worker processed jobs without a parent trace context
- DB queries and service calls appeared as orphaned root spans in SpanBarn
- Wrap each job processing cycle in a `worker_cycle` root span
- Only creates spans when there's actual work (not on idle polls)

## Test plan
- [ ] CI passes
- [ ] Image queue job spans appear under worker_cycle root in SpanBarn