### PR TITLE
chore(deploy): point production workflow + manifests at tama-prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy to nijmegen-testing
+      - name: Deploy to tama-test
         env:
           KUBECONFIG_DATA: ${{ secrets.KUBECONFIG }}
           BUGBARN_API_KEY: ${{ secrets.BUGBARN_API_KEY_PROD }}
@@ -119,7 +119,7 @@ jobs:
           chmod 600 ~/.kube/config
 
           IMAGE="ghcr.io/${{ github.repository }}:${{ github.sha }}"
-          NS="nijmegen-testing"
+          NS="tama-test"
 
           # Patch secrets
           kubectl patch secret github-tamagotchi-secrets -n $NS \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy to nijmegen-staging
+      - name: Deploy to tama-staging
         env:
           KUBECONFIG_DATA: ${{ secrets.KUBECONFIG }}
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
@@ -76,13 +76,13 @@ jobs:
 
           TAG="${GITHUB_REF#refs/tags/}"
           IMAGE="ghcr.io/${{ github.repository }}:$TAG"
-          NS="nijmegen-staging"
+          NS="tama-staging"
 
           # Ensure namespace and resources exist
           kubectl apply -f k8s/staging/namespace.yaml
 
           # Ensure deployments + service exist
-          sed 's/namespace: nijmegen-testing/namespace: nijmegen-staging/g; s|tamagotchi.nijmegen.wiebe.xyz|tamagotchi-staging.nijmegen.wiebe.xyz|g' \
+          sed 's/namespace: nijmegen-testing/namespace: tama-staging/g; s|tamagotchi.nijmegen.wiebe.xyz|tamagotchi-staging.nijmegen.wiebe.xyz|g' \
             k8s/deployment.yaml | kubectl apply -f -
 
           kubectl apply -f k8s/staging/ingress.yaml

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           ref: ${{ needs.read-staging-state.outputs.sha }}
 
-      - name: Deploy to tamagotchi-production on layer7
+      - name: Deploy to tama-prod on layer7
         env:
           KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_PROD }}
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
@@ -114,7 +114,7 @@ jobs:
           IMAGE="ghcr.io/${{ github.repository }}:${{ needs.promote-image.outputs.version }}"
           SHA="${{ needs.read-staging-state.outputs.sha }}"
           TAG="${{ needs.read-staging-state.outputs.tag }}"
-          NS="tamagotchi-production"
+          NS="tama-prod"
 
           echo "Deploying $IMAGE to $NS (from staging $TAG)"
 

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -25,9 +25,9 @@ jobs:
           chmod 600 "$KUBECFG"
           export KUBECONFIG="$KUBECFG"
 
-          SHA=$(kubectl get configmap deploy-state -n nijmegen-staging \
+          SHA=$(kubectl get configmap deploy-state -n tama-staging \
             -o jsonpath='{.data.sha}')
-          TAG=$(kubectl get configmap deploy-state -n nijmegen-staging \
+          TAG=$(kubectl get configmap deploy-state -n tama-staging \
             -o jsonpath='{.data.tag}')
 
           if [ -z "$SHA" ] || [ -z "$TAG" ]; then

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: github-tamagotchi-blue
-  namespace: tamagotchi-production
+  namespace: tama-prod
   labels:
     app: github-tamagotchi
     version: blue
@@ -91,7 +91,7 @@ spec:
                   name: github-tamagotchi-secrets
                   key: minio-secret-key
             - name: MINIO_BUCKET
-              value: "tamagotchi-production"
+              value: "tama-prod"
             - name: GITHUB_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -179,7 +179,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: github-tamagotchi-green
-  namespace: tamagotchi-production
+  namespace: tama-prod
   labels:
     app: github-tamagotchi
     version: green
@@ -268,7 +268,7 @@ spec:
                   name: github-tamagotchi-secrets
                   key: minio-secret-key
             - name: MINIO_BUCKET
-              value: "tamagotchi-production"
+              value: "tama-prod"
             - name: GITHUB_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -356,7 +356,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: github-tamagotchi
-  namespace: tamagotchi-production
+  namespace: tama-prod
 spec:
   selector:
     app: github-tamagotchi

--- a/k8s/production/ingress.yaml
+++ b/k8s/production/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: github-tamagotchi
-  namespace: tamagotchi-production
+  namespace: tama-prod
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt

--- a/k8s/production/init-db.yaml
+++ b/k8s/production/init-db.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: github-tamagotchi-init-db
-  namespace: tamagotchi-production
+  namespace: tama-prod
 spec:
   ttlSecondsAfterFinished: 300
   template:
@@ -61,7 +61,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: github-tamagotchi-init-minio
-  namespace: tamagotchi-production
+  namespace: tama-prod
 spec:
   ttlSecondsAfterFinished: 300
   template:
@@ -88,8 +88,8 @@ spec:
               set -e
               mc alias set minio http://minio.nijmegen-prod.svc.cluster.local:9000 admin "$MINIO_ROOT_PASSWORD"
 
-              echo "Creating bucket 'tamagotchi-production' if not exists..."
-              mc mb --ignore-existing minio/tamagotchi-production
+              echo "Creating bucket 'tama-prod' if not exists..."
+              mc mb --ignore-existing minio/tama-prod
 
               echo "Ensuring access policy for service account..."
               cat > /tmp/policy.json <<'POLICY'
@@ -99,12 +99,12 @@ spec:
                   {
                     "Effect": "Allow",
                     "Action": ["s3:*"],
-                    "Resource": ["arn:aws:s3:::tamagotchi-production", "arn:aws:s3:::tamagotchi-production/*"]
+                    "Resource": ["arn:aws:s3:::tama-prod", "arn:aws:s3:::tama-prod/*"]
                   }
                 ]
               }
               POLICY
-              mc admin policy create minio tamagotchi-production-readwrite /tmp/policy.json 2>/dev/null || true
-              mc admin policy attach minio tamagotchi-production-readwrite --user "$MINIO_ACCESS_KEY" 2>/dev/null || true
+              mc admin policy create minio tama-prod-readwrite /tmp/policy.json 2>/dev/null || true
+              mc admin policy attach minio tama-prod-readwrite --user "$MINIO_ACCESS_KEY" 2>/dev/null || true
 
               echo "MinIO setup complete."

--- a/k8s/production/middleware.yaml
+++ b/k8s/production/middleware.yaml
@@ -2,7 +2,7 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: redirect-to-https
-  namespace: tamagotchi-production
+  namespace: tama-prod
 spec:
   redirectScheme:
     permanent: true

--- a/k8s/production/namespace.yaml
+++ b/k8s/production/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: tamagotchi-production
+  name: tama-prod

--- a/k8s/staging/ingress.yaml
+++ b/k8s/staging/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: github-tamagotchi
-  namespace: nijmegen-staging
+  namespace: tama-staging
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt

--- a/k8s/staging/namespace.yaml
+++ b/k8s/staging/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nijmegen-staging
+  name: tama-staging

--- a/src/github_tamagotchi/main.py
+++ b/src/github_tamagotchi/main.py
@@ -80,6 +80,8 @@ templates.env.globals["funnelbarn_api_key"] = settings.funnelbarn_api_key
 templates.env.globals["bugbarn_endpoint"] = settings.bugbarn_endpoint
 templates.env.globals["bugbarn_api_key"] = settings.bugbarn_api_key
 templates.env.globals["bugbarn_project"] = settings.bugbarn_project
+templates.env.globals["site_base_url"] = settings.base_url.rstrip("/")
+templates.env.globals["site_name"] = "GitHub Tamagotchi"
 
 logger = structlog.get_logger()
 
@@ -747,6 +749,125 @@ async def pet_manifest(
     )
 
 
+
+
+@app.get("/robots.txt", include_in_schema=False)
+async def robots_txt() -> Response:
+    """Robots policy. Allow public pages, block auth/admin areas, point to sitemap."""
+    base = settings.base_url.rstrip("/")
+    body = (
+        "User-agent: *\n"
+        "Allow: /\n"
+        "Disallow: /admin\n"
+        "Disallow: /admin/\n"
+        "Disallow: /auth/\n"
+        "Disallow: /api/\n"
+        "Disallow: /dashboard\n"
+        "Disallow: /dashboard/\n"
+        "Disallow: /register\n"
+        "Disallow: /register/\n"
+        "Disallow: /pet/*/admin\n"
+        "Disallow: /mcp\n"
+        "Disallow: /mcp/\n"
+        "\n"
+        f"Sitemap: {base}/sitemap.xml\n"
+    )
+    return Response(
+        content=body,
+        media_type="text/plain; charset=utf-8",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@app.get("/sitemap.xml", include_in_schema=False)
+async def sitemap_xml(session: Annotated[AsyncSession, Depends(get_session)]) -> Response:
+    """Dynamic XML sitemap covering all public, indexable URLs."""
+    from xml.sax.saxutils import escape as xml_escape
+
+    base = settings.base_url.rstrip("/")
+    now_iso = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    urls: list[dict[str, str]] = [
+        {"loc": f"{base}/", "changefreq": "daily", "priority": "1.0", "lastmod": now_iso},
+        {
+            "loc": f"{base}/leaderboard",
+            "changefreq": "hourly",
+            "priority": "0.8",
+            "lastmod": now_iso,
+        },
+        {
+            "loc": f"{base}/graveyard",
+            "changefreq": "daily",
+            "priority": "0.5",
+            "lastmod": now_iso,
+        },
+    ]
+
+    # Living pets: profile + insights
+    living = await session.execute(
+        select(Pet.repo_owner, Pet.repo_name, Pet.updated_at)
+        .where(Pet.is_dead.is_(False))
+        .order_by(Pet.updated_at.desc())
+        .limit(10000)
+    )
+    seen_orgs: set[str] = set()
+    for owner, repo, updated in living.all():
+        lastmod = (updated or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        urls.append({
+            "loc": f"{base}/pet/{owner}/{repo}",
+            "changefreq": "daily",
+            "priority": "0.7",
+            "lastmod": lastmod,
+        })
+        urls.append({
+            "loc": f"{base}/pet/{owner}/{repo}/insights",
+            "changefreq": "weekly",
+            "priority": "0.5",
+            "lastmod": lastmod,
+        })
+        seen_orgs.add(owner)
+
+    # Dead pets: memorial pages
+    dead = await session.execute(
+        select(Pet.repo_owner, Pet.repo_name, Pet.died_at)
+        .where(Pet.is_dead.is_(True))
+        .order_by(Pet.died_at.desc())
+        .limit(10000)
+    )
+    for owner, repo, died in dead.all():
+        lastmod = (died or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        urls.append({
+            "loc": f"{base}/graveyard/{owner}/{repo}",
+            "changefreq": "monthly",
+            "priority": "0.4",
+            "lastmod": lastmod,
+        })
+
+    # Org overview pages (one per owner that has a pet)
+    for org in sorted(seen_orgs):
+        urls.append({
+            "loc": f"{base}/org/{org}",
+            "changefreq": "daily",
+            "priority": "0.6",
+            "lastmod": now_iso,
+        })
+
+    parts = ['<?xml version="1.0" encoding="UTF-8"?>',
+             '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    for u in urls:
+        parts.append("<url>")
+        parts.append(f"<loc>{xml_escape(u['loc'])}</loc>")
+        parts.append(f"<lastmod>{u['lastmod']}</lastmod>")
+        parts.append(f"<changefreq>{u['changefreq']}</changefreq>")
+        parts.append(f"<priority>{u['priority']}</priority>")
+        parts.append("</url>")
+    parts.append("</urlset>")
+
+    return Response(
+        content="".join(parts),
+        media_type="application/xml; charset=utf-8",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
 
 
 @app.middleware("http")

--- a/src/github_tamagotchi/templates/_seo.html
+++ b/src/github_tamagotchi/templates/_seo.html
@@ -1,0 +1,49 @@
+{#
+  Shared SEO head partial.
+
+  Inputs (set with {% set %} before include):
+    seo_title         — page <title> + og:title fallback (required)
+    seo_description   — meta description + og:description (required)
+    canonical_path    — path beginning with "/" (required for canonical+og:url)
+    seo_robots        — robots directive (default: "index,follow")
+    og_type           — og:type (default: "website")
+    og_image          — absolute or path; resolved against site_base_url
+    og_image_width    — optional integer
+    og_image_height   — optional integer
+    twitter_card      — "summary" | "summary_large_image" (default: "summary_large_image" if og_image else "summary")
+    json_ld           — list of dicts; each rendered as application/ld+json script
+
+  Globals available: site_base_url, site_name
+#}
+{%- set _base = site_base_url|default('', true)|string -%}
+{%- set _canonical = _base ~ (canonical_path|default('/')) -%}
+{%- if og_image and og_image.startswith('http') -%}
+  {%- set _og_image = og_image -%}
+{%- elif og_image -%}
+  {%- set _og_image = _base ~ og_image -%}
+{%- else -%}
+  {%- set _og_image = _base ~ '/pwa/icon/512.png' -%}
+{%- endif -%}
+{%- set _twitter_card = twitter_card|default(('summary_large_image' if og_image else 'summary'), true) -%}
+<title>{{ seo_title }}</title>
+<meta name="description" content="{{ seo_description }}">
+<meta name="robots" content="{{ seo_robots|default('index,follow', true) }}">
+<link rel="canonical" href="{{ _canonical }}">
+
+<meta property="og:type" content="{{ og_type|default('website') }}">
+<meta property="og:site_name" content="{{ site_name }}">
+<meta property="og:title" content="{{ og_title|default(seo_title) }}">
+<meta property="og:description" content="{{ og_description|default(seo_description) }}">
+<meta property="og:url" content="{{ _canonical }}">
+<meta property="og:image" content="{{ _og_image }}">
+{% if og_image_width %}<meta property="og:image:width" content="{{ og_image_width }}">{% endif %}
+{% if og_image_height %}<meta property="og:image:height" content="{{ og_image_height }}">{% endif %}
+
+<meta name="twitter:card" content="{{ _twitter_card }}">
+<meta name="twitter:title" content="{{ og_title|default(seo_title) }}">
+<meta name="twitter:description" content="{{ og_description|default(seo_description) }}">
+<meta name="twitter:image" content="{{ _og_image }}">
+
+{% if json_ld %}{% for block in json_ld %}
+<script type="application/ld+json">{{ block | tojson }}</script>
+{% endfor %}{% endif %}

--- a/src/github_tamagotchi/templates/admin_achievements.html
+++ b/src/github_tamagotchi/templates/admin_achievements.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin Achievements - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>

--- a/src/github_tamagotchi/templates/admin_jobs.html
+++ b/src/github_tamagotchi/templates/admin_jobs.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Job History - Admin - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     <style>
         .jobs-table {

--- a/src/github_tamagotchi/templates/admin_overview.html
+++ b/src/github_tamagotchi/templates/admin_overview.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin Overview - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>

--- a/src/github_tamagotchi/templates/admin_pets.html
+++ b/src/github_tamagotchi/templates/admin_pets.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>All Pets - Admin - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>

--- a/src/github_tamagotchi/templates/admin_sprites.html
+++ b/src/github_tamagotchi/templates/admin_sprites.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin Sprites - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>

--- a/src/github_tamagotchi/templates/admin_webhooks.html
+++ b/src/github_tamagotchi/templates/admin_webhooks.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Webhook Event Log - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     <style>
         .events-table {

--- a/src/github_tamagotchi/templates/contributor_dashboard.html
+++ b/src/github_tamagotchi/templates/contributor_dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ username }}'s Dashboard - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/src/github_tamagotchi/templates/dashboard.html
+++ b/src/github_tamagotchi/templates/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Pets - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/src/github_tamagotchi/templates/error.html
+++ b/src/github_tamagotchi/templates/error.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ status_code }} — GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
     <style>

--- a/src/github_tamagotchi/templates/graveyard.html
+++ b/src/github_tamagotchi/templates/graveyard.html
@@ -3,7 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% if username %}{{ username }}'s Graveyard{% else %}The Graveyard{% endif %} — GitHub Tamagotchi</title>
+    {% if username %}
+    {% set seo_title = username ~ "'s Graveyard — GitHub Tamagotchi" %}
+    {% set seo_description = "Memorial pages for " ~ username ~ "'s GitHub Tamagotchi pets that died of neglect or abandonment." %}
+    {% set canonical_path = "/graveyard/" ~ username %}
+    {% else %}
+    {% set seo_title = "The Graveyard — GitHub Tamagotchi" %}
+    {% set seo_description = "Memorial pages for GitHub Tamagotchi pets that died of neglect or abandonment. A reminder to maintain your repositories." %}
+    {% set canonical_path = "/graveyard" %}
+    {% endif %}
+    {% set og_image = "/pwa/icon/512.png" %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
     <style>

--- a/src/github_tamagotchi/templates/graveyard_grave.html
+++ b/src/github_tamagotchi/templates/graveyard_grave.html
@@ -3,19 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>In Memory of {{ pet.name }} — GitHub Tamagotchi</title>
+    {% set seo_title = "In Memory of " ~ pet.name ~ " — GitHub Tamagotchi" %}
+    {% set seo_description = cause_label ~ ". Lived " ~ age_days ~ " day" ~ ('s' if age_days != 1 else '') ~ " and reached " ~ (pet.stage | upper) ~ " stage." %}
+    {% set canonical_path = "/graveyard/" ~ pet.repo_owner ~ "/" ~ pet.repo_name %}
+    {% set og_type = "article" %}
+    {% set og_title = "In Memory of " ~ pet.name ~ " (" ~ pet.repo_owner ~ "/" ~ pet.repo_name ~ ")" %}
+    {% set og_image = "/api/v1/pets/" ~ pet.repo_owner ~ "/" ~ pet.repo_name ~ "/image/" ~ pet.stage %}
+    {% set og_image_width = 1024 %}
+    {% set og_image_height = 1024 %}
+    {% set twitter_card = "summary_large_image" %}
+    {% set json_ld = [
+        {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Graveyard", "item": site_base_url ~ "/graveyard"},
+            {"@type": "ListItem", "position": 2, "name": pet.name, "item": site_base_url ~ canonical_path}
+        ]}
+    ] %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
-
-    <!-- OG tags for social sharing -->
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="In Memory of {{ pet.name }} ({{ pet.repo_owner }}/{{ pet.repo_name }})">
-    <meta property="og:description" content="{{ cause_label }}. Lived {{ age_days }} day{{ 's' if age_days != 1 else '' }} and reached {{ pet.stage | upper }} stage.">
-    <meta property="og:url" content="{{ base_url }}/graveyard/{{ pet.repo_owner }}/{{ pet.repo_name }}">
-    <meta property="og:image" content="{{ base_url }}/api/v1/pets/{{ pet.repo_owner }}/{{ pet.repo_name }}/image/{{ pet.stage }}">
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="In Memory of {{ pet.name }}">
-    <meta name="twitter:description" content="{{ cause_label }}. Would have been {{ would_be_days }} days old today.">
 
     <style>
         .memorial {

--- a/src/github_tamagotchi/templates/landing.html
+++ b/src/github_tamagotchi/templates/landing.html
@@ -3,20 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GitHub Tamagotchi — Virtual pets for your repos</title>
-
-    <!-- OpenGraph / Social Sharing -->
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="GitHub Tamagotchi">
-    <meta property="og:title" content="GitHub Tamagotchi — Virtual pets for your repos">
-    <meta property="og:description" content="Give your GitHub repository a virtual pet that lives and dies by your commit activity.">
-    <meta property="og:url" content="{{ base_url }}">
-
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="GitHub Tamagotchi — Virtual pets for your repos">
-    <meta name="twitter:description" content="Give your GitHub repository a virtual pet that lives and dies by your commit activity.">
-
+    {% set seo_title = "GitHub Tamagotchi — Virtual pets for your repos" %}
+    {% set seo_description = "Give your GitHub repository a virtual pet that lives and dies by your commit activity. Real-time pets driven by stars, commits, releases and CI runs." %}
+    {% set canonical_path = "/" %}
+    {% set og_image = "/pwa/icon/512.png" %}
+    {% set og_image_width = 512 %}
+    {% set og_image_height = 512 %}
+    {% set json_ld = [
+        {"@context": "https://schema.org", "@type": "WebSite", "name": site_name, "url": site_base_url ~ "/", "potentialAction": {"@type": "SearchAction", "target": site_base_url ~ "/pet/{search_term_string}", "query-input": "required name=search_term_string"}},
+        {"@context": "https://schema.org", "@type": "Organization", "name": site_name, "url": site_base_url ~ "/", "logo": site_base_url ~ "/pwa/icon/512.png"}
+    ] %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/src/github_tamagotchi/templates/leaderboard.html
+++ b/src/github_tamagotchi/templates/leaderboard.html
@@ -3,7 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Leaderboard — GitHub Tamagotchi</title>
+    {% set seo_title = "Leaderboard — GitHub Tamagotchi" %}
+    {% set seo_description = "Top GitHub repositories by Tamagotchi pet XP and longest commit streaks. See which projects are the healthiest and most active." %}
+    {% set canonical_path = "/leaderboard" %}
+    {% set og_image = "/pwa/icon/512.png" %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/src/github_tamagotchi/templates/org_overview.html
+++ b/src/github_tamagotchi/templates/org_overview.html
@@ -3,7 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ org_name }}'s Pets — GitHub Tamagotchi</title>
+    {% set seo_title = org_name ~ "'s Pets — GitHub Tamagotchi" %}
+    {% set seo_description = "Aggregate Tamagotchi health for " ~ org_name ~ ": " ~ total ~ " pets, average " ~ avg_health ~ "% health. Contributor leaderboard and per-repo status." %}
+    {% set canonical_path = "/org/" ~ org_name %}
+    {% set og_image = "/pwa/icon/512.png" %}
+    {% set json_ld = [
+        {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Home", "item": site_base_url ~ "/"},
+            {"@type": "ListItem", "position": 2, "name": org_name, "item": site_base_url ~ canonical_path}
+        ]}
+    ] %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/src/github_tamagotchi/templates/pet_admin.html
+++ b/src/github_tamagotchi/templates/pet_admin.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin — {{ pet.name }} | GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     <script>
     window.__bugbarn = {

--- a/src/github_tamagotchi/templates/pet_insights.html
+++ b/src/github_tamagotchi/templates/pet_insights.html
@@ -3,7 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ pet.name }} Insights — {{ repo_owner }}/{{ repo_name }} | GitHub Tamagotchi</title>
+    {% set seo_title = pet.name ~ " Insights — " ~ repo_owner ~ "/" ~ repo_name ~ " | GitHub Tamagotchi" %}
+    {% set seo_description = "Detailed health insights for " ~ pet.name ~ ", the Tamagotchi pet for " ~ repo_owner ~ "/" ~ repo_name ~ ": commits, CI, PR/issue activity and contributor stats." %}
+    {% set canonical_path = "/pet/" ~ repo_owner ~ "/" ~ repo_name ~ "/insights" %}
+    {% set og_image = "/api/v1/pets/" ~ repo_owner ~ "/" ~ repo_name ~ "/image/" ~ pet.stage %}
+    {% set og_image_width = 1024 %}
+    {% set og_image_height = 1024 %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
     <style>

--- a/src/github_tamagotchi/templates/pet_profile.html
+++ b/src/github_tamagotchi/templates/pet_profile.html
@@ -3,32 +3,32 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ pet.name }} — {{ repo_owner }}/{{ repo_name }} | GitHub Tamagotchi</title>
-
-    <!-- OpenGraph / Social Sharing -->
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="GitHub Tamagotchi">
-    <meta property="og:title" content="{{ pet.name }} the {{ pet.stage | capitalize }} · GitHub Tamagotchi">
+    {% set seo_title = pet.name ~ " — " ~ repo_owner ~ "/" ~ repo_name ~ " | GitHub Tamagotchi" %}
     {% if pet.is_dead %}
-    <meta property="og:description" content="{{ pet.name }} has passed away. 🪦 {{ repo_owner }}/{{ repo_name }} needs some love.">
+    {% set seo_description = pet.name ~ " has passed away. The Tamagotchi for " ~ repo_owner ~ "/" ~ repo_name ~ " is on the memorial page." %}
     {% else %}
-    <meta property="og:description" content="{{ pet.name }} is a {{ pet.mood }} {{ pet.stage }} with {{ pet.health }}HP, watching over {{ repo_owner }}/{{ repo_name }}.">
+    {% set seo_description = pet.name ~ " is a " ~ pet.mood ~ " " ~ pet.stage ~ " with " ~ pet.health ~ "HP, watching over " ~ repo_owner ~ "/" ~ repo_name ~ "." %}
     {% endif %}
-    <meta property="og:image" content="{{ base_url }}/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/badge.svg">
-    <meta property="og:image:width" content="120">
-    <meta property="og:image:height" content="80">
-    <meta property="og:url" content="{{ base_url }}/pets/{{ repo_owner }}/{{ repo_name }}">
-
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ pet.name }} the {{ pet.stage | capitalize }} · GitHub Tamagotchi">
+    {% set canonical_path = "/pet/" ~ repo_owner ~ "/" ~ repo_name %}
+    {% set og_title = pet.name ~ " the " ~ (pet.stage | capitalize) ~ " · GitHub Tamagotchi" %}
+    {% set og_type = "profile" %}
     {% if pet.is_dead %}
-    <meta name="twitter:description" content="{{ pet.name }} has passed away. 🪦 {{ repo_owner }}/{{ repo_name }} needs some love.">
+    {% set og_image = "/api/v1/pets/" ~ repo_owner ~ "/" ~ repo_name ~ "/image/egg" %}
     {% else %}
-    <meta name="twitter:description" content="{{ pet.name }} is a {{ pet.mood }} {{ pet.stage }} with {{ pet.health }}HP, watching over {{ repo_owner }}/{{ repo_name }}.">
+    {% set og_image = "/api/v1/pets/" ~ repo_owner ~ "/" ~ repo_name ~ "/image/" ~ pet.stage %}
     {% endif %}
-    <meta name="twitter:image" content="{{ base_url }}/api/v1/pets/{{ repo_owner }}/{{ repo_name }}/badge.svg">
-
+    {% set og_image_width = 1024 %}
+    {% set og_image_height = 1024 %}
+    {% set twitter_card = "summary_large_image" %}
+    {% set json_ld = [
+        {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Home", "item": site_base_url ~ "/"},
+            {"@type": "ListItem", "position": 2, "name": repo_owner, "item": site_base_url ~ "/org/" ~ repo_owner},
+            {"@type": "ListItem", "position": 3, "name": pet.name, "item": site_base_url ~ canonical_path}
+        ]},
+        {"@context": "https://schema.org", "@type": "CreativeWork", "name": pet.name, "url": site_base_url ~ canonical_path, "description": seo_description, "image": site_base_url ~ og_image, "about": {"@type": "SoftwareSourceCode", "name": repo_owner ~ "/" ~ repo_name, "codeRepository": "https://github.com/" ~ repo_owner ~ "/" ~ repo_name}}
+    ] %}
+    {% include "_seo.html" %}
     <link rel="stylesheet" href="/static/css/style.css">
     {% set pwa_manifest_url = '/pet/' + repo_owner + '/' + repo_name + '/manifest.json' %}
     {% set pwa_app_title = pet.name %}

--- a/src/github_tamagotchi/templates/register.html
+++ b/src/github_tamagotchi/templates/register.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Register Your Pet - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/src/github_tamagotchi/templates/register_complete.html
+++ b/src/github_tamagotchi/templates/register_complete.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ pet_name }} is Ready! - GitHub Tamagotchi</title>
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="/static/css/style.css">
     {% include "_pwa_head.html" %}
 </head>

--- a/tests/api/test_seo.py
+++ b/tests/api/test_seo.py
@@ -1,0 +1,108 @@
+"""Tests for SEO: robots.txt, sitemap.xml, canonical, meta description, JSON-LD."""
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from github_tamagotchi.models.pet import Pet, PetStage
+from tests.conftest import test_session_factory
+
+
+def _add_pet(
+    repo_owner: str,
+    repo_name: str,
+    is_dead: bool = False,
+    stage: str = "baby",
+) -> None:
+    async def _do() -> None:
+        async with test_session_factory() as session:
+            pet = Pet(
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                name=f"{repo_name}-pet",
+                stage=PetStage(stage),
+                health=80,
+                experience=0,
+                is_dead=is_dead,
+            )
+            session.add(pet)
+            await session.commit()
+
+    asyncio.run(_do())
+
+
+class TestRobotsTxt:
+    def test_returns_200_and_plain_text(self, client: TestClient) -> None:
+        r = client.get("/robots.txt")
+        assert r.status_code == 200
+        assert "text/plain" in r.headers["content-type"]
+
+    def test_disallows_admin_and_auth(self, client: TestClient) -> None:
+        r = client.get("/robots.txt")
+        assert "Disallow: /admin" in r.text
+        assert "Disallow: /auth/" in r.text
+        assert "Disallow: /dashboard" in r.text
+        assert "Disallow: /register" in r.text
+
+    def test_points_to_sitemap(self, client: TestClient) -> None:
+        r = client.get("/robots.txt")
+        assert "Sitemap:" in r.text
+        assert "/sitemap.xml" in r.text
+
+
+class TestSitemapXml:
+    def test_returns_xml(self, client: TestClient) -> None:
+        r = client.get("/sitemap.xml")
+        assert r.status_code == 200
+        assert "application/xml" in r.headers["content-type"]
+        assert r.text.startswith("<?xml")
+        assert "<urlset" in r.text
+
+    def test_includes_landing_and_static_routes(self, client: TestClient) -> None:
+        r = client.get("/sitemap.xml")
+        assert "/leaderboard" in r.text
+        assert "/graveyard" in r.text
+
+    def test_includes_living_and_dead_pet_urls(self, client: TestClient) -> None:
+        _add_pet("alice", "alive-repo", is_dead=False, stage="baby")
+        _add_pet("bob", "dead-repo", is_dead=True, stage="egg")
+        r = client.get("/sitemap.xml")
+        assert "/pet/alice/alive-repo" in r.text
+        assert "/pet/alice/alive-repo/insights" in r.text
+        assert "/graveyard/bob/dead-repo" in r.text
+        # Org page for owner of a living pet should appear too
+        assert "/org/alice" in r.text
+
+
+class TestSeoMetaOnPublicPages:
+    def test_landing_has_canonical_and_description(self, client: TestClient) -> None:
+        r = client.get("/")
+        assert '<link rel="canonical"' in r.text
+        assert '<meta name="description"' in r.text
+        assert 'application/ld+json' in r.text
+
+    def test_leaderboard_has_canonical(self, client: TestClient) -> None:
+        r = client.get("/leaderboard")
+        assert '<link rel="canonical"' in r.text
+        assert '/leaderboard' in r.text
+
+    def test_graveyard_has_canonical(self, client: TestClient) -> None:
+        r = client.get("/graveyard")
+        assert '<link rel="canonical"' in r.text
+
+    def test_pet_profile_has_canonical_and_jsonld(self, client: TestClient) -> None:
+        _add_pet("charlie", "seo-test-repo", is_dead=False, stage="child")
+        r = client.get("/pet/charlie/seo-test-repo")
+        assert r.status_code == 200
+        assert '<link rel="canonical"' in r.text
+        assert "BreadcrumbList" in r.text
+
+
+class TestNoIndexOnPrivatePages:
+    def test_dashboard_redirects_or_noindex(self, client: TestClient) -> None:
+        # /dashboard requires auth and typically redirects; just verify it's not
+        # an indexable success page.
+        r = client.get("/dashboard", follow_redirects=False)
+        assert r.status_code in (200, 302, 303, 307, 401, 403)
+        if r.status_code == 200:
+            assert "noindex" in r.text


### PR DESCRIPTION
## Summary
Mirror of #237 for production.

The first Promote to Production attempt (run 26676785593) failed because the workflow targeted `tamagotchi-production`, which is only an empty service and a terminating pod. The actual production runtime — postgres, blue/green deployments, secrets — lives in `tama-prod` (15d old, matches the `tama-{test,staging,prod}` convention used by every other project on the cluster).

- `promote-to-production.yml`: `NS=tama-prod`
- `k8s/production/{namespace,middleware,deployment,ingress,init-db}.yaml`: namespace renamed

`PROD_*` GitHub Actions secrets were re-synced from the live `tama-prod` in-cluster secret before this PR.

## Test plan
- [ ] CI green on this branch
- [ ] After merge, manually trigger Promote to Production -> rolls out into `tama-prod` and `/robots.txt` + `/sitemap.xml` go live on `tamagotchi.webwiebe.nl`