### PR TITLE
fix: commit is_admin sync instead of only flushing

### DIFF
--- a/src/github_tamagotchi/api/auth.py
+++ b/src/github_tamagotchi/api/auth.py
@@ -99,7 +99,7 @@ async def get_current_user(
     should_be_admin = user.github_login in settings.admin_github_logins
     if user.is_admin != should_be_admin:
         user.is_admin = should_be_admin
-        await session.flush()
+        await session.commit()
     return user
 
 
@@ -129,7 +129,7 @@ async def get_optional_user(
         should_be_admin = user.github_login in settings.admin_github_logins
         if user.is_admin != should_be_admin:
             user.is_admin = should_be_admin
-            await session.flush()
+            await session.commit()
     return user
 
 
@@ -275,7 +275,7 @@ async def oauth_callback(
         user.is_admin = (
             github_user["login"] in settings.admin_github_logins
         )
-        await session.flush()
+        await session.commit()
 
         span.set_attribute("auth.user_id", str(user.id))
         span.set_attribute("auth.is_admin", user.is_admin)


### PR DESCRIPTION
## Summary

- Same bug as #226 — `flush()` without `commit()` means changes roll back when the session closes
- Three places in `auth.py` where `is_admin` sync was flushed but never committed:
  - `get_current_user` (every authenticated request)
  - `get_optional_user` (every page load)
  - OAuth callback (login flow)

## Impact

Low — admin status rarely changes, and it re-syncs on every request anyway (just never persists). But it means toggling someone's admin status in config requires a restart to actually stick in the DB.

## Test plan

- [x] All 84 auth-related tests pass