### PR TITLE
fix(telemetry): consolidate span-export failures into one BugBarn fingerprint

### DIFF
--- a/src/github_tamagotchi/core/telemetry.py
+++ b/src/github_tamagotchi/core/telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +14,65 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 _provider: Any = None
+
+# The OTel SDK logs span-export failures at ERROR from several internal sites
+# ("Failed to export span batch code: ...", "Failed to export span batch due to
+# timeout, max retries or shutdown.", etc.). Each unique message becomes a
+# separate BugBarn fingerprint, which spams the issue tracker with multiple
+# entries for what is one upstream condition. We silence those specific loggers
+# and consolidate the signal into a single log emitted by
+# `_ResilientOTLPSpanExporter` below.
+_NOISY_OTEL_LOGGERS = (
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    "opentelemetry.sdk.trace.export",
+)
+
+
+def _detach_noisy_otel_loggers_from_bugbarn() -> None:
+    """Stop the OTel SDK's per-site export-failure logs from feeding BugBarn.
+
+    Each distinct message ("Failed to export span batch code: 404…",
+    "Failed to export span batch due to timeout…", etc.) is a separate BugBarn
+    fingerprint, which is why one upstream condition surfaced as three issues
+    (GT-16, GT-20, GT-21). We set `propagate=False` so these loggers no longer
+    flow into the root structlog/BugBarn pipeline, and attach a plain stderr
+    handler so `kubectl logs` still shows them for upstream-health debugging.
+    The single BugBarn signal for "spans dropped" is then emitted by
+    `_make_resilient_exporter` below.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    for name in _NOISY_OTEL_LOGGERS:
+        lg = logging.getLogger(name)
+        lg.propagate = False
+        if not lg.handlers:
+            lg.addHandler(handler)
+
+
+def _make_resilient_exporter(base_cls: type) -> type:
+    """Factory for a span exporter that consolidates failures into one log.
+
+    The OTel SDK's own exporter logs span-export failures at ERROR from several
+    internal sites, each becoming a distinct BugBarn fingerprint. The returned
+    subclass calls `base_cls.export()` and emits exactly one warning log via
+    our project logger when the result is FAILURE — letting BugBarn group all
+    upstream spanbarn outages under a single fingerprint.
+    """
+    from opentelemetry.sdk.trace.export import SpanExportResult
+
+    class _ResilientExporter(base_cls):  # type: ignore[misc]
+        def export(self, spans: Any) -> Any:
+            result = super().export(spans)
+            if result == SpanExportResult.FAILURE:
+                logger.warning(
+                    "Span batch dropped to spanbarn",
+                    span_count=len(spans),
+                )
+            return result
+
+    return _ResilientExporter
 
 
 def init_telemetry(app: FastAPI) -> None:
@@ -47,7 +107,9 @@ def init_telemetry(app: FastAPI) -> None:
     sampler = TraceIdRatioBased(settings.otel_traces_sample_rate)
     _provider = TracerProvider(resource=resource, sampler=sampler)
 
-    exporter = OTLPSpanExporter(timeout=5)
+    _detach_noisy_otel_loggers_from_bugbarn()
+
+    exporter = _make_resilient_exporter(OTLPSpanExporter)(timeout=5)
     _provider.add_span_processor(BatchSpanProcessor(
         exporter,
         max_export_batch_size=128,

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -1,0 +1,112 @@
+"""Tests for telemetry resilience helpers.
+
+The OTel SDK logs span-export failures from several internal sites with
+distinct messages — each becomes a separate BugBarn issue (GT-16/20/21 are
+three fingerprints for the same upstream condition).
+
+The fix has two parts:
+1. `_make_resilient_exporter` — emits one warning per failed batch via our
+   project logger so BugBarn groups them all under a single fingerprint.
+   Events on that one issue are useful signal (volume, timing) and not a
+   problem to reduce further.
+2. `_detach_noisy_otel_loggers_from_bugbarn` — keeps the SDK's per-site logs
+   visible in stdout/`kubectl logs` for upstream-health debugging but stops
+   them propagating into the structlog → BugBarn pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from github_tamagotchi.core.telemetry import (
+    _NOISY_OTEL_LOGGERS,
+    _detach_noisy_otel_loggers_from_bugbarn,
+    _make_resilient_exporter,
+)
+
+
+class _StubExporter:
+    """Stand-in for OTLPSpanExporter — lets us pick the return value."""
+
+    def __init__(self, result: SpanExportResult, **_: object) -> None:
+        self._result = result
+
+    def export(self, _spans: object) -> SpanExportResult:
+        return self._result
+
+
+def _make(result: SpanExportResult) -> object:
+    return _make_resilient_exporter(_StubExporter)(result=result)
+
+
+def test_success_does_not_log_warning() -> None:
+    exporter = _make(SpanExportResult.SUCCESS)
+    with patch("github_tamagotchi.core.telemetry.logger") as mock_logger:
+        out = exporter.export([object(), object()])
+        assert out == SpanExportResult.SUCCESS
+        mock_logger.warning.assert_not_called()
+
+
+def test_failure_emits_exactly_one_warning() -> None:
+    exporter = _make(SpanExportResult.FAILURE)
+    with patch("github_tamagotchi.core.telemetry.logger") as mock_logger:
+        out = exporter.export([object(), object(), object()])
+        assert out == SpanExportResult.FAILURE
+        mock_logger.warning.assert_called_once()
+        # The single log carries the batch size so BugBarn aggregates show volume
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert kwargs.get("span_count") == 3
+
+
+def test_repeated_failures_share_one_fingerprint() -> None:
+    """Each failed batch is its own event but they all share one BugBarn fingerprint.
+
+    Multiple events on a single issue are useful signal (volume, recency) — the
+    invariant we care about is that all of them have the *same* message text so
+    BugBarn groups them under one issue instead of opening new ones per call site.
+    """
+    exporter = _make(SpanExportResult.FAILURE)
+    with patch("github_tamagotchi.core.telemetry.logger") as mock_logger:
+        for _ in range(5):
+            exporter.export([object()])
+        assert mock_logger.warning.call_count == 5
+        messages = {c.args[0] for c in mock_logger.warning.call_args_list}
+        assert messages == {"Span batch dropped to spanbarn"}
+
+
+def test_wrapped_exporter_subclasses_the_base() -> None:
+    """Sanity: the resilient wrapper IS the base type, so SDK type checks pass."""
+    cls = _make_resilient_exporter(_StubExporter)
+    inst = cls(result=SpanExportResult.SUCCESS)
+    assert isinstance(inst, _StubExporter)
+
+
+def test_detach_stops_propagation_to_bugbarn_pipeline() -> None:
+    """Noisy SDK loggers must not propagate to the root (where BugBarn lives)."""
+    _detach_noisy_otel_loggers_from_bugbarn()
+    for name in _NOISY_OTEL_LOGGERS:
+        lg = logging.getLogger(name)
+        assert lg.propagate is False, f"{name} should not propagate to root"
+
+
+def test_detach_preserves_stdout_visibility() -> None:
+    """Each detached logger gets a stream handler so logs still hit stdout/stderr."""
+    _detach_noisy_otel_loggers_from_bugbarn()
+    for name in _NOISY_OTEL_LOGGERS:
+        lg = logging.getLogger(name)
+        assert any(
+            isinstance(h, logging.StreamHandler) for h in lg.handlers
+        ), f"{name} should retain a StreamHandler for kubectl-logs visibility"
+
+
+def test_detach_is_idempotent() -> None:
+    """Re-running detach must not stack duplicate handlers."""
+    _detach_noisy_otel_loggers_from_bugbarn()
+    before = {name: len(logging.getLogger(name).handlers) for name in _NOISY_OTEL_LOGGERS}
+    _detach_noisy_otel_loggers_from_bugbarn()
+    _detach_noisy_otel_loggers_from_bugbarn()
+    after = {name: len(logging.getLogger(name).handlers) for name in _NOISY_OTEL_LOGGERS}
+    assert before == after


### PR DESCRIPTION
## Summary

GT-16, GT-20 and GT-21 are three BugBarn issues for the same upstream condition: spans aren't reaching spanbarn. They exist as three separate **fingerprints** because the OTel SDK logs the failure at ERROR from three distinct call sites with three distinct messages — `_bugbarn_processor` opens a new issue per unique message.

The events on each of those issues are not the problem (multiple events on one issue = useful signal). The problem is the three-way fingerprint duplication.

## Fix — capture-on-bubble-up

- **`_make_resilient_exporter`** wraps `OTLPSpanExporter`. On `SpanExportResult.FAILURE` it emits one warning via our project logger: `"Span batch dropped to spanbarn"` with `span_count`. Same message every time ⇒ BugBarn groups all occurrences under a single fingerprint.
- **`_detach_noisy_otel_loggers_from_bugbarn`** sets `propagate=False` on `opentelemetry.exporter.otlp.proto.http.trace_exporter` and `opentelemetry.sdk.trace.export`, and attaches a stderr handler. They keep printing for `kubectl logs` (upstream-health visibility preserved) but no longer feed BugBarn — eliminating the three-way fingerprint duplication at the source.

## Why this shape

Previous draft of this PR level-demoted the noisy loggers in `_bugbarn_processor`. Wrong layer — that's a filter on the symptom. The right fix is to have one place in our code own "spans aren't reaching spanbarn" and emit a single signal, instead of letting three SDK call sites each create their own issue.

## Test plan

- [x] Unit tests for the wrapper (success path, failure path, repeat-failures share fingerprint)
- [x] Unit tests for the detach (propagation off, stdout handler present, idempotent)
- [x] mypy, ruff
- [ ] After deploy: confirm GT-16/20/21 stop accumulating events and any new export failures land on a single new "Span batch dropped to spanbarn" issue. Resolve the three old ones.