### PR TITLE
fix: webhook events not persisted to database

### DIFF
--- a/src/github_tamagotchi/api/routes/v1/webhooks.py
+++ b/src/github_tamagotchi/api/routes/v1/webhooks.py
@@ -143,7 +143,7 @@ async def github_webhook(request: Request, session: DbSession) -> WebhookRespons
                 processed=processed,
             )
             session.add(event_log)
-            await session.flush()
+            await session.commit()
         except Exception:
             logger.exception("Failed to log webhook event")
 


### PR DESCRIPTION
## Summary

- `WebhookEvent` log entries were never saved — `flush()` sent the SQL but the transaction rolled back when the session closed
- One-character fix: `flush()` → `commit()`

## Root cause

The webhook handler commits its own pet state changes, then the `WebhookEvent` is added *after* that commit. The subsequent `flush()` writes the INSERT to the DB transaction but never commits, so the session context manager rolls back on exit.

## Test plan

- [x] All 46 webhook tests pass
- [ ] Deploy and verify events appear in admin panel