### PR TITLE
feat(badge): auto-create placeholder pet on badge fetch, claim via OAuth

### DIFF
--- a/alembic/versions/029_add_pet_placeholder.py
+++ b/alembic/versions/029_add_pet_placeholder.py
@@ -1,0 +1,40 @@
+"""Add is_placeholder and claimed_at to pets for badge-driven auto-signup.
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-05-16
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "029"
+down_revision = "028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pets",
+        sa.Column(
+            "is_placeholder",
+            sa.Boolean,
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "pets",
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_pets_is_placeholder", "pets", ["is_placeholder"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pets_is_placeholder", table_name="pets")
+    op.drop_column("pets", "claimed_at")
+    op.drop_column("pets", "is_placeholder")

--- a/src/github_tamagotchi/api/auth.py
+++ b/src/github_tamagotchi/api/auth.py
@@ -1,6 +1,7 @@
 """GitHub OAuth authentication routes."""
 
 import logging
+import re
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
@@ -26,8 +27,10 @@ auth_router = APIRouter(prefix="/auth", tags=["auth"])
 
 DbSession = Annotated[AsyncSession, Depends(get_session)]
 
-# In-memory state store for CSRF protection during OAuth flow
-_oauth_states: dict[str, datetime] = {}
+# In-memory state store for CSRF protection during OAuth flow.
+# Values are (created_at, optional_claim_target). claim_target is "owner/repo"
+# when the OAuth flow was initiated from a badge "click to claim" link.
+_oauth_states: dict[str, tuple[datetime, str | None]] = {}
 _STATE_TTL_MINUTES = 10
 
 GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
@@ -65,9 +68,24 @@ def _cleanup_expired_states() -> None:
     """Remove expired OAuth states."""
     now = datetime.now(UTC)
     max_age = _STATE_TTL_MINUTES * 60
-    expired = [k for k, v in _oauth_states.items() if (now - v).total_seconds() > max_age]
+    expired = [
+        k for k, (created, _claim) in _oauth_states.items()
+        if (now - created).total_seconds() > max_age
+    ]
     for k in expired:
         del _oauth_states[k]
+
+
+_CLAIM_RE = re.compile(r"^[\w.-]{1,100}/[\w.-]{1,100}$")
+
+
+def _parse_claim(claim: str | None) -> str | None:
+    """Validate `owner/repo` shape; return normalised value or None."""
+    if not claim:
+        return None
+    if not _CLAIM_RE.match(claim):
+        return None
+    return claim
 
 
 async def get_current_user(
@@ -133,9 +151,82 @@ async def get_optional_user(
     return user
 
 
+class _ClaimError(Exception):
+    """Raised when an OAuth claim cannot be completed."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+async def _verify_github_repo_access(access_token: str, owner: str, repo: str) -> bool:
+    """Return True if the OAuth user can see this repo via GitHub's API.
+
+    A 200 from `GET /repos/{owner}/{repo}` is enough — for private repos this
+    requires the user have at least read access. We don't require push, on the
+    assumption that anyone who can see the repo has a legitimate interest in
+    its tamagotchi (and the API today allows anonymous pet creation anyway).
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(
+            f"https://api.github.com/repos/{owner}/{repo}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    return resp.status_code == 200
+
+
+async def _claim_placeholder_for_user(
+    *,
+    session: AsyncSession,
+    user: User,
+    access_token: str,
+    claim_target: str,
+) -> tuple[str, str]:
+    """Bind the placeholder pet for claim_target to `user`, queueing first image.
+
+    Returns (owner, repo) on success. Raises _ClaimError with a reason slug
+    that the caller can surface in a redirect query string.
+    """
+    from github_tamagotchi.models.pet import PetStage
+    from github_tamagotchi.services import image_queue
+    from github_tamagotchi.services import pet as pet_service
+
+    owner, repo = claim_target.split("/", 1)
+
+    pet = await pet_service.get_by_repo(session, owner, repo)
+    if pet is None:
+        raise _ClaimError("not_found")
+    if not pet.is_placeholder and pet.user_id is not None:
+        if pet.user_id == user.id:
+            return owner, repo  # idempotent: already mine
+        raise _ClaimError("already_claimed")
+
+    if not await _verify_github_repo_access(access_token, owner, repo):
+        raise _ClaimError("no_access")
+
+    await pet_service.claim_placeholder(session, pet, user_id=user.id)
+    try:
+        await image_queue.create_job(session, pet.id, PetStage.EGG.value)
+    except ValueError:
+        # Image generation not configured — leave pet unclaimed-image; user can regenerate later.
+        logger.info(
+            "claim_image_enqueue_skipped pet_id=%s reason=no_provider",
+            pet.id,
+        )
+    return owner, repo
+
+
 @auth_router.get("/github")
-async def login_github(response: Response) -> Response:
-    """Redirect to GitHub OAuth authorization page."""
+async def login_github(response: Response, claim: str | None = None) -> Response:
+    """Redirect to GitHub OAuth authorization page.
+
+    When `claim=owner/repo` is provided (from a badge "click to claim" link),
+    the value is bound to the OAuth state and consumed in /auth/callback to
+    finish binding the placeholder pet to the authenticated user.
+    """
     if not settings.github_oauth_client_id:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -144,7 +235,7 @@ async def login_github(response: Response) -> Response:
 
     _cleanup_expired_states()
     state = secrets.token_urlsafe(32)
-    _oauth_states[state] = datetime.now(UTC)
+    _oauth_states[state] = (datetime.now(UTC), _parse_claim(claim))
 
     params = {
         "client_id": settings.github_oauth_client_id,
@@ -176,6 +267,7 @@ async def oauth_callback(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired OAuth state",
         )
+    _state_created, claim_target = _oauth_states[state]
     del _oauth_states[state]
 
     if not settings.github_oauth_client_id or not settings.github_oauth_client_secret:
@@ -280,12 +372,35 @@ async def oauth_callback(
         span.set_attribute("auth.user_id", str(user.id))
         span.set_attribute("auth.is_admin", user.is_admin)
 
+        # If the OAuth flow was initiated from a "click to claim" badge,
+        # verify GitHub access and bind the placeholder pet to this user.
+        redirect_target = "/register"
+        if claim_target:
+            try:
+                bound = await _claim_placeholder_for_user(
+                    session=session,
+                    user=user,
+                    access_token=access_token,
+                    claim_target=claim_target,
+                )
+            except _ClaimError as claim_exc:
+                logger.warning(
+                    "oauth_claim_failed: %s — claim_target=%s user=%s",
+                    claim_exc.reason,
+                    claim_target,
+                    user.github_login,
+                )
+                redirect_target = f"/?claim_error={claim_exc.reason}&repo={claim_target}"
+            else:
+                owner, repo = bound
+                redirect_target = f"/pets/{owner}/{repo}"
+
         # Create JWT session token
         token = _create_jwt(user.id)
 
         response = Response(
             status_code=status.HTTP_307_TEMPORARY_REDIRECT,
-            headers={"location": "/register"},
+            headers={"location": redirect_target},
         )
         response.set_cookie(
             key="session_token",

--- a/src/github_tamagotchi/api/routes/v1/pets/media.py
+++ b/src/github_tamagotchi/api/routes/v1/pets/media.py
@@ -8,7 +8,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import github_tamagotchi.api.routes as _api_routes  # for test-patch-compatible symbol lookup
-from github_tamagotchi.api.dependencies import DbSession, get_pet_or_404
+from github_tamagotchi.api.dependencies import DbSession
 from github_tamagotchi.models.pet import Pet, PetStage
 from github_tamagotchi.schemas.pets import ImageGenerationResponse
 from github_tamagotchi.services import pet as pet_service
@@ -68,10 +68,18 @@ async def get_pet_badge(
     session: DbSession,
     style: str | None = Query(default=None, description="Badge style override"),
 ) -> Response:
-    """Return an SVG badge representing the current pet state."""
+    """Return an SVG badge representing the current pet state.
+
+    If no pet exists yet, lazy-create a placeholder and return a
+    "click to claim" seedling badge. This turns a README badge embed into
+    the entry point of a sign-up funnel.
+    """
     import base64
 
-    from github_tamagotchi.services.badge import generate_badge_svg
+    from github_tamagotchi.services.badge import (
+        generate_badge_svg,
+        generate_seedling_badge_svg,
+    )
 
     if style is not None and style not in BADGE_STYLES:
         valid = ", ".join(sorted(BADGE_STYLES))
@@ -80,7 +88,17 @@ async def get_pet_badge(
             detail=f"Invalid badge style '{style}'. Must be one of: {valid}",
         )
 
-    pet = await get_pet_or_404(repo_owner, repo_name, session)
+    pet, created = await pet_service.get_or_create_placeholder(
+        session, repo_owner, repo_name
+    )
+    if created:
+        logger.info(
+            "badge_placeholder_created",
+            repo=f"{repo_owner}/{repo_name}",
+        )
+    if pet.is_placeholder:
+        svg = generate_seedling_badge_svg(repo_owner, repo_name)
+        return Response(content=svg, media_type="image/svg+xml", headers=_SVG_HEADERS)
 
     pet_image_b64: str | None = None
     try:

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -319,8 +319,8 @@ async def _poll_repositories_inner(triggered_by: str, poll_span: Any) -> None:
 
     try:
         async with async_session_factory() as session:
-            # Query all pets
-            result = await session.execute(select(Pet))
+            # Query all real pets; placeholders are skipped until claimed.
+            result = await session.execute(select(Pet).where(Pet.is_placeholder.is_(False)))
             pets = result.scalars().all()
             total_pets = len(pets)
 

--- a/src/github_tamagotchi/models/pet.py
+++ b/src/github_tamagotchi/models/pet.py
@@ -188,6 +188,16 @@ class Pet(Base):
         Integer, nullable=False, default=0, server_default="0"
     )
 
+    # Placeholder pets are lazy-created on a badge fetch for a repo nobody has
+    # claimed yet. They have no owner, no scheduled polling, and no image
+    # generation until somebody claims them via the OAuth flow.
+    is_placeholder: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false", index=True
+    )
+    claimed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Relationships
     image_jobs: Mapped[list["ImageGenerationJob"]] = relationship(
         "ImageGenerationJob", back_populates="pet", cascade="all, delete-orphan"

--- a/src/github_tamagotchi/repositories/pet.py
+++ b/src/github_tamagotchi/repositories/pet.py
@@ -23,6 +23,7 @@ async def create_pet(
     name: str,
     user_id: int | None = None,
     style: str = "kawaii",
+    is_placeholder: bool = False,
 ) -> Pet:
     """Create a new pet with generated personality traits."""
     personality = generate_personality(repo_owner, repo_name)
@@ -32,6 +33,7 @@ async def create_pet(
         name=name,
         user_id=user_id,
         style=style,
+        is_placeholder=is_placeholder,
         personality_activity=personality.activity,
         personality_sociability=personality.sociability,
         personality_bravery=personality.bravery,
@@ -39,6 +41,17 @@ async def create_pet(
         personality_appetite=personality.appetite,
     )
     db.add(pet)
+    await _commit_refresh(db, pet)
+    return pet
+
+
+async def claim_placeholder(
+    db: AsyncSession, pet: Pet, user_id: int
+) -> Pet:
+    """Bind a placeholder pet to an owning user. Idempotent on already-claimed pets."""
+    pet.user_id = user_id
+    pet.is_placeholder = False
+    pet.claimed_at = datetime.now(UTC)
     await _commit_refresh(db, pet)
     return pet
 
@@ -60,8 +73,9 @@ async def get_pets(
     """Get pets with pagination, optionally filtered by user."""
     offset = (page - 1) * per_page
 
-    base_query = select(Pet)
-    count_query = select(func.count()).select_from(Pet)
+    # Hide placeholders from listing — they're a sign-up artifact, not real pets
+    base_query = select(Pet).where(Pet.is_placeholder.is_(False))
+    count_query = select(func.count()).select_from(Pet).where(Pet.is_placeholder.is_(False))
     if user_id is not None:
         base_query = base_query.where(Pet.user_id == user_id)
         count_query = count_query.where(Pet.user_id == user_id)
@@ -269,9 +283,11 @@ async def update_canonical_appearance(
 
 
 async def get_all(db: AsyncSession, limit: int = 10000) -> list[Pet]:
-    """Return all pets up to the given limit."""
+    """Return all real pets up to the given limit. Placeholders are excluded."""
     try:
-        result = await db.execute(select(Pet).limit(limit))
+        result = await db.execute(
+            select(Pet).where(Pet.is_placeholder.is_(False)).limit(limit)
+        )
         return list(result.scalars().all())
     except SQLAlchemyError as exc:
         raise RepositoryError(str(exc)) from exc

--- a/src/github_tamagotchi/services/badge.py
+++ b/src/github_tamagotchi/services/badge.py
@@ -478,6 +478,53 @@ def _dependent_flair_text(dependent_count: int) -> str | None:
     return None
 
 
+def generate_seedling_badge_svg(repo_owner: str, repo_name: str) -> str:
+    """Badge served when no claimed pet exists yet for the repo.
+
+    A placeholder pet is created on first badge fetch (see badge route). This
+    SVG nudges the README reader / repo owner to click through and bind the
+    pet to their GitHub account via OAuth.
+
+    README authors typically wrap the badge image in a Markdown link, e.g.
+
+        [![tamagotchi](.../badge.svg)](https://tamagotchi.webwiebe.nl/?claim=owner/repo)
+
+    so the SVG itself only needs to make the call-to-action visible.
+    """
+    label = f"{repo_owner}/{repo_name}"
+    if len(label) > 22:
+        label = label[:21] + "…"
+    label_w = 90
+    value_w = 80
+    total_w = label_w + value_w
+    label_x = label_w // 2
+    value_x = label_w + value_w // 2
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total_w}" height="20"'
+        f' role="img" aria-label="tamagotchi: click to claim">',
+        f"  <title>{label} — click to claim your tamagotchi</title>",
+        "  <defs>",
+        '    <linearGradient id="s" x2="0" y2="100%">',
+        '      <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>',
+        '      <stop offset="1" stop-opacity=".1"/>',
+        "    </linearGradient>",
+        f'    <clipPath id="r"><rect width="{total_w}" height="20" rx="3"/></clipPath>',
+        "  </defs>",
+        '  <g clip-path="url(#r)">',
+        f'    <rect width="{label_w}" height="20" fill="#555"/>',
+        f'    <rect x="{label_w}" width="{value_w}" height="20" fill="#16a34a"/>',
+        f'    <rect width="{total_w}" height="20" fill="url(#s)"/>',
+        "  </g>",
+        f'  <text x="{label_x}" y="14" font-size="10" fill="#fff" text-anchor="middle"'
+        f' font-family="DejaVu Sans,Verdana,Geneva,sans-serif">🥚 tamagotchi</text>',
+        f'  <text x="{value_x}" y="14" font-size="10" fill="#fff" text-anchor="middle"'
+        f' font-family="DejaVu Sans,Verdana,Geneva,sans-serif">click to claim</text>',
+        "</svg>",
+    ]
+    return "\n".join(lines)
+
+
 def generate_badge_svg(
     name: str,
     stage: str,

--- a/src/github_tamagotchi/services/pet.py
+++ b/src/github_tamagotchi/services/pet.py
@@ -64,7 +64,12 @@ async def create(
     user_id: int | None,
     style: str,
 ) -> Pet:
-    """Create a pet, raising ConflictError if one already exists for the repo."""
+    """Create a pet, or claim a pre-existing placeholder for this repo.
+
+    Raises ConflictError if a real (claimed or anonymous) pet already exists.
+    A placeholder pet — auto-created by the badge endpoint — is upgraded to
+    a real pet bound to the given user_id.
+    """
     with _tracer.start_as_current_span(
         "service.pet.create",
         attributes={
@@ -75,11 +80,43 @@ async def create(
         },
     ):
         existing = await pet_repo.get_pet_by_repo(db, owner, repo)
+        if existing and existing.is_placeholder:
+            existing.name = name
+            existing.style = style
+            if user_id is not None:
+                return await pet_repo.claim_placeholder(db, existing, user_id)
+            return await pet_repo.save(db, existing)
         if existing:
             raise ConflictError(f"Pet already exists for {owner}/{repo}")
         return await pet_repo.create_pet(
             db, owner, repo, name, user_id=user_id, style=style
         )
+
+
+async def get_or_create_placeholder(
+    db: AsyncSession, owner: str, repo: str
+) -> tuple[Pet, bool]:
+    """Return the pet for owner/repo; if none exists, lazy-create a placeholder.
+
+    Returns (pet, created). Placeholders carry no user_id, no scheduled polling,
+    and trigger no image generation until claimed via the OAuth flow. Used by
+    the public badge endpoint so a README badge can act as a sign-up funnel.
+    """
+    from github_tamagotchi.services.naming import generate_name_from_repo
+
+    existing = await pet_repo.get_pet_by_repo(db, owner, repo)
+    if existing is not None:
+        return existing, False
+    name = generate_name_from_repo(owner, repo)
+    pet = await pet_repo.create_pet(
+        db, owner, repo, name, user_id=None, is_placeholder=True
+    )
+    return pet, True
+
+
+async def claim_placeholder(db: AsyncSession, pet: Pet, user_id: int) -> Pet:
+    """Bind a placeholder pet to a user. No-op-ish if the pet isn't a placeholder."""
+    return await pet_repo.claim_placeholder(db, pet, user_id)
 
 
 async def delete(db: AsyncSession, pet: Pet) -> None:

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -241,10 +241,18 @@ class TestBadgeEndpoint:
         assert "</svg>" in body
         assert "Buddy" in body
 
-    async def test_badge_not_found(self, async_client: AsyncClient) -> None:
-        """Badge endpoint returns 404 when pet does not exist."""
+    async def test_badge_unknown_repo_returns_seedling_placeholder(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Unknown repo lazy-creates a placeholder and serves a "click to claim" badge.
+
+        See feat/badge-auto-signup: the badge endpoint is a sign-up funnel; a
+        404 here would defeat the whole flow. Placeholder creation is verified
+        in tests/test_badge_auto_signup.py.
+        """
         response = await async_client.get("/api/v1/pets/nobody/norepo/badge.svg")
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert "click to claim" in response.text
 
     async def test_badge_falls_back_to_emoji_when_no_image(self, async_client: AsyncClient) -> None:
         """Badge endpoint returns emoji-based SVG when no sprite is in storage."""

--- a/tests/test_badge_auto_signup.py
+++ b/tests/test_badge_auto_signup.py
@@ -1,0 +1,254 @@
+"""Tests for the badge-driven auto-signup funnel.
+
+Embedding the pet badge in a README counts as high-intent — first fetch
+lazy-creates a placeholder, the badge nudges to "click to claim", and the
+OAuth callback binds the placeholder once the user proves access to the repo.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from github_tamagotchi.api import auth as auth_mod
+from github_tamagotchi.models.pet import Pet
+from github_tamagotchi.models.user import User
+from github_tamagotchi.repositories import pet as pet_repo
+from github_tamagotchi.services import pet as pet_service
+
+
+async def _count_pets(session: AsyncSession, owner: str, repo: str) -> int:
+    result = await session.execute(
+        select(Pet).where(Pet.repo_owner == owner, Pet.repo_name == repo)
+    )
+    return len(result.scalars().all())
+
+
+# ----- Badge endpoint -----
+
+
+@pytest.mark.asyncio
+async def test_badge_for_unknown_repo_creates_placeholder_and_serves_seedling(
+    async_client: AsyncClient,
+) -> None:
+    resp = await async_client.get("/api/v1/pets/octocat/unbadged/badge.svg")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/svg+xml")
+    body = resp.text
+    assert "click to claim" in body
+    assert "octocat/unbadged" in body  # repo label visible on placeholder
+
+
+@pytest.mark.asyncio
+async def test_badge_fetch_is_idempotent(async_client: AsyncClient) -> None:
+    """Repeated fetches for the same unknown repo must not create duplicates."""
+    for _ in range(3):
+        resp = await async_client.get("/api/v1/pets/octocat/repeated/badge.svg")
+        assert resp.status_code == 200
+
+    from tests.conftest import test_session_factory
+    async with test_session_factory() as session:
+        assert await _count_pets(session, "octocat", "repeated") == 1
+
+
+@pytest.mark.asyncio
+async def test_badge_for_existing_pet_returns_normal_badge(
+    async_client: AsyncClient,
+) -> None:
+    from tests.conftest import test_session_factory
+    async with test_session_factory() as session:
+        await pet_repo.create_pet(
+            session, "octocat", "real", name="Pixel", is_placeholder=False
+        )
+
+    resp = await async_client.get("/api/v1/pets/octocat/real/badge.svg")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "click to claim" not in body
+    assert "Pixel" in body
+
+
+# ----- get_or_create_placeholder service -----
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_placeholder_creates_once(test_db: AsyncSession) -> None:
+    pet1, created1 = await pet_service.get_or_create_placeholder(
+        test_db, "octocat", "lazycat"
+    )
+    pet2, created2 = await pet_service.get_or_create_placeholder(
+        test_db, "octocat", "lazycat"
+    )
+    assert created1 is True
+    assert created2 is False
+    assert pet1.id == pet2.id
+    assert pet1.is_placeholder is True
+    assert pet1.user_id is None
+
+
+# ----- Scheduler skips placeholders -----
+
+
+@pytest.mark.asyncio
+async def test_listings_skip_placeholders(test_db: AsyncSession) -> None:
+    await pet_repo.create_pet(test_db, "a", "real", name="Real", is_placeholder=False)
+    await pet_repo.create_pet(
+        test_db, "b", "placeholder", name="Seedling", is_placeholder=True
+    )
+
+    pets, total = await pet_repo.get_pets(test_db, page=1, per_page=10)
+    names = {p.name for p in pets}
+    assert names == {"Real"}
+    assert total == 1
+
+    all_pets = await pet_repo.get_all(test_db)
+    assert {p.name for p in all_pets} == {"Real"}
+
+
+# ----- POST /pets claims a placeholder -----
+
+
+@pytest.mark.asyncio
+async def test_create_pet_via_post_claims_existing_placeholder(
+    test_db: AsyncSession,
+) -> None:
+    placeholder = await pet_repo.create_pet(
+        test_db, "octocat", "to-claim", name="Seedling", is_placeholder=True
+    )
+
+    upgraded = await pet_service.create(
+        test_db, "octocat", "to-claim", "Pixel", user_id=42, style="kawaii"
+    )
+
+    assert upgraded.id == placeholder.id  # same row
+    assert upgraded.is_placeholder is False
+    assert upgraded.user_id == 42
+    assert upgraded.name == "Pixel"
+    assert upgraded.claimed_at is not None
+
+
+# ----- OAuth claim helper -----
+
+
+def _fake_user(*, id: int = 7, login: str = "alice") -> User:
+    user = User(github_id=1, github_login=login, github_avatar_url=None)
+    user.id = id
+    return user
+
+
+@pytest.mark.asyncio
+async def test_claim_helper_happy_path(test_db: AsyncSession) -> None:
+    await pet_repo.create_pet(
+        test_db, "alice", "myrepo", name="Seedling", is_placeholder=True
+    )
+
+    with (
+        patch.object(
+            auth_mod,
+            "_verify_github_repo_access",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "github_tamagotchi.services.image_queue.create_job",
+            new=AsyncMock(return_value=MagicMock(id=1)),
+        ),
+    ):
+        owner, repo = await auth_mod._claim_placeholder_for_user(
+            session=test_db,
+            user=_fake_user(),
+            access_token="tok",
+            claim_target="alice/myrepo",
+        )
+
+    assert (owner, repo) == ("alice", "myrepo")
+    pet = await pet_repo.get_pet_by_repo(test_db, "alice", "myrepo")
+    assert pet is not None
+    assert pet.is_placeholder is False
+    assert pet.user_id == 7
+    assert pet.claimed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_claim_helper_no_access_raises(test_db: AsyncSession) -> None:
+    await pet_repo.create_pet(
+        test_db, "alice", "private", name="Seedling", is_placeholder=True
+    )
+    with patch.object(
+        auth_mod,
+        "_verify_github_repo_access",
+        new=AsyncMock(return_value=False),
+    ), pytest.raises(auth_mod._ClaimError) as excinfo:
+        await auth_mod._claim_placeholder_for_user(
+            session=test_db,
+            user=_fake_user(),
+            access_token="tok",
+            claim_target="alice/private",
+        )
+    assert excinfo.value.reason == "no_access"
+
+    pet = await pet_repo.get_pet_by_repo(test_db, "alice", "private")
+    assert pet is not None and pet.is_placeholder is True
+
+
+@pytest.mark.asyncio
+async def test_claim_helper_already_claimed_by_other_user_raises(
+    test_db: AsyncSession,
+) -> None:
+    pet = await pet_repo.create_pet(
+        test_db, "alice", "taken", name="Seedling", is_placeholder=True
+    )
+    await pet_repo.claim_placeholder(test_db, pet, user_id=99)
+
+    with pytest.raises(auth_mod._ClaimError) as excinfo:
+        await auth_mod._claim_placeholder_for_user(
+            session=test_db,
+            user=_fake_user(id=7),
+            access_token="tok",
+            claim_target="alice/taken",
+        )
+    assert excinfo.value.reason == "already_claimed"
+
+
+@pytest.mark.asyncio
+async def test_claim_helper_idempotent_for_same_user(test_db: AsyncSession) -> None:
+    pet = await pet_repo.create_pet(
+        test_db, "alice", "mine", name="Seedling", is_placeholder=True
+    )
+    await pet_repo.claim_placeholder(test_db, pet, user_id=7)
+
+    owner, repo = await auth_mod._claim_placeholder_for_user(
+        session=test_db,
+        user=_fake_user(id=7),
+        access_token="tok",
+        claim_target="alice/mine",
+    )
+    assert (owner, repo) == ("alice", "mine")
+
+
+@pytest.mark.asyncio
+async def test_claim_helper_not_found_raises(test_db: AsyncSession) -> None:
+    with pytest.raises(auth_mod._ClaimError) as excinfo:
+        await auth_mod._claim_placeholder_for_user(
+            session=test_db,
+            user=_fake_user(),
+            access_token="tok",
+            claim_target="ghost/repo",
+        )
+    assert excinfo.value.reason == "not_found"
+
+
+# ----- /auth/github accepts and validates claim param -----
+
+
+def test_parse_claim_accepts_well_formed_owner_repo() -> None:
+    assert auth_mod._parse_claim("foo/bar") == "foo/bar"
+    assert auth_mod._parse_claim("foo-bar/baz.qux") == "foo-bar/baz.qux"
+
+
+def test_parse_claim_rejects_garbage() -> None:
+    for bad in (None, "", "no-slash", "a/b/c", "a/", "/a", "a/b c", "a/" + "x" * 200):
+        assert auth_mod._parse_claim(bad) is None

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -65,8 +65,8 @@ class TestOAuthStateCleanup:
 
     def test_cleanup_removes_expired_states(self) -> None:
         _oauth_states.clear()
-        _oauth_states["fresh"] = datetime.now(UTC)
-        _oauth_states["expired"] = datetime.now(UTC) - timedelta(minutes=15)
+        _oauth_states["fresh"] = (datetime.now(UTC), None)
+        _oauth_states["expired"] = (datetime.now(UTC) - timedelta(minutes=15), None)
         _cleanup_expired_states()
         assert "fresh" in _oauth_states
         assert "expired" not in _oauth_states
@@ -367,7 +367,7 @@ class TestOAuthCallbackErrors:
     async def test_503_when_oauth_not_configured(self, auth_client: AsyncClient) -> None:
         """Returns 503 when client_id/secret is missing after state validation."""
         _oauth_states.clear()
-        _oauth_states["validstate"] = datetime.now(UTC)
+        _oauth_states["validstate"] = (datetime.now(UTC), None)
 
         with patch("github_tamagotchi.api.auth.settings") as mock_settings:
             mock_settings.github_oauth_client_id = None


### PR DESCRIPTION
Closes #233.

## Summary

Embedding the tamagotchi badge in a README is the highest-intent signal we have — and today the badge endpoint 404s for unknown repos, so the funnel dead-ends.

This PR turns that 404 into a sign-up funnel:

1. First fetch of `GET /api/v1/pets/{owner}/{repo}/badge.svg` for an unknown repo **lazy-creates a placeholder pet** (`is_placeholder=true`, `user_id=null`). No image generation, no scheduler polling, no openrouter spend.
2. The badge served for a placeholder is a small `🥚 tamagotchi · click to claim` SVG with the repo label, nudging the reader to a claim link.
3. README authors wrap the badge in a Markdown link:

   ```markdown
   [![tamagotchi](.../badge.svg)](https://tamagotchi.webwiebe.nl/?claim=owner/repo)
   ```

4. `/auth/github?claim=owner/repo` binds the claim target to the OAuth state.
5. `/auth/callback` consumes the claim: verifies access via `GET /repos/{o}/{r}` with the user's token, then flips `is_placeholder→false`, sets `user_id` + `claimed_at`, enqueues the first image job, and redirects to `/pets/{owner}/{repo}`. Failures redirect to `/?claim_error=...&repo=...` with `no_access` / `already_claimed` / `not_found`.

Placeholders are filtered out of the polling scheduler, `pet_repo.get_pets`, and `pet_repo.get_all` so they don't burn cycles or surface in user-facing UI. `POST /pets` gracefully upgrades a placeholder to a real pet, so the "create pet" UI doesn't 409 if the badge was hit first.

Per #233 we deliberately defer **GC of unclaimed placeholders** and **per-IP rate limiting** until spam is actually a problem.

## Files

- `alembic/versions/029_add_pet_placeholder.py` — `is_placeholder` bool + `claimed_at` timestamp on `pets`
- `models/pet.py`, `repositories/pet.py`, `services/pet.py` — placeholder + claim + upgrade
- `services/badge.py` — `generate_seedling_badge_svg`
- `api/routes/v1/pets/media.py` — badge endpoint lazy-creates placeholder
- `api/auth.py` — OAuth state carries claim target, callback consumes it
- `main.py` — `poll_repositories` filters out placeholders

## Test plan

- [x] 13 new tests in `tests/test_badge_auto_signup.py`: badge auto-create, idempotent fetch, existing pet unaffected, listings skip placeholders, POST /pets claims placeholder, claim helper happy / no_access / already_claimed / not_found / idempotent, claim param validation
- [x] Updated 1 test in `tests/test_badge.py` (404→200 seedling) and 2 in `tests/unit/test_auth.py` (tuple-shaped `_oauth_states`)
- [x] Full suite green: 1159 passed
- [x] ruff + mypy clean
- [ ] After deploy: visit `/api/v1/pets/<unknown>/<repo>/badge.svg` for an unbadged repo, confirm SVG returns and a placeholder row appears in the `pets` table
- [ ] Walk through claim from a real test repo end-to-end and confirm the pet binds + first image generates